### PR TITLE
Update TextBubble Layout to fix choice size placement

### DIFF
--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/DialogicTextBubbleLayout.gd
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/DialogicTextBubbleLayout.gd
@@ -40,10 +40,10 @@ extends CanvasLayer
 @export_subgroup('Choices Text')
 @export var choices_text_size := 15
 @export_file('*.ttf') var choices_text_font := ""
-@export var choices_text_color := Color.LIGHT_SLATE_GRAY
-@export var choices_text_color_hover := Color.DARK_GRAY
-@export var choices_text_color_focus := Color.BLACK
-@export var choices_text_color_disabled := Color.LIGHT_GRAY
+@export var choices_text_color := Color.DARK_SLATE_GRAY
+@export var choices_text_color_hover := Color.DARK_MAGENTA
+@export var choices_text_color_focus := Color.DARK_MAGENTA
+@export var choices_text_color_disabled := Color.DARK_GRAY
 
 @export_subgroup('Choices Layout')
 @export var choices_layout_alignment := FlowContainer.ALIGNMENT_END
@@ -152,6 +152,21 @@ func bubble_apply_overrides(bubble:Control) -> void:
 	var choice_theme :Theme = null
 	if choices_base_theme.is_empty():
 		choice_theme = Theme.new()
+		var base_style := StyleBoxFlat.new()
+		base_style.draw_center = false
+		base_style.border_width_bottom = 2
+		base_style.border_color = choices_text_color
+		choice_theme.set_stylebox('normal', 'Button', base_style)
+		var focus_style := base_style.duplicate()
+		focus_style.border_color = choices_text_color_focus
+		choice_theme.set_stylebox('focus', 'Button', focus_style)
+		var hover_style := base_style.duplicate()
+		hover_style.border_color = choices_text_color_hover
+		choice_theme.set_stylebox('hover', 'Button', hover_style)
+		var disabled_style := base_style.duplicate()
+		disabled_style.border_color = choices_text_color_disabled
+		choice_theme.set_stylebox('disabled', 'Button', disabled_style)
+		choice_theme.set_stylebox('pressed', 'Button', base_style)
 	else:
 		choice_theme = load(choices_base_theme)
 	

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/DialogicTextBubbleLayout.gd
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/DialogicTextBubbleLayout.gd
@@ -16,7 +16,7 @@ extends CanvasLayer
 @export var box_modulate := Color.WHITE
 @export var box_modulate_by_character_color := false
 @export var box_padding := Vector2(10,10)
-@export_range(0.1, 2) var box_corner_radius := 0.3
+@export_range(1, 999) var box_corner_radius := 25
 @export_range(0.1, 5) var box_wobble_speed := 1
 @export_range(0, 1) var box_wobbliness := 0.2
 
@@ -99,14 +99,12 @@ func bubble_apply_overrides(bubble:Control) -> void:
 	
 	
 	## BOX & TAIL COLOR
-	bubble.get_node('Tail').default_color = box_modulate
-	bubble.get_node('Background').color = box_modulate
-	bubble.get_node('Background').material.set_shader_parameter('radius', box_corner_radius)
-	bubble.get_node('Background').material.set_shader_parameter('crease', box_wobbliness*0.1)
-	bubble.get_node('Background').material.set_shader_parameter('speed', box_wobble_speed)
+	bubble.get_node('Group').self_modulate = box_modulate
+	bubble.get_node('%Background').material.set_shader_parameter('radius', box_corner_radius)
+	bubble.get_node('%Background').material.set_shader_parameter('wobble_amount', box_wobbliness*0.1)
+	bubble.get_node('%Background').material.set_shader_parameter('wobble_speed', box_wobble_speed)
 	if box_modulate_by_character_color and bubble.character != null:
-		bubble.get_node('Tail').modulate = bubble.character.color
-		bubble.get_node('Background').modulate = bubble.character.color
+		bubble.get_node('Group').self_modulate = bubble.character.color
 	bubble.padding = box_padding
 	
 	## NAME LABEL SETTINGS
@@ -126,7 +124,7 @@ func bubble_apply_overrides(bubble:Control) -> void:
 	nlp.get_theme_stylebox('panel').content_margin_right = name_label_padding.x
 	nlp.get_theme_stylebox('panel').content_margin_top = name_label_padding.y
 	nlp.get_theme_stylebox('panel').content_margin_bottom = name_label_padding.y
