### PR TITLE
Fix User Input Auto-Advance

### DIFF
--- a/.github/workflows/resources/project.godot
+++ b/.github/workflows/resources/project.godot
@@ -18,3 +18,7 @@ config/icon="res://icon.svg"
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+
+[autoload]
+
+Dialogic="*res://addons/dialogic/Other/DialogicGameHandler.gd"

--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -41,15 +41,15 @@ func resume() -> void:
 ####### MAIN METHODS ###########################################################
 #region MAIN METHODS
 
-func handle_input():
+func handle_input() -> void:
 	if dialogic.paused or is_input_blocked():
 		return
 
-	if !action_was_consumed:
+	if not action_was_consumed:
 		# We want to stop auto-advancing that cancels on user inputs.
 		if (auto_advance.is_enabled()
 			and auto_advance.enabled_until_user_input):
-			auto_advance.enabled_until_next_event = false
+			auto_advance.enabled_until_user_input = false
 			action_was_consumed = true
 
 		# We want to stop auto-skipping if it's enabled, we are listening

--- a/addons/dialogic/Modules/Text/auto_advance.gd
+++ b/addons/dialogic/Modules/Text/auto_advance.gd
@@ -68,6 +68,7 @@ var enabled_until_user_input := false :
 		enabled_until_user_input = enabled
 		_try_emit_toggled()
 
+
 func _init() -> void:
 	DialogicUtil.autoload().Input.add_child(autoadvance_timer)
 	autoadvance_timer.one_shot = true

--- a/addons/dialogic/Tests/Unit/test_auto_advance.gd
+++ b/addons/dialogic/Tests/Unit/test_auto_advance.gd
@@ -1,4 +1,3 @@
-class_name AutoAdvanceTest
 extends GdUnitTestSuite
 
 ## Ensure Auto-Advance is enabled properly using the user input flag.

--- a/addons/dialogic/Tests/Unit/test_auto_advance.gd
+++ b/addons/dialogic/Tests/Unit/test_auto_advance.gd
@@ -1,0 +1,20 @@
+class_name AutoAdvanceTest
+extends GdUnitTestSuite
+
+## Ensure Auto-Advance is enabled properly using the user input flag.
+func test_enable_auto_advance() -> void:
+	Dialogic.Input.auto_advance.enabled_until_user_input = true
+	var is_enabled: bool = Dialogic.Input.auto_advance.is_enabled()
+
+	assert(is_enabled == true, "Auto-Advance is not enabled.")
+
+
+## This test was created to ensure a bug was fixed:
+## When the user enabled the Auto-Advance until user input,
+## the Auto-Advance would still run after the user input.
+func test_disable_auto_advance() -> void:
+	Dialogic.Input.auto_advance.enabled_until_user_input = true
+	Dialogic.Input.handle_input()
+
+	var is_enabled: bool = Dialogic.Input.auto_advance.is_enabled()
+	assert(is_enabled == false, "Auto-Advance is still running after input")

--- a/addons/dialogic/Tests/Unit/test_example.gd
+++ b/addons/dialogic/Tests/Unit/test_example.gd
@@ -1,4 +1,3 @@
-class_name GdUnitExampleTest
 extends GdUnitTestSuite
 
 func test_example() -> void:


### PR DESCRIPTION
Fixes Auto-Advance enabled until the next user input not ending on user input.

Fixes the PR https://github.com/dialogic-godot/dialogic/issues/2022.

This PR fixes unit tests relying on the Dialogic `autoload`.