### PR TITLE
Extend `DialogicPortrait` by custom portraits.

### DIFF
--- a/addons/dialogic/Example Assets/portraits/CustomPortrait_AnimatedSprite.gd
+++ b/addons/dialogic/Example Assets/portraits/CustomPortrait_AnimatedSprite.gd
@@ -1,11 +1,11 @@
 @tool
-extends Node2D
+extends DialogicPortrait
 
 # If the custom portrait accepts a change, then accept it here
 func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
 	if passed_portrait == "":
 		passed_portrait = passed_character['default_portrait']
-	
+
 	if $Sprite.sprite_frames.has_animation(passed_portrait):
 		$Sprite.play(passed_portrait)
 

--- a/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
+++ b/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
@@ -3,17 +3,16 @@ extends DialogicPortrait
 
 enum Faces {BASED_ON_PORTRAIT_NAME, NEUTRAL, HAPPY, SAD, JOY, SHOCK, ANGRY}
 
-var portrait
-
 @export var emotion : Faces = Faces.BASED_ON_PORTRAIT_NAME
 @export var portrait_width: int
 @export var portrait_height: int
-@export var alien = true
+@export var alien := true
 
-var does_custom_portrait_change = true
+var does_custom_portrait_change := true
 
-func _ready():
+func _ready() -> void:
 	$Alien.hide()
+
 
 # Function to accept and use the extra data, if the custom portrait wants to accept it
 func _set_extra_data(data: String) -> void:
@@ -22,14 +21,17 @@ func _set_extra_data(data: String) -> void:
 	elif data == "no_alien":
 		$Alien.hide()
 
+
 # This function can be overridden. Defaults to true, if not overridden!
-func _should_do_portrait_update(character:DialogicCharacter, portrait:String) -> bool:
+func _should_do_portrait_update(_character: DialogicCharacter, _portrait:String) -> bool:
 	return true
 
+
 # If the custom portrait accepts a change, then accept it here
-func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
+func _update_portrait(_passed_character: DialogicCharacter, passed_portrait: String) -> void:
 	for face in $Faces.get_children():
 		face.hide()
+
 	if emotion == Faces.BASED_ON_PORTRAIT_NAME:
 		if 'happy' in passed_portrait.to_lower(): $Faces/Smile.show()
 		elif 'sad' in passed_portrait.to_lower(): $Faces/Frown.show()
@@ -37,6 +39,7 @@ func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String
 		elif 'shock' in passed_portrait.to_lower(): $Faces/Shock.show()
 		elif 'angry' in passed_portrait.to_lower(): $Faces/Anger.show()
 		else: $Faces/Neutral.show()
+
 	else:
 		if emotion == Faces.HAPPY: $Faces/Smile.show()
 		elif emotion == Faces.SAD: $Faces/Frown.show()
@@ -47,10 +50,23 @@ func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String
 
 	$Alien.visible = alien
 
-func _set_mirror(mirror:bool) -> void:
-	if mirror: scale.x *= -1
 
-# if implemented, this is used by the editor for the "full view" mode
+func _set_mirror(is_mirrored: bool) -> void:
+	var nd: Node2D = get_parent().get_child(0)
+
+	if is_mirrored:
+		nd.scale.x = -1
+
+	else:
+		nd.scale.x = 1
+
+
+## If implemented, this is used by the editor for the "full view" mode
 func _get_covered_rect() -> Rect2:
-	#return Rect2($Faces/Anger.position+$Faces.position, $Faces/Anger.get_rect().size*$Faces/Anger.scale*$Faces.scale) #  will fcus on the face
-	return Rect2($Body.position, $Body.get_rect().size*$Body.scale)
+	# This will focus on the face.
+	# return Rect2($Faces/Anger.position+$Faces.position, $Faces/Anger.get_rect().size*$Faces/Anger.scale*$Faces.scale)
+	var size: Vector2 = $Body.get_rect().size
+	var scaled_size: Vector2 = size * $Body.scale
+	var position: Vector2 = $Body.position
+
+	return Rect2(position, scaled_size)

--- a/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
+++ b/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
@@ -52,13 +52,11 @@ func _update_portrait(_passed_character: DialogicCharacter, passed_portrait: Str
 
 
 func _set_mirror(is_mirrored: bool) -> void:
-	var nd: Node2D = get_parent().get_child(0)
-
 	if is_mirrored:
-		nd.scale.x = -1
+		self.scale.x = -1
 
 	else:
-		nd.scale.x = 1
+		self.scale.x = 1
 
 
 ## If implemented, this is used by the editor for the "full view" mode

--- a/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
+++ b/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.gd
@@ -1,5 +1,5 @@
 @tool
-extends Node2D
+extends DialogicPortrait
 
 enum Faces {BASED_ON_PORTRAIT_NAME, NEUTRAL, HAPPY, SAD, JOY, SHOCK, ANGRY}
 
@@ -44,7 +44,7 @@ func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String
 		elif emotion == Faces.SHOCK: $Faces/Shock.show()
 		elif emotion == Faces.ANGRY: $Faces/Anger.show()
 		else: $Faces/Neutral.show()
-	
+
 	$Alien.visible = alien
 
 func _set_mirror(mirror:bool) -> void:

--- a/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.tscn
+++ b/addons/dialogic/Example Assets/portraits/CustomPortrait_FaceAtlas.tscn
@@ -10,7 +10,7 @@
 [ext_resource type="Texture2D" uid="uid://c5aku2g01k6c6" path="res://addons/dialogic/Example Assets/portraits/Princess/shock.png" id="7_5xil3"]
 [ext_resource type="Texture2D" uid="uid://dsid4ye0q74nl" path="res://addons/dialogic/Example Assets/portraits/Princess/smile.png" id="8_7s6tq"]
 
-[node name="CustomPortraitFaceAtlass" type="Node2D"]
+[node name="CustomPortraitFaceAtlas" type="Node2D"]
 position = Vector2(301, 598)
 script = ExtResource("1_fc12l")
 


### PR DESCRIPTION
This PR extends `DialogicPortrait` on custom portraits in the custom assets.

This prevents errors when a method like `_highlight` is invoked.