### PR TITLE
Split workflows into two

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,15 +15,9 @@ on:
 
   workflow_dispatch:
 
-permissions:
-    contents: read
-    actions: read
-    checks: write
-
 concurrency:
   group: unit-test${{ github.event.number }}
   cancel-in-progress: true
-
 
 jobs:
   unit-test:
@@ -100,20 +94,11 @@ jobs:
           chmod +x ./addons/gdUnit4/runtest.sh
           xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://addons/dialogic/Tests/" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
 
-      - name: "Publish Test Report"
-        if: ${{ always() }}
-        uses: dorny/test-reporter@v1.6.0
-        with:
-          name: "test_report_${{ matrix.godot-version }}"
-          path: "reports/**/results.xml"
-          reporter: java-junit
-          fail-on-error: 'false'
-
       - name: "Upload Unit Test Reports"
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
-          name: "test_report_${{ matrix.godot-version }}"
+          name: "godot-version"
           path: |
             reports/**
             /var/lib/systemd/coredump/**

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,9 +9,6 @@ on:
         - '**.md'
 
   pull_request:
-    paths-ignore:
-      - '**.yml'
-      - '**.md'
 
   workflow_dispatch:
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -103,7 +103,6 @@ jobs:
             reports/**
             /var/lib/systemd/coredump/**
             /var/log/syslog
-          fail-on-error: 'false'
 
   finalize:
     if: ${{ !cancelled() }}

--- a/.github/workflows/unit_test_report.yml
+++ b/.github/workflows/unit_test_report.yml
@@ -1,0 +1,24 @@
+name: 'publish-test'
+on:
+  workflow_run:
+    workflows: ['unit-test']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: "Publish Test Report"
+      if: ${{ always() }}
+      uses: dorny/test-reporter@v1.6.0
+      with:
+        name: "test_report"
+        path: "reports/**/results.xml"
+        reporter: java-junit

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+    contents: read
+    actions: read
+    checks: write
 
 concurrency:
   group: unit-test${{ github.event.number }}

--- a/addons/dialogic/Tests/Unit/test_example.gd
+++ b/addons/dialogic/Tests/Unit/test_example.gd
@@ -2,7 +2,7 @@ class_name GdUnitExampleTest
 extends GdUnitTestSuite
 
 func test_example() -> void:
-    const EXAMPLE_STRING := "Dialogic!"
+    const EXAMPLE_STRING := "Dialogic Test!"
 
     assert_str(EXAMPLE_STRING)\
         .has_length(EXAMPLE_STRING.length())\


### PR DESCRIPTION
This uses two workflows. One per push/PR, uploading artefacts, and the other runs after the success of the first one, then publishes the test results.