### PR TITLE
Prevent failure when report upload fails

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -114,6 +114,7 @@ jobs:
             reports/**
             /var/lib/systemd/coredump/**
             /var/log/syslog
+          fail-on-error: 'false'
 
   finalize:
     if: ${{ !cancelled() }}


### PR DESCRIPTION
If there is a networking or permission issue but the tests succeeded, the workflow shall pass.