### PR TITLE
Fix Unit Test CI

### DIFF
--- a/.github/workflows/resources/project.godot
+++ b/.github/workflows/resources/project.godot
@@ -1,0 +1,20 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="dialogic"
+config/features=PackedStringArray("4.2", "GL Compatibility")
+config/icon="res://icon.svg"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         # Insert here the Godot version you want to run your tests with.
-        godot-version: ['4.2']
+        godot-version: ['4.2.1']
 
     name: "CI Unit Test v${{ matrix.godot-version }}"
     runs-on: 'ubuntu-22.04'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,7 +63,7 @@ jobs:
           echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
 
       - name: "Clone the gdUnit4 repository"
-        run: git clone --branch master https://github.com/MikeSchulze/gdUnit4 addons/gdUnit4
+        run: git clone --branch master https://github.com/MikeSchulze/gdUnit4 .addons/gdUnit4
 
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
             git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4
             rsync -av gdUnit4/addons/ ./addons/
+            rm -rf ./gdUnit4
 
       - name: Print Directory Structure
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -90,8 +90,8 @@ jobs:
           GODOT_BIN: ${{ env.GODOT_BIN }}
         shell: bash
         run: |
-          chmod +x ./addons/gdUnit4/runtest.sh
-          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
+          chmod +x ./addons/dialogic/addons/gdUnit4/runtest.sh
+          xvfb-run --auto-servernum ./addons/dialogic/addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
 
       - name: "Publish Test Report"
         if: ${{ always() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
+          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
 
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -64,6 +64,9 @@ jobs:
           echo "GODOT_HOME=$GODOT_HOME" >> "$GITHUB_ENV"
           echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
 
+      - name: "Clone the gdUnit4 repository"
+        run: git clone --branch master https://github.com/MikeSchulze/gdUnit4 addons/gdUnit4
+
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"
         if: ${{ !cancelled() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -63,7 +63,9 @@ jobs:
           echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
 
       - name: "Clone the gdUnit4 repository"
-        run: git clone --branch master https://github.com/MikeSchulze/gdUnit4 .addons/gdUnit4
+        run: |
+            git clone --branch master https://github.com/MikeSchulze/gdUnit4
+            mv gdUnit4/addons/gdUnit4 .
 
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . --headless --audio-driver Dummy
+          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
 
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4
-            rsync -av gdUnit4/addons/ ./addons/
+            rsync -av gdUnit4/addons/ ./addons/dialogic/addons/
             rm -rf ./gdUnit4
 
       - name: Print Directory Structure

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -62,6 +62,9 @@ jobs:
           echo "GODOT_HOME=$GODOT_HOME" >> "$GITHUB_ENV"
           echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
 
+      - name: "Add project.godot"
+        run: cp .github/workflows/resources/project.godot .
+
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4
-            rsync -av gdUnit4/addons/ ./addons/dialogic/addons/
+            rsync -av gdUnit4/addons/ ./addons/
             rm -rf ./gdUnit4
 
       - name: Print Directory Structure
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/dialogic/addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
 
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}
@@ -90,8 +90,8 @@ jobs:
           GODOT_BIN: ${{ env.GODOT_BIN }}
         shell: bash
         run: |
-          chmod +x ./addons/dialogic/addons/gdUnit4/runtest.sh
-          xvfb-run --auto-servernum ./addons/dialogic/addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
+          chmod +x ./addons/gdUnit4/runtest.sh
+          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
 
       - name: "Publish Test Report"
         if: ${{ always() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
+          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . --headless --audio-driver Dummy
 
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -62,7 +62,7 @@ jobs:
           echo "GODOT_HOME=$GODOT_HOME" >> "$GITHUB_ENV"
           echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
 
-      - name: "Add project.godot"
+      - name: "Copy `project.godot`"
         run: cp .github/workflows/resources/project.godot .
 
       - name: "Clone the gdUnit4 repository"
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: |
           chmod +x ./addons/gdUnit4/runtest.sh
-          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://test" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
+          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://addons/dialogic/Tests/" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
 
       - name: "Publish Test Report"
         if: ${{ always() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: "Clone the gdUnit4 repository"
         run: |
-            git clone --branch master https://github.com/MikeSchulze/gdUnit4
+            git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4
             rsync -av gdUnit4/addons/ ./addons/
 
       - name: Print Directory Structure

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
-            mv gdUnit4/addons/gdUnit4 .
+            mv gdUnit4/addons/gdUnit4 .addons/
 
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,8 +3,6 @@ run-name: ${{ github.head_ref || github.ref_name }}-unit-test
 
 on:
   push:
-    branches:
-        - main
 
     paths-ignore:
         - '**.yml'

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
-            mv gdUnit4/addons/ addons/
+            mv gdUnit4/addons/ ./addons/
 
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
+          ${{ env.GODOT_BIN }} -e --path . -s res://addons/dialogic/addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
 
       - name: "Run Unit Tests"
         if: ${{ !cancelled() }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
-            mv gdUnit4/addons/gdUnit4 .addons/
+            mv gdUnit4/addons/ addons/
 
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
-            mv gdUnit4/addons/ ./addons/
+            mv gdUnit4/addons/ ./
 
       - name: Print Directory Structure
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -65,7 +65,7 @@ jobs:
       - name: "Clone the gdUnit4 repository"
         run: |
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
-            mv gdUnit4/addons/ ./
+            rsync -av gdUnit4/addons/ ./addons/
 
       - name: Print Directory Structure
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -67,6 +67,10 @@ jobs:
             git clone --branch master https://github.com/MikeSchulze/gdUnit4
             mv gdUnit4/addons/ ./addons/
 
+      - name: Print Directory Structure
+        run: |
+            ls -R
+
       # We need to update the project before running tests, Godot has actually issues with loading the plugin.
       - name: "Update Project"
         if: ${{ !cancelled() }}

--- a/addons/dialogic/Tests/Unit/test_example.gd
+++ b/addons/dialogic/Tests/Unit/test_example.gd
@@ -1,0 +1,9 @@
+class_name GdUnitExampleTest
+extends GdUnitTestSuite
+
+func test_example() -> void:
+    const EXAMPLE_STRING := "Dialogic!"
+
+    assert_str(EXAMPLE_STRING)\
+        .has_length(EXAMPLE_STRING.length())\
+        .starts_with("Dia")


### PR DESCRIPTION
This PR fixes the unit test workflow by copying a `project.godot` file from `.github/workflows/resources/`.
Set the test folder to `addons/dialogic/Tests`.