### PR TITLE
Remove explicit timeline clear to fix #1996

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -245,15 +245,6 @@ func load_event_buttons() -> void:
 #endregion
 
 
-#region CLEANUP
-################################################################################
-
-func _exit_tree() -> void:
-	# Explicitly free any open cache resources on close, so we don't get leaked resource errors on shutdown
-	clear_timeline_nodes()
-#endregion
-
-
 #region CONTENT LIST
 ################################################################################
 


### PR DESCRIPTION
I'm pretty sure this isn't necessary anyways, but might be wrong. If we get leaked instances again (there is HUNDREDS of leaked StringNames all the time anyways), I will find a different solution.
