### PR TITLE
Return concrete types in Dialogic game handler

### DIFF
--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemAudio
 
 ## Subsystem that manages music and sounds.
 

--- a/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemBackgrounds
 
 ## Subsystem for managing backgrounds.
 

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemPortraits
 
 ## Subsystem that manages portraits and portrait positions.
 

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemChoices
 
 ## Subsystem that manages showing and activating of choices.
 

--- a/addons/dialogic/Modules/Core/subsystem_animation.gd
+++ b/addons/dialogic/Modules/Core/subsystem_animation.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemAnimation
 
 ## Subsystem that allows entering and leaving an animation state.
 

--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemExpression
 
 ## Subsystem that allows executing strings (with the Expression class).
 ## This is used by conditions and to allow expresions as variables.

--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemInput
 
 ## Subsystem that handles input, autoadvance & skipping.
 

--- a/addons/dialogic/Modules/Glossary/subsystem_glossary.gd
+++ b/addons/dialogic/Modules/Glossary/subsystem_glossary.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemGlossary
 
 ## Subsystem that handles glossaries.
 

--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemHistory
 
 ## Subsystem that manages history storing.
 

--- a/addons/dialogic/Modules/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Modules/Jump/subsystem_jump.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemJump
 
 ## Subsystem that holds methods for jumping to specific labels, or return to the previous jump.
 

--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemSave
 
 ### Subsystem that manages saving and loading data.
 

--- a/addons/dialogic/Modules/Settings/subsystem_settings.gd
+++ b/addons/dialogic/Modules/Settings/subsystem_settings.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemSettings
 
 ## Subsystem that allows setting and getting settings that are automatically saved slot independent.
 ## All settings that are stored in the project settings dialogic/settings section are supported.

--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemStyles
 
 ## Subsystem that manages loading layouts with specific styles applied.
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemText
 
 ## Subsystem that handles showing of dialog text (+text effects & modifiers), name label, and next indicator
 

--- a/addons/dialogic/Modules/TextInput/subsystem_text_input.gd
+++ b/addons/dialogic/Modules/TextInput/subsystem_text_input.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemTextInput
 
 ## Subsystem that handles showing of input promts. 
 

--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemVariables
 
 ## Subsystem that manages variables and allows to access them.
 

--- a/addons/dialogic/Modules/Voice/subsystem_voice.gd
+++ b/addons/dialogic/Modules/Voice/subsystem_voice.gd
@@ -1,4 +1,5 @@
 extends DialogicSubsystem
+class_name DialogicSubsystemVoice
 
 ## Subsystem that manages setting voice lines for text events.
 

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -80,6 +80,77 @@ var timeline_directory: Dictionary = {}
 var _event_script_cache: Array[DialogicEvent] = []
 
 
+## Built-in subsystems, subsystems from extensions can't be shown currently in GDScript.
+
+var audio: DialogicSubsystemAudio:
+	get:
+		return get_node_or_null("Audio") as DialogicSubsystemAudio
+
+var backgrounds: DialogicSubsystemBackgrounds:
+	get:
+		return get_node_or_null("Backgrounds") as DialogicSubsystemBackgrounds
+
+var portraits: DialogicSubsystemPortraits:
+	get:
+		return get_node_or_null("Portraits") as DialogicSubsystemPortraits
+
+var choices: DialogicSubsystemChoices:
+	get:
+		return get_node_or_null("Choices") as DialogicSubsystemChoices
+
+var expression: DialogicSubsystemExpression:
+	get:
+		return get_node_or_null("Expression") as DialogicSubsystemExpression
+
+var animation: DialogicSubsystemAnimation:
+	get:
+		return get_node_or_null("Animation") as DialogicSubsystemAnimation
+
+var input: DialogicSubsystemInput:
+	get:
+		return get_node_or_null("Input") as DialogicSubsystemInput
+
+var glossary: DialogicSubsystemGlossary:
+	get:
+		return get_node_or_null("Glossary") as DialogicSubsystemGlossary
+
+var history: DialogicSubsystemHistory:
+	get:
+		return get_node_or_null("History") as DialogicSubsystemHistory
+
+var jump: DialogicSubsystemJump:
+	get:
+		return get_node_or_null("Jump") as DialogicSubsystemJump
+
+var save: DialogicSubsystemSave:
+	get:
+		return get_node_or_null("Save") as DialogicSubsystemSave
+
+var settings: DialogicSubsystemSettings:
+	get:
+		return get_node_or_null("Settings") as DialogicSubsystemSettings
+
+var styles: DialogicSubsystemStyles:
+	get:
+		return get_node_or_null("Styles") as DialogicSubsystemStyles
+
+var text: DialogicSubsystemText:
+	get:
+		return get_node_or_null("Text") as DialogicSubsystemText
+
+var text_input: DialogicSubsystemTextInput:
+	get:
+		return get_node_or_null("TextInput") as DialogicSubsystemTextInput
+
+var variables: DialogicSubsystemVariables:
+	get:
+		return get_node_or_null("VAR") as DialogicSubsystemVariables
+
+var voice: DialogicSubsystemVoice:
+	get:
+		return get_node_or_null("Voice") as DialogicSubsystemVoice
+
+
 ## Autoloads are added first, so this happens REALLY early on game startup.
 func _ready() -> void:
 	rebuild_character_directory()


### PR DESCRIPTION
this PR addresses https://github.com/coppolaemilio/dialogic/issues/1816

There were some concessions to be made, the properties don't match the current way of how the subsystems are accessed. But having a 1-to-1 translation would cause Godot to give an error as it shadows native types.

Another oddity is that Godot (4.1.3) _does_ recognize the properties on `Dialogic`, but _does not_ give proper hints to how the subsystem is structured. However it _does_ recognize when functions have the wrong amount of arguments. if i cast `Dialogic`  to `Dialogic` the hinting system seems to work as expected. So it seems to be a bug on the Godot side.