### PR TITLE
fix a function bug in subsystem_variables.gd

### DIFF
--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -187,7 +187,7 @@ class VariableFolder:
 	func _set(property, value) -> bool:
 		property = str(property)
 		if not value is VariableFolder:
-			outside._set_value_in_dictionary(path+"."+property, outside.dialogic.current_state_info['variables'], value)
+			DialogicUtil._set_value_in_dictionary(path+"."+property, outside.dialogic.current_state_info['variables'], value)
 		return true
 
 	func has(key) -> bool:


### PR DESCRIPTION
![image](https://github.com/dialogic-godot/dialogic/assets/4829591/a94297c6-b295-4e49-84f2-11d6b1003ea5)


![image](https://github.com/dialogic-godot/dialogic/assets/4829591/6f169f73-b3c6-49f9-a3bd-2fe8d7af5b1e)


When setting a dialogic variable in code, it shows a bug here after `alpha 12`.

The method called `_set_value_in_dictionary` in `outside` as `VariableFolder` has been removed since commit [Variables Rework (second PR attempt) (#1972)](https://github.com/dialogic-godot/dialogic/commit/ccd5e3385db2366bcb8c7eb3702070eef25adedd)

I think this is a missing part.