### PR TITLE
1.x converter "jump" working by prep loop func + character "positions" debugged

### DIFF
--- a/addons/dialogic/Modules/Background/event_background.gd
+++ b/addons/dialogic/Modules/Background/event_background.gd
@@ -100,7 +100,7 @@ func build_event_editor():
 		'left_text' :'Show',
 		'options': [
 			{
-				'label': 'Default Scene',
+				'label': 'Background',
 				'value': SceneTypes.DEFAULT,
 				'icon': ["GuiRadioUnchecked", "EditorIcons"]
 			},
@@ -109,11 +109,12 @@ func build_event_editor():
 				'value': SceneTypes.CUSTOM,
 				'icon': ["PackedScene", "EditorIcons"]
 			}
-		], "symbol_only": true})
-	add_header_label("Default BG Scene with", '_scene_type == SceneTypes.DEFAULT')
+		]})
+	add_header_label("with image", "_scene_type == SceneTypes.DEFAULT")
 	add_header_edit("scene", ValueType.FILE,
 			{'file_filter':'*.tscn, *.scn; Scene Files',
-			'placeholder': "Default scene",
+			'placeholder': "Custom scene",
+			'editor_icon': ["PackedScene", "EditorIcons"],
 			}, '_scene_type == SceneTypes.CUSTOM')
 	add_header_edit('_arg_type', ValueType.FIXED_OPTIONS, {
 		'left_text' : 'with',
@@ -132,6 +133,7 @@ func build_event_editor():
 	add_header_edit('argument', ValueType.FILE,
 			{'file_filter':'*.jpg, *.jpeg, *.png, *.webp, *.tga, *svg, *.bmp, *.dds, *.exr, *.hdr; Supported Image Files',
 			'placeholder': "No Image",
+			'editor_icon': ["Image", "EditorIcons"],
 			},
 			'_arg_type == ArgumentTypes.IMAGE or _scene_type == SceneTypes.DEFAULT')
 	add_header_edit('argument', ValueType.SINGLELINE_TEXT, {}, '_arg_type == ArgumentTypes.CUSTOM')

--- a/addons/dialogic/Modules/Converter/settings_converter.gd
+++ b/addons/dialogic/Modules/Converter/settings_converter.gd
@@ -517,27 +517,36 @@ func convertTimelines():
 						"dialogic_012":
 							#If event
 							var valueLookup = "broken variable"
-							if definitionFolderBreakdown.size():
-								valueLookup = variableNameConversion("[" + definitionFolderBreakdown[event['definition']]['path'] + definitionFolderBreakdown[event['definition']]['name'] + "]" )
+							if event.has('definition') and event['definition'] in definitionFolderBreakdown:
+								if definitionFolderBreakdown.size():
+									var definition = definitionFolderBreakdown[event['definition']]
+									if 'path' in definition and 'name' in definition:
+										valueLookup = variableNameConversion( "[" + definition['path'] + definition['name'] + "]")
+									else:
+										# Handle the case where 'path' or 'name' keys are missing
+										%OutputLog.text += "[color=red]Path or name not found in definition[/color]" + "\r\n"
 
-							eventLine += "if "
-							eventLine += valueLookup
-							if event['condition'] != "":
-								eventLine += " " + event['condition']
+								eventLine += "if "
+								eventLine += valueLookup
+								if event['condition'] != "":
+									eventLine += " " + event['condition']
+								else:
+									#default is true, so it may not store it
+									eventLine += " =="
+
+								# weird line due to missing type casts on String in current Godot 4 alpha
+								if event['value'] == str(event['value'].to_int()):
+									eventLine += " " + event['value']
+								else:
+									eventLine += " \"" + event['value'] + "\""
+
+								eventLine += ":"
+								file.store_string(eventLine)
+								#print("if branch node")
+								depth.push_front("condition")
 							else:
-								#default is true, so it may not store it
-								eventLine += " =="
-
-							# weird line due to missing type casts on String in current Godot 4 alpha
-							if event['value'] == str(event['value'].to_int()):
-								eventLine += " " + event['value']
-							else:
-								eventLine += " \"" + event['value'] + "\""
-
-							eventLine += ":"
-							file.store_string(eventLine)
-							#print("if branch node")
-							depth.push_front("condition")
+								# Handle the case where 'definition' key is missing or not in definitionFolderBreakdown
+								%OutputLog.text += "[color=red]Definition not found in event or definitionFolderBreakdown[/color]" + "\r\n"
 
 							#print ("bracnh depth now" + str(depth))
 						"dialogic_013":

--- a/addons/dialogic/Modules/Converter/settings_converter.gd
+++ b/addons/dialogic/Modules/Converter/settings_converter.gd
@@ -351,8 +351,7 @@ func convertTimelines():
 
 										for i in event['position']:
 											if event['position'][i] == true:
-												#1.x uses positions 0-4, while the default 2.0 scene uses positions 1-5
-												eventLine += str(i.to_int() + 1)
+												eventLine += str(i.to_int())
 
 										if (event['animation'] != "[Default]" && event['animation'] != "") || ('z_index' in event) || ('mirror_portrait' in event):
 											# Note: due to Anima changes, animations will be converted into a default. Times and wait will be perserved
@@ -392,7 +391,7 @@ func convertTimelines():
 
 													if event['position'][i] == true:
 														positionCheck = true
-														eventLine += str(i.to_int() + 1)
+														eventLine += str(i.to_int())
 
 											if !positionCheck:
 												eventLine += " 0"


### PR DESCRIPTION
Tested the dialogic-1 converter today.  Noticed the change_timeline() to jump conversion needed touching up.  

Added a prep loop to populate a dictionary with timeline keys and file names to be able to populate the converted timeline to write out proper "jump nextTimeline/" in editor.

*Noticed the character position conversion for 2.0 now mirrors 1.x again.  Deleted the +1 in the code. 

**Committed a fix for conversion for an empty if-statement definition. https://github.com/dialogic-godot/dialogic/issues/1494