-	nlp.position += name_label_offset
+	bubble.name_label_offset = name_label_offset
 	
 	if !name_label_enabled:
 		nlp.queue_free()

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd
@@ -100,7 +100,7 @@ func _on_dialog_text_started_revealing_text():
 	var font :Font = %DialogText.get_theme_font("normal_font")
 	var text_size := font.get_multiline_string_size(%DialogText.get_parsed_text(), HORIZONTAL_ALIGNMENT_LEFT, max_width, %DialogText.get_theme_font_size("normal_font_size"))
 	
-	if $DialogText.has_child('NameLabel'):
+	if $DialogText.has_node('NameLabel'):
 		$DialogText/NameLabel.position = Vector2(0, -$DialogText/NameLabel.size.y)+name_label_offset
 	
 	_resize_bubble(text_size)

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd
@@ -100,8 +100,8 @@ func _on_dialog_text_started_revealing_text():
 	var font :Font = %DialogText.get_theme_font("normal_font")
 	var text_size := font.get_multiline_string_size(%DialogText.get_parsed_text(), HORIZONTAL_ALIGNMENT_LEFT, max_width, %DialogText.get_theme_font_size("normal_font_size"))
 	
-#	var nl_font :Font = %NameLabel.get_theme_font("font")
-	$DialogText/NameLabel.position = Vector2(0, -$DialogText/NameLabel.size.y)+name_label_offset
+	if $DialogText.has_child('NameLabel'):
+		$DialogText/NameLabel.position = Vector2(0, -$DialogText/NameLabel.size.y)+name_label_offset
 	
 	_resize_bubble(text_size)
 

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
@@ -66,7 +66,7 @@ offset_right = 157.0
 offset_bottom = 70.0
 mouse_filter = 2
 
-[node name="DialogText" type="RichTextLabel" parent="."]
+[node name="DialogText" type="RichTextLabel" parent="." node_paths=PackedStringArray("textbox_root")]
 unique_name_in_owner = true
 clip_contents = false
 layout_mode = 1
@@ -85,6 +85,7 @@ theme_override_colors/default_color = Color(0, 0, 0, 1)
 scroll_active = false
 visible_characters_behavior = 1
 script = ExtResource("3_syv35")
+textbox_root = NodePath("..")
 
 [node name="DialogicNode_TypeSounds" type="AudioStreamPlayer" parent="DialogText"]
 script = ExtResource("4_7bm4b")
@@ -166,4 +167,3 @@ flat = true
 script = ExtResource("7_0tnh1")
 
 [connection signal="started_revealing_text" from="DialogText" to="." method="_on_dialog_text_started_revealing_text"]
