### PR TITLE
Fix Current Speaker if nobody speaks

### DIFF
--- a/Tests/Resources/unit_test_character.dch
+++ b/Tests/Resources/unit_test_character.dch
@@ -1,0 +1,19 @@
+{
+"@path": "res://addons/dialogic/Resources/character.gd",
+"@subpath": NodePath(""),
+"_translation_id": "",
+"color": Color(1, 1, 1, 1),
+"custom_info": {
+"sound_mood_default": "",
+"sound_moods": {},
+"style": ""
+},
+"default_portrait": "",
+"description": "",
+"display_name": "unit_test_character",
+"mirror": false,
+"nicknames": [""],
+"offset": Vector2(0, 0),
+"portraits": {},
+"scale": 1.0
+}

--- a/Tests/Unit/subsystem_text_test.gd
+++ b/Tests/Unit/subsystem_text_test.gd
@@ -2,14 +2,14 @@ extends GdUnitTestSuite
 
 const VALID_SPEAKER_PATH := "res://Tests/Resources/unit_test_character.dch"
 
-## We ensure that no speaker will return the correct value.
-func test_current_speaker() -> void:
+## We ensure that missing a speaker will return null.
+func test_missing_current_speaker() -> void:
     var null_speaker := DialogicUtil.autoload().Text.get_current_speaker()
 
     assert(null_speaker == null, "Current speaker is not null.")
 
 
-## We ensure incorrect speakers return the correct value.
+## We ensure invalid speaker paths return the correct value.
 func test_set_invalid_current_speaker() -> void:
     DialogicUtil.autoload().current_state_info["speaker"] = "Invalid Speaker Path"
     var current_speaker := DialogicUtil.autoload().Text.get_current_speaker()
@@ -17,8 +17,8 @@ func test_set_invalid_current_speaker() -> void:
     assert(current_speaker == null, "Invalid speaker must be invalid, but is valid.")
 
 
-## We ensure that valid speakers return a valid Dialogic Speaker and
-## that the path is set correctly.
+## We ensure valid speaker paths return a valid [class DialogicCharacter] and
+## the path is set correctly.
 func test_set_valid_current_speaker() -> void:
     DialogicUtil.autoload().current_state_info["speaker"] = VALID_SPEAKER_PATH
     var current_speaker := DialogicUtil.autoload().Text.get_current_speaker()

--- a/Tests/Unit/subsystem_text_test.gd
+++ b/Tests/Unit/subsystem_text_test.gd
@@ -1,0 +1,27 @@
+extends GdUnitTestSuite
+
+const VALID_SPEAKER_PATH := "res://Tests/Resources/unit_test_character.dch"
+
+## We ensure that no speaker will return the correct value.
+func test_current_speaker() -> void:
+    var null_speaker := DialogicUtil.autoload().Text.get_current_speaker()
+
+    assert(null_speaker == null, "Current speaker is not null.")
+
+
+## We ensure incorrect speakers return the correct value.
+func test_set_invalid_current_speaker() -> void:
+    DialogicUtil.autoload().current_state_info["speaker"] = "Invalid Speaker Path"
+    var current_speaker := DialogicUtil.autoload().Text.get_current_speaker()
+
+    assert(current_speaker == null, "Invalid speaker must be invalid, but is valid.")
+
+
+## We ensure that valid speakers return a valid Dialogic Speaker and
+## that the path is set correctly.
+func test_set_valid_current_speaker() -> void:
+    DialogicUtil.autoload().current_state_info["speaker"] = VALID_SPEAKER_PATH
+    var current_speaker := DialogicUtil.autoload().Text.get_current_speaker()
+
+    assert(not current_speaker == null, "Valid speaker must be valid, but is invalid.")
+    assert(current_speaker.get_path() == VALID_SPEAKER_PATH, "Valid speaker path is not set correctly.")

--- a/addons/dialogic/Modules/Glossary/glossary_editor.tscn
+++ b/addons/dialogic/Modules/Glossary/glossary_editor.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Glossary/glossary_editor.gd" id="1_tf3p1"]
 [ext_resource type="Texture2D" uid="uid://cenut3sc5cul0" path="res://addons/dialogic/Modules/Glossary/add-glossary.svg" id="2_0elx7"]
 
-[sub_resource type="Image" id="Image_ib0c1"]
+[sub_resource type="Image" id="Image_puu06"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -12,8 +12,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_c8i3m"]
-image = SubResource("Image_ib0c1")
+[sub_resource type="ImageTexture" id="ImageTexture_dfvxn"]
+image = SubResource("Image_puu06")
 
 [node name="GlossaryEditor" type="VBoxContainer"]
 anchors_preset = 15
@@ -63,14 +63,14 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Import Glossary File"
-icon = SubResource("ImageTexture_c8i3m")
+icon = SubResource("ImageTexture_dfvxn")
 
 [node name="DeleteGlossaryFile" type="Button" parent="Entries/Settings/Glossaries/Glossaries/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Delete Glossary"
-icon = SubResource("ImageTexture_c8i3m")
+icon = SubResource("ImageTexture_dfvxn")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Entries/Settings/Glossaries/Glossaries"]
 layout_mode = 2
@@ -149,21 +149,21 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "New Glossary Entry"
-icon = SubResource("ImageTexture_c8i3m")
+icon = SubResource("ImageTexture_dfvxn")
 
 [node name="DeleteGlossaryEntry" type="Button" parent="Entries/HSplit/VBoxContainer/Tabs/Entries/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 tooltip_text = "Delete Glossary Entry"
-icon = SubResource("ImageTexture_c8i3m")
+icon = SubResource("ImageTexture_dfvxn")
 
 [node name="EntrySearch" type="LineEdit" parent="Entries/HSplit/VBoxContainer/Tabs/Entries/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 placeholder_text = "Search"
-right_icon = SubResource("ImageTexture_c8i3m")
+right_icon = SubResource("ImageTexture_dfvxn")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Entries/HSplit/VBoxContainer/Tabs/Entries"]
 layout_mode = 2
@@ -229,7 +229,7 @@ unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Case sensitive"
 toggle_mode = true
-icon = SubResource("ImageTexture_c8i3m")
+icon = SubResource("ImageTexture_dfvxn")
 flat = true
 
 [node name="Label3" type="Label" parent="Entries/HSplit/EntryEditor/VBox/Entry Settings/EntrySettings"]

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -397,8 +397,22 @@ func _ready():
 		_autopauses[RegEx.create_from_string('(?<!(\\[|\\{))['+i+'](?!([\\w\\s]*!?[\\]\\}]|$))')] = autopause_data[i]
 
 
+## Returns the [class DialogicCharacter] of the current speaker.
+## If there is no current speaker or the speaker is not found, returns null.
 func get_current_speaker() -> DialogicCharacter:
-	return (load(dialogic.current_state_info.get('speaker', "")) as DialogicCharacter)
+	var speaker_path: String = dialogic.current_state_info.get("speaker", "")
+
+	if speaker_path.is_empty():
+		return null
+
+	var speaker_resource := load(speaker_path)
+
+	if speaker_resource == null:
+		return null
+
+	var speaker_character := speaker_resource as DialogicCharacter
+
+	return speaker_character
 
 
 func _update_user_speed(user_speed:float) -> void:


### PR DESCRIPTION
In the case that a text line has no speaker or Dialogic is outside of a timeline, the `current_speaker` method crashes.

This PR handles invalid character values and returns `null`. On top, this adds unit tests.