### PR TITLE
Wait one frame before clean to avoid disconnecting internal ONESHOT connections

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -272,7 +272,11 @@ func clear(clear_flags:=ClearFlags.FULL_CLEAR) -> bool:
 
 	# Resetting variables
 	if current_timeline:
+		# This is necessary because otherwise INTERNAL GODOT ONESHOT CONNECTIONS
+		# are disconnected before they can disconnect themselves.
+		await get_tree().process_frame
 		current_timeline.clean()
+
 	current_timeline = null
 	current_event_idx = -1
 	current_timeline_events = []


### PR DESCRIPTION
- Should fix #2069

Godot seemed to try to disconnect a signal we had already cleared (in timeline.clean()). Unfortunately it seemed pretty hard to differentiate these signals from other signals (because I wasn't allowed to access it's object). Luckily it is solved by simply waiting a frame because godot will have removed the connection on the next frame.

@Atlinx would love if you could try this!