-[connection signal="resized" from="DialogText/ChoiceContainer" to="." method="_on_choice_container_resized"]

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=13 format=3 uid="uid://dlx7jcvm52tyw"]
+[gd_scene load_steps=11 format=3 uid="uid://dlx7jcvm52tyw"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd" id="1_jdhpk"]
 [ext_resource type="Shader" path="res://addons/dialogic/Modules/DefaultLayouts/TextBubble/speech_bubble.gdshader" id="2_1mhvf"]
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Text/node_dialog_text.gd" id="3_syv35"]
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Text/node_type_sound.gd" id="4_7bm4b"]
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Text/node_name_label.gd" id="6_5gd03"]
-[ext_resource type="Script" path="res://addons/dialogic/Modules/Choice/node_choice_button.gd" id="7_0tnh1"]
 
 [sub_resource type="Curve" id="Curve_0j8nu"]
 _data = [Vector2(0, 1), 0.0, -1.0, 0, 1, Vector2(1, 0), -1.0, 0.0, 1, 0]
@@ -23,7 +22,7 @@ noise = SubResource("FastNoiseLite_lsfnp")
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_60xbe"]
 shader = ExtResource("2_1mhvf")
 shader_parameter/radius = 25.0
-shader_parameter/box_size = Vector2(150, 70)
+shader_parameter/box_size = Vector2(735, 530)
 shader_parameter/box_padding = 30.0
 shader_parameter/wobble_amount = 0.2
 shader_parameter/wobble_speed = 1.0
@@ -41,11 +40,6 @@ corner_radius_bottom_left = 10
 shadow_color = Color(0, 0, 0, 0.278431)
 shadow_size = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_g4yjl"]
-draw_center = false
-border_width_bottom = 3
-border_color = Color(0, 0, 0, 0.498039)
-
 [node name="TextBubble" type="Control"]
 layout_mode = 3
 anchors_preset = 0
@@ -62,8 +56,10 @@ width_curve = SubResource("Curve_0j8nu")
 [node name="Background" type="ColorRect" parent="Group"]
 unique_name_in_owner = true
 material = SubResource("ShaderMaterial_60xbe")
-offset_right = 157.0
-offset_bottom = 70.0
+offset_left = -289.0
+offset_top = -230.0
+offset_right = 446.0
+offset_bottom = 300.0
 mouse_filter = 2
 
 [node name="DialogText" type="RichTextLabel" parent="." node_paths=PackedStringArray("textbox_root")]
@@ -107,63 +103,5 @@ text = "Word"
 horizontal_alignment = 1
 script = ExtResource("6_5gd03")
 name_label_root = NodePath("..")
-
-[node name="ChoiceContainer" type="HFlowContainer" parent="DialogText"]
-layout_mode = 1
-anchors_preset = 12
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = -25.0
-offset_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 0
-theme_override_constants/v_separation = -6
-alignment = 2
-
-[node name="DialogicNode_ChoiceButton" type="Button" parent="DialogText/ChoiceContainer"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
-text = "A"
-flat = true
-script = ExtResource("7_0tnh1")
-
-[node name="DialogicNode_ChoiceButton2" type="Button" parent="DialogText/ChoiceContainer"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
-text = "A"
-flat = true
-script = ExtResource("7_0tnh1")
-
-[node name="DialogicNode_ChoiceButton3" type="Button" parent="DialogText/ChoiceContainer"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
-text = "A"
-flat = true
-script = ExtResource("7_0tnh1")
-
-[node name="DialogicNode_ChoiceButton4" type="Button" parent="DialogText/ChoiceContainer"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
-text = "A"
-flat = true
-script = ExtResource("7_0tnh1")
-
-[node name="DialogicNode_ChoiceButton5" type="Button" parent="DialogText/ChoiceContainer"]
-visible = false
-layout_mode = 2
-size_flags_horizontal = 4
-theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
-text = "A"
-flat = true
-script = ExtResource("7_0tnh1")
 
 [connection signal="started_revealing_text" from="DialogText" to="." method="_on_dialog_text_started_revealing_text"]

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=3 uid="uid://dlx7jcvm52tyw"]
+[gd_scene load_steps=13 format=3 uid="uid://dlx7jcvm52tyw"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/DefaultLayouts/TextBubble/TextBubble.gd" id="1_jdhpk"]
 [ext_resource type="Shader" path="res://addons/dialogic/Modules/DefaultLayouts/TextBubble/speech_bubble.gdshader" id="2_1mhvf"]
@@ -11,13 +11,6 @@
 _data = [Vector2(0, 1), 0.0, -1.0, 0, 1, Vector2(1, 0), -1.0, 0.0, 1, 0]
 point_count = 2
 
-[sub_resource type="Curve" id="Curve_4meji"]
-_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(1, 1), 2.61284, 0.0, 0, 0]
-point_count = 2
-
-[sub_resource type="CurveTexture" id="CurveTexture_q6qf6"]
-curve = SubResource("Curve_4meji")
-
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_lsfnp"]
 noise_type = 0
 fractal_type = 0
@@ -27,27 +20,15 @@ cellular_jitter = 0.15
 seamless = true
 noise = SubResource("FastNoiseLite_lsfnp")
 
-[sub_resource type="FastNoiseLite" id="FastNoiseLite_ejxnv"]
-noise_type = 2
-frequency = 0.012
-fractal_type = 0
-cellular_jitter = 0.008
-
-[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_4la3x"]
-seamless = true
-noise = SubResource("FastNoiseLite_ejxnv")
-
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_60xbe"]
 shader = ExtResource("2_1mhvf")
-shader_parameter/radius = 1.39
-shader_parameter/ratio = Vector2(2.251, 1)
-shader_parameter/crease = 0.12
-shader_parameter/speed = 2.53
-shader_parameter/texture_scale = 0.24
-shader_parameter/texture_offset = 172.5
+shader_parameter/radius = 25.0
+shader_parameter/box_size = Vector2(150, 70)
+shader_parameter/box_padding = 30.0
+shader_parameter/wobble_amount = 0.2
+shader_parameter/wobble_speed = 1.0
+shader_parameter/wobble_detail = 0.5
 shader_parameter/deformation_sampler = SubResource("NoiseTexture2D_kr7hw")
-shader_parameter/spikes_sampler = SubResource("NoiseTexture2D_4la3x")
-shader_parameter/curve_sampler = SubResource("CurveTexture_q6qf6")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h6ls0"]
 content_margin_left = 5.0
@@ -70,17 +51,19 @@ layout_mode = 3
 anchors_preset = 0
 script = ExtResource("1_jdhpk")
 
-[node name="Tail" type="Line2D" parent="."]
+[node name="Group" type="CanvasGroup" parent="."]
+
+[node name="Tail" type="Line2D" parent="Group"]
+unique_name_in_owner = true
+points = PackedVector2Array(-1, 9, -10, 66, -64, 107)
 width = 96.0
 width_curve = SubResource("Curve_0j8nu")
 
-[node name="Background" type="ColorRect" parent="."]
+[node name="Background" type="ColorRect" parent="Group"]
+unique_name_in_owner = true
 material = SubResource("ShaderMaterial_60xbe")
-layout_mode = 1
-offset_left = -69.0
-offset_top = -21.0
-offset_right = 225.0
-offset_bottom = 79.0
+offset_right = 157.0
+offset_bottom = 70.0
 mouse_filter = 2
 
 [node name="DialogText" type="RichTextLabel" parent="."]
@@ -99,7 +82,6 @@ offset_bottom = 12.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/default_color = Color(0, 0, 0, 1)
-text = "Some Text"
 scroll_active = false
 visible_characters_behavior = 1
 script = ExtResource("3_syv35")
@@ -110,33 +92,36 @@ script = ExtResource("4_7bm4b")
 [node name="NameLabel" type="PanelContainer" parent="DialogText"]
 layout_mode = 1
 anchors_preset = -1
-offset_left = 16.0
-offset_top = -26.0
-offset_right = 27.0
+offset_left = -2.0
+offset_top = -35.0
+offset_right = 50.0
+offset_bottom = -9.0
 grow_horizontal = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_h6ls0")
 
 [node name="NameLabel" type="Label" parent="DialogText/NameLabel" node_paths=PackedStringArray("name_label_root")]
 unique_name_in_owner = true
 layout_mode = 2
+text = "Word"
 horizontal_alignment = 1
 script = ExtResource("6_5gd03")
 name_label_root = NodePath("..")
 
-[node name="ChoiceContainer" type="HBoxContainer" parent="DialogText"]
+[node name="ChoiceContainer" type="HFlowContainer" parent="DialogText"]
 layout_mode = 1
 anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 5.0
-offset_top = -31.0
-offset_right = -4.0
+offset_top = -25.0
+offset_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 0
+theme_override_constants/v_separation = -6
 alignment = 2
 
 [node name="DialogicNode_ChoiceButton" type="Button" parent="DialogText/ChoiceContainer"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
@@ -145,6 +130,7 @@ flat = true
 script = ExtResource("7_0tnh1")
 
 [node name="DialogicNode_ChoiceButton2" type="Button" parent="DialogText/ChoiceContainer"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
@@ -153,6 +139,7 @@ flat = true
 script = ExtResource("7_0tnh1")
 
 [node name="DialogicNode_ChoiceButton3" type="Button" parent="DialogText/ChoiceContainer"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
@@ -161,6 +148,16 @@ flat = true
 script = ExtResource("7_0tnh1")
 
 [node name="DialogicNode_ChoiceButton4" type="Button" parent="DialogText/ChoiceContainer"]
+visible = false
+layout_mode = 2
+size_flags_horizontal = 4
+theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
+text = "A"
+flat = true
+script = ExtResource("7_0tnh1")
+
+[node name="DialogicNode_ChoiceButton5" type="Button" parent="DialogText/ChoiceContainer"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/focus = SubResource("StyleBoxFlat_g4yjl")
@@ -169,3 +166,4 @@ flat = true
 script = ExtResource("7_0tnh1")
 
 [connection signal="started_revealing_text" from="DialogText" to="." method="_on_dialog_text_started_revealing_text"]
+[connection signal="resized" from="DialogText/ChoiceContainer" to="." method="_on_choice_container_resized"]

--- a/addons/dialogic/Modules/DefaultLayouts/TextBubble/speech_bubble.gdshader
+++ b/addons/dialogic/Modules/DefaultLayouts/TextBubble/speech_bubble.gdshader
@@ -1,24 +1,17 @@
 shader_type canvas_item;
-uniform sampler2D deformation_sampler : filter_linear, repeat_enable;
-uniform sampler2D spikes_sampler : filter_linear, repeat_enable;
-uniform sampler2D curve_sampler;
-uniform float radius :hint_range(0.1, 5, 0.01)= 0.25;
-uniform vec2 ratio = vec2(1.0, 1.0);
 
-uniform float crease : hint_range(0.0, 1.0, 0.01) = 0.1;
-uniform float speed : hint_range(0.0, 10.0, 0.01) = 1;
-uniform float texture_scale : hint_range(0.0, 0.5, 0.01) = 0.2;
-uniform float texture_offset : hint_range(0.0, 300, 0.5) = 1;
+uniform sampler2D deformation_sampler : filter_linear, repeat_enable;
+uniform float radius :hint_range(1.0, 200, 0.01)= 25;
+uniform vec2 box_size = vec2(100, 100);
+uniform float box_padding = 15;
+uniform float wobble_amount : hint_range(0.0, 1.0, 0.01) = 0.2;
+uniform float wobble_speed : hint_range(0.0, 10.0, 0.01) = 1;
+uniform float wobble_detail : hint_range(0.01, 1, 0.01) = 0.5;
 
 void fragment() {
-	vec2 ratio_uv = UV * ratio;
-	float spikes = texture(spikes_sampler, ratio_uv * texture_scale + vec2(texture_offset)).x;
-//
-	float d = length(max(abs(ratio_uv - vec2(0.5) * ratio) + radius - vec2(0.5) * ratio,0.0)) - radius;
-	d += (distance(vec2(0.5), UV) - 0.5) * radius;
-	float curve = texture(curve_sampler, vec2(d + spikes, 0.0)).x;
-	d += curve * crease;
-	d += texture(deformation_sampler, ratio_uv * 0.05 + TIME * speed*0.01).x * 0.1;
-	float mask = smoothstep(0.0, -0.005, d);
-	COLOR.a = mask;
+	float adjusted_radius = min(min(radius, box_size.x/2.0), box_size.y/2.0);
+	vec2 deformation_sample = texture(deformation_sampler, UV*wobble_detail+TIME*wobble_speed*0.05).xy*(vec2(box_padding)/box_size)*0.9;
+	vec2 deformed_UV = UV+((deformation_sample)-vec2(0.5)*vec2(box_padding)/box_size)*wobble_amount;
+	float rounded_box = length(max(abs(deformed_UV*(box_size+vec2(box_padding))-vec2(0.5)*(box_size+vec2(box_padding)))+adjusted_radius-vec2(0.5)*box_size,0))-adjusted_radius;
+	COLOR.a = min(smoothstep(0.0, -1, rounded_box), COLOR.a);
 }


### PR DESCRIPTION
Supposed to be a fix for coppolaemilio#1721, also kindof adresses coppolaemilio#1734.
@Kookiness Maybe you could try out this branch?

Choice size is now correctly taken into account and the text-bubble will get as big as needed. When choices get to long, they will get pushed into the next line.
This also means, we can't say for sure how big the choices will be which results in a size-increase after text finished (when choices become visible).

I also decided to rewrite the bubble-shader to more clearly expose the settings that are of interest for us. This results in a bit of a different look, especially with the same settings.

Also fixes
- text bubble background ignored modulate alpha

