### PR TITLE
Refactor Manual-Advance to `Dialogic.Inputs.manual_advance`

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -13,16 +13,18 @@ var action_was_consumed := false
 
 var auto_skip: DialogicAutoSkip = null
 var auto_advance : DialogicAutoAdvance = null
+var manual_advance: DialogicManualAdvance = null
 
 
 #region SUBSYSTEM METHODS
 ################################################################################
 
-func clear_game_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
+func clear_game_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	if not is_node_ready():
 		await ready
 
-	set_manualadvance(true)
+	manual_advance.enabled_until_next_event = false
+	manual_advance.enabled_forced = true
 
 
 func pause() -> void:
@@ -91,8 +93,10 @@ func _unhandled_input(event:InputEvent) -> void:
 ## If any DialogicInputNode is present this won't do anything (because that node handles MouseInput then).
 func _input(event:InputEvent) -> void:
 	if Input.is_action_pressed(ProjectSettings.get_setting('dialogic/text/input_action', 'dialogic_default_action')):
+
 		if not event is InputEventMouse or get_tree().get_nodes_in_group('dialogic_input').any(func(node):return node.is_visible_in_tree()):
 			return
+
 		handle_input()
 
 
@@ -109,6 +113,7 @@ func block_input(time:=0.1) -> void:
 func _ready() -> void:
 	auto_skip = DialogicAutoSkip.new()
 	auto_advance = DialogicAutoAdvance.new()
+	manual_advance = DialogicManualAdvance.new()
 
 	# We use the process method to count down the auto-start_autoskip_timer timer.
 	set_process(false)
@@ -142,7 +147,7 @@ func _on_autoskip_toggled(enabled: bool) -> void:
 ## Handles fine-grained Auto-Skip logic.
 ## The [method _process] method allows for a more precise timer than the
 ## [Timer] class.
-func _process(delta):
+func _process(delta: float) -> void:
 	if _auto_skip_timer_left > 0:
 		_auto_skip_timer_left -= delta
 
@@ -154,25 +159,6 @@ func _process(delta):
 		set_process(false)
 
 #endregion
-
-
-#region MANUAL ADVANCE
-################################################################################
-
-func set_manualadvance(enabled:=true, temp:= false) -> void:
-	if !dialogic.current_state_info.has('manual_advance'):
-		dialogic.current_state_info['manual_advance'] = {'enabled':false, 'temp_enabled':false}
-	if temp:
-		dialogic.current_state_info['manual_advance']['temp_enabled'] = enabled
-	else:
-		dialogic.current_state_info['manual_advance']['enabled'] = enabled
-
-
-func is_manualadvance_enabled() -> bool:
-	return dialogic.current_state_info['manual_advance']['enabled'] and dialogic.current_state_info['manual_advance'].get('temp_enabled', true)
-
-#endregion
-
 
 #region TEXT EFFECTS
 ################################################################################
@@ -189,7 +175,7 @@ func effect_input(text_node:Control, skipped:bool, argument:String) -> void:
 
 func effect_noskip(text_node:Control, skipped:bool, argument:String) -> void:
 	dialogic.Text.set_text_reveal_skippable(false, true)
-	set_manualadvance(false, true)
+	manual_advance.enabled_until_next_event = true
 	effect_autoadvance(text_node, skipped, argument)
 
 

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -219,7 +219,7 @@ func _on_dialogic_input_action() -> void:
 				dialogic.Inputs.stop_timers()
 				dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))
 		_:
-			if dialogic.Inputs.is_manualadvance_enabled():
+			if dialogic.Inputs.manual_advance.is_enabled():
 				advance.emit()
 				dialogic.Inputs.stop_timers()
 				dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))

--- a/addons/dialogic/Modules/Text/manual_advance.gd
+++ b/addons/dialogic/Modules/Text/manual_advance.gd
@@ -1,0 +1,60 @@
+extends RefCounted
+class_name DialogicManualAdvance
+## This class holds the settings for the Manual-Advance feature.
+## Changing the variables will alter the behaviour of manually advancing
+## the timeline, e.g. using the input action.
+
+## The key giving access to the state info of Manual-Advance.
+const STATE_INFO_KEY := "manual_advance"
+## The key for the enabled state in the current state info.
+const ENABLED_STATE_KEY := "enabled"
+## The key for the temporary event state in the current state info.
+const ENABLED_UNTIL_NEXT_EVENT_STATE_KEY := "temp_enabled"
+
+
+## If `true`, Manual-Advance will be active until the next event.
+##
+## Use this flag to create a temporary Manual-Advance mode.
+##
+## Stacks with [variable enabled_forced].
+var enabled_until_next_event := false :
+	set(enabled):
+		enabled_until_next_event = enabled
+		DialogicUtil.autoload().current_state_info[STATE_INFO_KEY][ENABLED_UNTIL_NEXT_EVENT_STATE_KEY] = enabled
+
+
+## If `true`, Manual-Advance will stay enabled until this is set to `false`.
+##
+## Use this flag to activate or disable Manual-Advance mode.
+##
+## Stacks with [variable enabled_until_next_event].
+var enabled_forced := true :
+	set(enabled):
+		enabled_forced = enabled
+		DialogicUtil.autoload().current_state_info[STATE_INFO_KEY][ENABLED_STATE_KEY] = enabled
+
+
+## Checks if the current state info has the Manual-Advance settings.
+## If not, populates the current state info with the default settings.
+func _init() -> void:
+	if DialogicUtil.autoload().current_state_info.has(STATE_INFO_KEY):
+		var state_info := DialogicUtil.autoload().current_state_info
+		var manual_advance: Dictionary = state_info[STATE_INFO_KEY]
+
+		enabled_until_next_event = manual_advance[ENABLED_UNTIL_NEXT_EVENT_STATE_KEY]
+		enabled_forced = manual_advance[ENABLED_STATE_KEY]
+
+	else:
+		DialogicUtil.autoload().current_state_info[STATE_INFO_KEY] = {
+			ENABLED_STATE_KEY: enabled_forced,
+			ENABLED_UNTIL_NEXT_EVENT_STATE_KEY: enabled_until_next_event,
+		}
+
+
+#region MANUAL ADVANCE HELPERS
+
+## Whether the player can use Manual-Advance to advance the timeline.
+func is_enabled() -> bool:
+	return enabled_until_next_event or enabled_forced
+
+#endregion

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -148,7 +148,7 @@ func update_dialog_text(text: String, instant := false, additional := false) -> 
 	# Reset Auto-Advance temporarily and the No-Skip setting:
 	dialogic.Inputs.auto_advance.enabled_until_next_event = false
 	dialogic.Inputs.auto_advance.override_delay_for_current_event = -1
-	dialogic.Inputs.set_manualadvance(true, true)
+	dialogic.Inputs.manual_advance.enabled_until_next_event = false
 
 	set_text_reveal_skippable(true, true)
 


### PR DESCRIPTION
Evens out the difference between Auto-Advance, Auto-Skip, and Manual-Advance by turning it into a property on the `Inputs`-subsystem.

This has a breaking impact on the API and results in the following changes:

Setting the enable state of Manual-Advance:
```gdscript
# Old:
Dialogic.Inputs.set_manualadvance(true, false)

# New:
Dialogic.Inputs.manual_advance.enabled_forced = true
Dialogic.Inputs.manual_advance.enabled_until_next_event = false
```

Getting the enable state of Manual-Advance:
```gdscript

# Old:
var result := Dialogic.Inputs.is_manualadvance_enabled()

# New:
var result := Dialogic.Inputs.manual_advance.is_enabled()
```