### PR TITLE
Fix empty-choice-indentation bug

### DIFF
--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -150,7 +150,7 @@ func process() -> void:
 				_events.append(end_event.duplicate())
 		# Add an end event if the indent is the same but the previous was an opener
 		# (so for example choice that is empty)
-		elif prev_was_opener and len(indent) == len(prev_indent):
+		if prev_was_opener and len(indent) <= len(prev_indent):
 			_events.append(end_event.duplicate())
 		prev_indent = indent
 


### PR DESCRIPTION
Reported by a user on discord, having an empty choice before an indentation change would incorreclty calculate the amount of end branches needed.

Example timeline of failure:
```
if {RedWandCount} > 0 or {BlueWandCount} > 0 or {GreenWandCount} > 0:
	The pedestal is empty.
	- Place red wand [if {RedWandCount} > 0][else="hide"]
	- Place blue wand [if {BlueWandCount} > 0][else="hide"]
	- Place green wand [if {GreenWandCount} > 0][else="hide"]
else:
	The pedestal is empty and you can't do anything about it.
The end
[end_timeline]
```
Would fail previously, but now works.