### PR TITLE
Add Undo/Redo for choice and condition buttons.

### DIFF
--- a/addons/dialogic/Modules/Choice/ui_choice_end.gd
+++ b/addons/dialogic/Modules/Choice/ui_choice_end.gd
@@ -21,5 +21,8 @@ func _on_add_choice_pressed() -> void:
 	if timeline:
 		var resource = DialogicChoiceEvent.new()
 		resource.created_by_button = true
-		timeline.add_event_with_end_branch(resource, get_parent().get_index()+1)
+		timeline.add_event_undoable(resource, get_parent().get_index()+1)
 		timeline.indent_events()
+		timeline.something_changed()
+		# Prevent focusing on future redos
+		resource.created_by_button = false

--- a/addons/dialogic/Modules/Condition/ui_condition_end.gd
+++ b/addons/dialogic/Modules/Condition/ui_condition_end.gd
@@ -33,13 +33,15 @@ func add_elif():
 	if timeline:
 		var resource = DialogicConditionEvent.new()
 		resource.condition_type = DialogicConditionEvent.ConditionTypes.ELIF
-		timeline.add_event_with_end_branch(resource, get_parent().get_index()+1)
+		timeline.add_event_undoable(resource, get_parent().get_index()+1)
 		timeline.indent_events()
+		timeline.something_changed()
 
 func add_else():
 	var timeline = find_parent('VisualEditor')
 	if timeline:
 		var resource = DialogicConditionEvent.new()
 		resource.condition_type = DialogicConditionEvent.ConditionTypes.ELSE
-		timeline.add_event_with_end_branch(resource, get_parent().get_index()+1)
+		timeline.add_event_undoable(resource, get_parent().get_index()+1)
 		timeline.indent_events()
+		timeline.something_changed()


### PR DESCRIPTION
Fixes #2064 

- Adds Undo/Redo support for choice and condition buttons (Buttons you click on below the nodes to create more of itself)
- Refactored event creating in `timeline_editor_visual.gd` to use a custom `add_event_undoable` function.