### PR TITLE
[dialogic-1] Sort portraits when importing from a folder

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -340,6 +340,7 @@ func _on_Import_Portrait_Folder_Button_pressed():
 func _on_dir_selected(path, target):
 	var dir = Directory.new()
 	if dir.open(path) == OK:
+		var file_list = []
 		dir.list_dir_begin()
 		var file_name = dir.get_next()
 		while file_name != "":
@@ -347,9 +348,13 @@ func _on_dir_selected(path, target):
 				var file_lower = file_name.to_lower()
 				if '.svg' in file_lower or '.png' in file_lower:
 					if not '.import' in file_lower:
-						var final_name = path+ "/" + file_name
-						create_portrait_entry(DialogicResources.get_filename_from_path(file_name), final_name)
+						file_list.append(file_name)
 			file_name = dir.get_next()
+		file_list.sort()
+		for file in file_list:
+			var final_name = path + "/" + file
+			create_portrait_entry(DialogicResources.get_filename_from_path(file), final_name)
+		dir.list_dir_end()
 	else:
 		print("An error occurred when trying to access the path.")
 


### PR DESCRIPTION
This PR sorts the names of the portraits alphabetically when importing portraits from a folder. Since the order of the portrait names in the timeline editor is based on the order of the portraits in the character editor, this helps to find the portrait you are looking for much faster when creating timelines.

Before & After:
![before](https://github.com/dialogic-godot/dialogic/assets/22630098/f124f204-ec10-4de2-bb83-d8e7c5ff824b)![after](https://github.com/dialogic-godot/dialogic/assets/22630098/ab663e06-5eae-4a25-9bd5-af974c543799)
