### PR TITLE
Show used Locales in Test Locale Dropdown

### DIFF
--- a/addons/dialogic/Editor/Settings/csv_file.gd
+++ b/addons/dialogic/Editor/Settings/csv_file.gd
@@ -32,9 +32,6 @@ var new_rows: int = 0
 ## a per-project file.
 var add_separator: bool = false
 
-## All locales found after the [method update_csv_file_on_disk] method is called.
-var locales: Array = []
-
 enum PropertyType {
 	String = 0,
 	Array = 1,
@@ -326,21 +323,14 @@ func update_csv_file_on_disk() -> void:
 	# Clear the current CSV file.
 	file = FileAccess.open(used_file_path, FileAccess.WRITE)
 
-	var is_first_line := true
-
 	for line in lines:
 		var row_key := line[0]
-
 
 		# In case there might be translations for this line already,
 		# add them at the end again (orig locale text is replaced).
 		if row_key in old_lines:
 			var old_line: PackedStringArray = old_lines[row_key]
 			var updated_line: PackedStringArray = line + old_line.slice(2)
-
-			if is_first_line:
-				locales = updated_line.slice(1)
-				is_first_line = false
 
 			var line_columns: int = updated_line.size()
 			var line_columns_to_add := column_count - line_columns
@@ -359,10 +349,6 @@ func update_csv_file_on_disk() -> void:
 			# Add trailing commas to match the amount of columns.
 			for _i in range(line_columns_to_add):
 				line.append("")
-
-			if is_first_line:
-				locales = line.slice(1)
-				is_first_line = false
 
 			file.store_csv_line(line)
 			new_rows += 1

--- a/addons/dialogic/Editor/Settings/csv_file.gd
+++ b/addons/dialogic/Editor/Settings/csv_file.gd
@@ -32,6 +32,9 @@ var new_rows: int = 0
 ## a per-project file.
 var add_separator: bool = false
 
+## All locales found after the [method update_csv_file_on_disk] method is called.
+var locales: Array = []
+
 enum PropertyType {
 	String = 0,
 	Array = 1,
@@ -323,14 +326,21 @@ func update_csv_file_on_disk() -> void:
 	# Clear the current CSV file.
 	file = FileAccess.open(used_file_path, FileAccess.WRITE)
 
+	var is_first_line := true
+
 	for line in lines:
 		var row_key := line[0]
+
 
 		# In case there might be translations for this line already,
 		# add them at the end again (orig locale text is replaced).
 		if row_key in old_lines:
 			var old_line: PackedStringArray = old_lines[row_key]
 			var updated_line: PackedStringArray = line + old_line.slice(2)
+
+			if is_first_line:
+				locales = updated_line.slice(1)
+				is_first_line = false
 
 			var line_columns: int = updated_line.size()
 			var line_columns_to_add := column_count - line_columns
@@ -349,6 +359,10 @@ func update_csv_file_on_disk() -> void:
 			# Add trailing commas to match the amount of columns.
 			for _i in range(line_columns_to_add):
 				line.append("")
+
+			if is_first_line:
+				locales = line.slice(1)
+				is_first_line = false
 
 			file.store_csv_line(line)
 			new_rows += 1

--- a/addons/dialogic/Editor/Settings/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/settings_translation.gd
@@ -143,7 +143,13 @@ func get_locales(_filter: String) -> Dictionary:
 	var used_locales: Array = ProjectSettings.get_setting(_USED_LOCALES_SETTING, TranslationServer.get_all_languages())
 
 	for locale: String in used_locales:
-		suggestions[locale] = {'value':locale, 'tooltip':TranslationServer.get_language_name(locale)}
+		var language_name := TranslationServer.get_language_name(locale)
+
+		# Invalid locales return an empty String.
+		if language_name.is_empty():
+			continue
+
+		suggestions[locale] = { 'value': locale, 'tooltip': language_name }
 
 	return suggestions
 

--- a/addons/dialogic/Editor/Settings/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/settings_translation.gd
@@ -234,13 +234,11 @@ func _handle_glossary_translation(
 
 			TranslationModes.PER_TIMELINE:
 				glossary_csv.update_csv_file_on_disk()
-				_collect_locales(glossary_csv.locales)
 				glossary_csv = null
 
 	# If a Per-Project glossary is still open, we need to save it.
 	if glossary_csv != null:
 		glossary_csv.update_csv_file_on_disk()
-		_collect_locales(glossary_csv.locales)
 		glossary_csv = null
 
 
@@ -334,7 +332,6 @@ func update_csv_files() -> void:
 
 		if translation_mode == TranslationModes.PER_TIMELINE:
 			csv_file.update_csv_file_on_disk()
-			_collect_locales(csv_file.locales)
 
 		csv_data.new_events += csv_file.new_rows
 		csv_data.updated_events += csv_file.updated_rows
@@ -356,7 +353,6 @@ func update_csv_files() -> void:
 
 	if translation_mode == TranslationModes.PER_PROJECT:
 		csv_per_project.update_csv_file_on_disk()
-		_collect_locales(csv_per_project.locales)
 
 	_silently_open_timeline(current_timeline)
 
@@ -418,7 +414,6 @@ func _handle_character_names(
 
 	character_name_csv.collect_lines_from_characters(all_characters)
 	character_name_csv.update_csv_file_on_disk()
-	_collect_locales(character_name_csv.locales)
 
 
 func collect_translations() -> void:
@@ -465,6 +460,11 @@ func collect_translations() -> void:
 
 		if not file_path in all_translation_files:
 			all_translation_files.append(file_path)
+			var path_without_suffix := file_path.trim_suffix('.translation')
+			var path_parts := path_without_suffix.split(".")
+			var locale_part := path_parts[-1]
+			_collect_locale(locale_part)
+
 
 	var valid_translation_files := PackedStringArray(all_translation_files)
 	ProjectSettings.set_setting('internationalization/locale/translations', valid_translation_files)
@@ -655,12 +655,10 @@ func _silently_open_timeline(timeline_to_open: Resource) -> void:
 		settings_editor.editors_manager.edit_resource(timeline_to_open, true, true)
 
 
-## Checks [param locales] for unique locales that have not been added
+## Checks [param locale] for unique locales that have not been added
 ## to the [_unique_locales] array yet.
-func _collect_locales(locales: Array) -> void:
+func _collect_locale(locale: String) -> void:
+	if _unique_locales.has(locale):
+		return
 
-	for locale: String in locales:
-		if _unique_locales.has(locale):
-			continue
-
-		_unique_locales.append(locale)
+	_unique_locales.append(locale)

--- a/addons/dialogic/Editor/Settings/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/settings_translation.gd
@@ -19,7 +19,7 @@ const DEFAULT_TIMELINE_CSV_NAME := "dialogic_timeline_translations.csv"
 
 const DEFAULT_GLOSSARY_CSV_NAME := "dialogic_glossary_translations.csv"
 
-const _USED_LOCALES_SETTINGS := "dialogic/translation/locales"
+const _USED_LOCALES_SETTING := "dialogic/translation/locales"
 
 ## Contains translation changes that were made during the last update.
 

--- a/addons/dialogic/Editor/Settings/settings_translation.tscn
+++ b/addons/dialogic/Editor/Settings/settings_translation.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/field_options_dynamic.tscn" id="3_dq4j2"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/field_file.tscn" id="4_kvsma"]
 
-[sub_resource type="Image" id="Image_6uwds"]
+[sub_resource type="Image" id="Image_g2hic"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -14,8 +14,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_5qvwl"]
-image = SubResource("Image_6uwds")
+[sub_resource type="ImageTexture" id="ImageTexture_xbph7"]
+image = SubResource("Image_g2hic")
 
 [node name="Translations" type="VBoxContainer"]
 anchors_preset = 15
@@ -73,9 +73,11 @@ text = "Testing locale"
 layout_mode = 2
 tooltip_text = "Change this locale to test your game in a different language (only in-editor).
 Equivalent of the testing local project setting. "
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Change this locale to test your game in a different language (only in-editor).
-Equivalent of the testing local project setting. "
+Equivalent of the testing local project setting. 
+
+Update dropdown list via \"Collect Translation\"."
 
 [node name="TestingLocale" parent="HBox/Testing/VBox3" instance=ExtResource("3_dq4j2")]
 unique_name_in_owner = true
@@ -111,7 +113,7 @@ text = "Default locale"
 [node name="HintTooltip" parent="TranslationSettings/VBoxContainer/Grid/VBox" instance=ExtResource("2_k2lou")]
 layout_mode = 2
 tooltip_text = "The locale of the language your timelines are written in."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "The locale of the language your timelines are written in."
 
 [node name="OrigLocale" parent="TranslationSettings/VBoxContainer/Grid" instance=ExtResource("3_dq4j2")]
@@ -129,7 +131,7 @@ text = "Translation folder"
 layout_mode = 2
 tooltip_text = "Choose a folder to let Dialogic save CSV files in.
 Also used when saving \"Inside Translation Folder\""
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Choose a folder to let Dialogic save CSV files in.
 Also used when saving \"Inside Translation Folder\""
 
@@ -157,7 +159,7 @@ For example, 10 timelines will be combined into 1 CSV file.
 For example, 10 timelines will result in 10 CSV files.
 
 The \"Per File\" option utilises \"Output location\", in contrast, the \"Per Type\" will always use the Translation folder."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Decides how many CSV files will be created.
 
 • \"Per Type\": Uses one CSV file for each type of resource: Timelines, characters, and glossaries.
@@ -195,7 +197,7 @@ tooltip_text = "Decides where to save the generated CSV files.
 
 This button requires the \"Per File\" Output mode.
 A resource type can be: Timelines, characters, and glossaries."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Decides where to save the generated CSV files.
 
 • \"Inside Translation Folder\": Uses the \"Translation folder\".
@@ -232,7 +234,7 @@ layout_mode = 2
 tooltip_text = "Adds an empty line into per-project CSVs to differentiate between sections.
 
 For example, when a new glossary item or timeline starts, an empty line will be added."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Adds an empty line into per-project CSVs to differentiate between sections.
 
 For example, when a new glossary item or timeline starts, an empty line will be added."
@@ -265,7 +267,7 @@ unique_name_in_owner = true
 layout_mode = 2
 disabled = true
 text = "Update CSV files"
-icon = SubResource("ImageTexture_5qvwl")
+icon = SubResource("ImageTexture_xbph7")
 
 [node name="HintTooltip5" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
@@ -274,7 +276,7 @@ tooltip_text = "This button will scan all timelines and generate or update their
 A Dialogic CSV file will be prefixed with \"dialogic_\".
 
 This action will be disabled if the \"Translation folder\" is missing or has an invalid path."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "This button will scan all timelines and generate or update their CSV files.
 
 A Dialogic CSV file will be prefixed with \"dialogic_\".
@@ -285,14 +287,14 @@ This action will be disabled if the \"Translation folder\" is missing or has an 
 unique_name_in_owner = true
 layout_mode = 2
 text = "Collect translations"
-icon = SubResource("ImageTexture_5qvwl")
+icon = SubResource("ImageTexture_xbph7")
 
 [node name="HintTooltip6" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
 tooltip_text = "Godot imports CSV files as \".translation\" files.
 This buttons adds them to \"Project Settings -> Localization\".
 "
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Godot imports CSV files as \".translation\" files.
 This buttons adds them to \"Project Settings -> Localization\".
 "
@@ -309,7 +311,7 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 text = "Remove translations"
-icon = SubResource("ImageTexture_5qvwl")
+icon = SubResource("ImageTexture_xbph7")
 
 [node name="HintTooltip7" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
@@ -319,7 +321,7 @@ It will try to delete any \".csv\" and \".translation\" files that are related t
 CSV and translation files prefixed with \"dialogic_\" are treated as Dialogic-related.
 
 Removes translation IDs (eg. #id:33) from timelines and characters."
-texture = SubResource("ImageTexture_5qvwl")
+texture = SubResource("ImageTexture_xbph7")
 hint_text = "Be very careful with this button!
 
 It will try to delete any \".csv\" and \".translation\" files that are related to Dialogic.


### PR DESCRIPTION
At the moment, the Test Locale in the Translation editor displays all possible locales.
This change will display all *unique* locales found in any of the CSVs.