### PR TITLE
Avoid null get_tree() call

### DIFF
--- a/addons/dialogic/Editor/Common/update_install_window.gd
+++ b/addons/dialogic/Editor/Common/update_install_window.gd
@@ -106,8 +106,9 @@ func _on_update_manager_downdload_completed(result:int):
 
 
 func _on_resources_reimported(resources:Array) -> void:
-	await get_tree().process_frame
-	get_parent().move_to_foreground()
+	if is_inside_tree():
+		await get_tree().process_frame
+		get_parent().move_to_foreground()
 
 
 func markdown_to_bbcode(text:String) -> String:


### PR DESCRIPTION
get_tree() can return null when the Dialogic view isn't open but this function is being called by an external system. No node tree exists to wait for or manipulate, so errors are spammed.