### PR TITLE
Fixed error 'Set Variable event failed' when setting bool false.

### DIFF
--- a/addons/dialogic/Modules/Variable/event_variable.gd
+++ b/addons/dialogic/Modules/Variable/event_variable.gd
@@ -74,7 +74,7 @@ var _suppress_default_value: bool = false
 func _execute() -> void:
 	if name:
 		var orig :Variant= dialogic.VAR.get_variable(name)
-		if value and orig != null:
+		if (value == false or value) and orig != null:
 			var the_value :Variant
 			match _value_type:
 				VarValueType.STRING: the_value = dialogic.VAR.get_variable('"'+value+'"')


### PR DESCRIPTION
This bug is in Main and 2.0-Alpha-13 (Godot 4.2+)

This will also fix #2112 .

Basically you can't set a bool Dialogic variable from true to false. This:


![Screenshot from 2024-02-24 23-00-16](https://github.com/dialogic-godot/dialogic/assets/2733986/5a261e25-ee63-4dea-8d58-197d916e03b7)

Will create the error:
```
printerr("Dialogic: Set Variable event failed because one value wasn't set!")
```

This is because the if statement on line 77 fails, because the variable value is false. In order to keep the same behavior, we can check that value is Truthy or equal to false.