### PR TITLE
Improve set variable and call event access

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -7,7 +7,7 @@ extends DialogicSubsystem
 #region MAIN METHODS
 ####################################################################################################
 
-func execute_string(string:String, default: Variant = null) -> Variant:
+func execute_string(string:String, default: Variant = null, no_warning := false) -> Variant:
 	# Some methods are not supported by the expression class, but very useful.
 	# Thus they are recreated below and secretly added.
 	string = string.replace('range(', 'd_range(')
@@ -30,12 +30,18 @@ func execute_string(string:String, default: Variant = null) -> Variant:
 		autoload_names.append(c.name)
 
 	if expr.parse(string, autoload_names) != OK:
-		printerr('Dialogic: Expression failed to parse: ', expr.get_error_text())
+		if not no_warning:
+			printerr('Dialogic: Expression failed to parse: ', expr.get_error_text())
+			printerr('		Expression: ', string)
+			print("\n")
 		return default
 
 	var result: Variant = expr.execute(autoloads, self)
 	if expr.has_execute_failed():
-		printerr('Dialogic: Expression failed to execute: ', expr.get_error_text())
+		if not no_warning:
+			printerr('Dialogic: Expression failed to execute: ', expr.get_error_text())
+			printerr('		Expression: ', string)
+			print("\n")
 		return default
 	return result
 

--- a/addons/dialogic/Modules/Variable/event_variable.gd
+++ b/addons/dialogic/Modules/Variable/event_variable.gd
@@ -31,6 +31,7 @@ var name: String = "":
 					_value_type = VarValueType.BOOL
 			ui_update_needed.emit()
 		update_editor_warning()
+
 ## The operation to perform.
 var operation: int = Operations.SET:
 	set(value):
@@ -73,8 +74,8 @@ var _suppress_default_value: bool = false
 
 func _execute() -> void:
 	if name:
-		var orig: Variant = dialogic.VAR.get_variable(name)
-		if value != null and orig != null:
+		var orig: Variant = dialogic.VAR.get_variable(name, null, operation == Operations.SET and "[" in name)
+		if value != null and (orig != null or (operation == Operations.SET and "[" in name)):
 			var the_value: Variant
 			match _value_type:
 				VarValueType.STRING:

--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -69,16 +69,51 @@ func set_variable(variable_name: String, value: Variant) -> bool:
 		var from := variable_name.get_slice('.', 0)
 		var variable := variable_name.trim_prefix(from+'.')
 
-		for a in get_autoloads():
-			if a.name == from:
-				a.set(variable, value)
-				return true
+		var autoloads := get_autoloads()
+		var object: Object = null
+		if from in autoloads:
+			object = autoloads[from]
+			while variable.count("."):
+				from = variable.get_slice('.', 0)
+				if from in object and object.get(from) is Object:
+					object = object.get(from)
+				variable = variable.trim_prefix(from+'.')
+
+		if object:
+			var sub_idx := ""
+			if '[' in variable:
+				sub_idx = variable.substr(variable.find('['))
+			variable = variable.trim_suffix(sub_idx)
+			sub_idx = sub_idx.trim_prefix('[').trim_suffix(']')
+
+			if variable in object:
+				match typeof(object.get(variable)):
+					TYPE_ARRAY:
+						if not sub_idx:
+							if typeof(value) == TYPE_ARRAY:
+								object.set(variable, value)
+								return true
+						elif sub_idx.is_valid_float():
+							object.get(variable).remove_at(int(sub_idx))
+							object.get(variable).insert(int(sub_idx), value)
+							return true
+					TYPE_DICTIONARY:
+						if not sub_idx:
+							if typeof(value) == TYPE_DICTIONARY:
+								object.set(variable, value)
+								return true
+						else:
+							object.get(variable).merge({str_to_var(sub_idx):value}, true)
+							return true
+					_:
+						object.set(variable, value)
+						return true
 
 	printerr("[Dialogic] Tried setting non-existant variable '"+variable_name+"'.")
 	return false
 
 
-func get_variable(variable_path:String, default: Variant = null) -> Variant:
+func get_variable(variable_path:String, default: Variant = null, no_warning := false) -> Variant:
 	if variable_path.begins_with('{') and variable_path.ends_with('}') and variable_path.count('{') == 1:
 		variable_path = variable_path.trim_prefix('{').trim_suffix('}')
 
@@ -89,12 +124,13 @@ func get_variable(variable_path:String, default: Variant = null) -> Variant:
 
 	# Second assume this is an expression.
 	else:
-		value = dialogic.Expressions.execute_string(variable_path, null)
+		value = dialogic.Expressions.execute_string(variable_path, null, no_warning)
 		if value != null:
 			return value
 
 	# If everything fails, tell the user and return the default
-	printerr("[Dialogic] Failed parsing variable/expression '"+variable_path+"'.")
+	if not no_warning:
+		printerr("[Dialogic] Failed parsing variable/expression '"+variable_path+"'.")
 	return default
 
 
@@ -154,10 +190,10 @@ func variables(absolute:=false) -> Array:
 #region HELPERS
 ################################################################################
 
-func get_autoloads() -> Array:
-	var autoloads := []
-	for c in get_tree().root.get_children():
-		autoloads.append(c)
+func get_autoloads() -> Dictionary:
+	var autoloads := {}
+	for node: Node in get_tree().root.get_children():
+		autoloads[node.name] = node
 	return autoloads
 
 


### PR DESCRIPTION
This allows setting arrays and dictionaries from the variable event.

It also allows to set variables or call methods (call/do event) on sub-objects of autoloads:
- `do Autoload.player.do_something()` 
- `do Dialogic.Text.set_text_reveal_skippable(false)`
- `set Dialogic.Inputs.auto_advance.enable_forced = true`

 
- fixes #1928
- fixes #1965
- fixes #2129
