### PR TITLE
Fix getting wrong Speaker Path

### DIFF
--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -163,7 +163,7 @@ func _on_dialog_text_finished() -> void:
 ## If a name changes, the [signal speaker_updated] signal is emitted.
 func update_name_label(character:DialogicCharacter) -> void:
 	var character_path := character.resource_path if character else ""
-	var current_character_path: String = dialogic.current_state_info.get('character', "")
+	var current_character_path: String = dialogic.current_state_info.get("speaker", "")
 
 	if character_path != current_character_path:
 		dialogic.current_state_info['speaker'] = character_path


### PR DESCRIPTION
We changed "character" to "speaker" on the current state info, previously, the edited code never returned a valid value and used the empty string fallback.

On my project, this caused my automatic text prefix and suffix processor to always apply the text modification, once a speaker said a sentence.
