### PR TITLE
Fix broken function `get_current_style` in Styles subsystem

### DIFF
--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -125,8 +125,8 @@ func reload_current_info_into_new_style():
 ## Returns the style currently in use
 func get_current_style() -> String:
 	if has_active_layout_node():
-		var style = get_layout_node().get_meta('style', '')
-		if style and "name" in style:
+		var style: DialogicStyle = get_layout_node().get_meta('style', null)
+		if style:
 			return style.name
 	return ''
 

--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -124,8 +124,10 @@ func reload_current_info_into_new_style():
 
 ## Returns the style currently in use
 func get_current_style() -> String:
-	if dialogic.has_active_layout_node():
-		return dialogic.get_layout_node().get_meta('style', '')
+	if has_active_layout_node():
+		var style = get_layout_node().get_meta('style', '')
+		if style and "name" in style:
+			return style.name
 	return ''
 
 


### PR DESCRIPTION
Function contained code with invalid syntax, and wrong variable return.
New code calls the method appropriately and makes a check for validity of the retrieved style.