### PR TITLE
Fix history not evaluating variables in names

### DIFF
--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -72,7 +72,8 @@ func _execute() -> void:
 		Actions.JOIN:
 			if character:
 				if dialogic.has_subsystem('History') and !dialogic.Portraits.is_character_joined(character):
-					dialogic.History.store_simple_history_entry(character.display_name + " joined", event_name, {'character': character.display_name, 'mode':'Join'})
+					var character_name_text = dialogic.Text.get_character_name_text(character)
+					dialogic.History.store_simple_history_entry(character_name_text + " joined", event_name, {'character': character_name_text, 'mode':'Join'})
 
 				var final_animation_length: float = animation_length
 
@@ -105,7 +106,8 @@ func _execute() -> void:
 
 			elif character:
 				if dialogic.has_subsystem('History') and dialogic.Portraits.is_character_joined(character):
-					dialogic.History.store_simple_history_entry(character.display_name+" left", event_name, {'character': character.display_name, 'mode':'Leave'})
+					var character_name_text = dialogic.Text.get_character_name_text(character)
+					dialogic.History.store_simple_history_entry(character_name_text+" left", event_name, {'character': character_name_text, 'mode':'Leave'})
 
 				await dialogic.Portraits.leave_character(
 					character,

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -72,7 +72,7 @@ func _execute() -> void:
 		Actions.JOIN:
 			if character:
 				if dialogic.has_subsystem('History') and !dialogic.Portraits.is_character_joined(character):
-					var character_name_text := dialogic.Text.get_character_name_text(character)
+					var character_name_text := dialogic.Text.get_character_name_parsed(character)
 					dialogic.History.store_simple_history_entry(character_name_text + " joined", event_name, {'character': character_name_text, 'mode':'Join'})
 
 				var final_animation_length: float = animation_length
@@ -106,7 +106,7 @@ func _execute() -> void:
 
 			elif character:
 				if dialogic.has_subsystem('History') and dialogic.Portraits.is_character_joined(character):
-					var character_name_text := dialogic.Text.get_character_name_text(character)
+					var character_name_text := dialogic.Text.get_character_name_parsed(character)
 					dialogic.History.store_simple_history_entry(character_name_text+" left", event_name, {'character': character_name_text, 'mode':'Leave'})
 
 				await dialogic.Portraits.leave_character(

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -72,7 +72,7 @@ func _execute() -> void:
 		Actions.JOIN:
 			if character:
 				if dialogic.has_subsystem('History') and !dialogic.Portraits.is_character_joined(character):
-					var character_name_text = dialogic.Text.get_character_name_text(character)
+					var character_name_text := dialogic.Text.get_character_name_text(character)
 					dialogic.History.store_simple_history_entry(character_name_text + " joined", event_name, {'character': character_name_text, 'mode':'Join'})
 
 				var final_animation_length: float = animation_length
@@ -106,7 +106,7 @@ func _execute() -> void:
 
 			elif character:
 				if dialogic.has_subsystem('History') and dialogic.Portraits.is_character_joined(character):
-					var character_name_text = dialogic.Text.get_character_name_text(character)
+					var character_name_text := dialogic.Text.get_character_name_text(character)
 					dialogic.History.store_simple_history_entry(character_name_text+" left", event_name, {'character': character_name_text, 'mode':'Leave'})
 
 				await dialogic.Portraits.leave_character(

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -55,7 +55,7 @@ func _execute() -> void:
 			dialogic.Styles.load_style(dialogic.current_state_info.get('base_style', 'Default'))
 			await dialogic.get_tree().process_frame
 
-	var character_name_text = dialogic.Text.get_character_name_text(character)
+	var character_name_text := dialogic.Text.get_character_name_text(character)
 	if character:
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.load_style(character.custom_info.style, null, false)

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -55,6 +55,7 @@ func _execute() -> void:
 			dialogic.Styles.load_style(dialogic.current_state_info.get('base_style', 'Default'))
 			await dialogic.get_tree().process_frame
 
+	var character_name_text = dialogic.Text.get_character_name_text(character)
 	if character:
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.load_style(character.custom_info.style, null, false)
@@ -119,7 +120,7 @@ func _execute() -> void:
 			_try_play_current_line_voice()
 			final_text = dialogic.Text.update_dialog_text(final_text, false, is_append)
 
-			_mark_as_read(final_text)
+			_mark_as_read(character_name_text, final_text)
 
 			# We must skip text animation before we potentially return when there
 			# is a Choice event.
@@ -169,10 +170,10 @@ func end_text_event() -> void:
 	finish()
 
 
-func _mark_as_read(final_text: String) -> void:
+func _mark_as_read(character_name_text: String, final_text: String) -> void:
 	if dialogic.has_subsystem('History'):
 		if character:
-			dialogic.History.store_simple_history_entry(final_text, event_name, {'character':character.display_name, 'character_color':character.color})
+			dialogic.History.store_simple_history_entry(final_text, event_name, {'character':character_name_text, 'character_color':character.color})
 		else:
 			dialogic.History.store_simple_history_entry(final_text, event_name)
 		dialogic.History.mark_event_as_visited(self)

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -55,7 +55,7 @@ func _execute() -> void:
 			dialogic.Styles.load_style(dialogic.current_state_info.get('base_style', 'Default'))
 			await dialogic.get_tree().process_frame
 
-	var character_name_text := dialogic.Text.get_character_name_text(character)
+	var character_name_text := dialogic.Text.get_character_name_parsed(character)
 	if character:
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.load_style(character.custom_info.style, null, false)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -159,9 +159,24 @@ func _on_dialog_text_finished() -> void:
 	text_finished.emit({'text':dialogic.current_state_info['text'], 'character':dialogic.current_state_info['speaker']})
 
 
+## Parses the character's display_name and returns the text that 
+## should be rendered. Note that characters may have variables in their
+## name, therefore this function should be called to evaluate
+## any potential variables in a character's name. 
+func get_character_name_text(character:DialogicCharacter) -> String:
+	if character:
+		var translated_display_name := character.get_display_name_translated()
+
+		if dialogic.has_subsystem('VAR'):
+			return dialogic.VAR.parse_variables(translated_display_name)
+		else:
+			return translated_display_name
+	return ""
+
+
 ## Updates the visible name on all name labels nodes.
 ## If a name changes, the [signal speaker_updated] signal is emitted.
-func update_name_label(character:DialogicCharacter) -> void:
+func update_name_label(character:DialogicCharacter):
 	var character_path := character.resource_path if character else ""
 	var current_character_path: String = dialogic.current_state_info.get("speaker", "")
 
@@ -169,21 +184,14 @@ func update_name_label(character:DialogicCharacter) -> void:
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)
 
+	var name_label_text = get_character_name_text(character)
+
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
-
+		name_label.text = name_label_text
 		if character:
-			var translated_display_name := character.get_display_name_translated()
-
-			if dialogic.has_subsystem('VAR'):
-				name_label.text = dialogic.VAR.parse_variables(translated_display_name)
-			else:
-				name_label.text = translated_display_name
-
 			if !'use_character_color' in name_label or name_label.use_character_color:
 				name_label.self_modulate = character.color
-
 		else:
-			name_label.text = ''
 			name_label.self_modulate = Color(1,1,1,1)
 
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -159,21 +159,6 @@ func _on_dialog_text_finished() -> void:
 	text_finished.emit({'text':dialogic.current_state_info['text'], 'character':dialogic.current_state_info['speaker']})
 
 
-## Parses the character's display_name and returns the text that 
-## should be rendered. Note that characters may have variables in their
-## name, therefore this function should be called to evaluate
-## any potential variables in a character's name. 
-func get_character_name_text(character:DialogicCharacter) -> String:
-	if character:
-		var translated_display_name := character.get_display_name_translated()
-
-		if dialogic.has_subsystem('VAR'):
-			return dialogic.VAR.parse_variables(translated_display_name)
-		else:
-			return translated_display_name
-	return ""
-
-
 ## Updates the visible name on all name labels nodes.
 ## If a name changes, the [signal speaker_updated] signal is emitted.
 func update_name_label(character:DialogicCharacter):
@@ -184,7 +169,7 @@ func update_name_label(character:DialogicCharacter):
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)
 
-	var name_label_text = get_character_name_text(character)
+	var name_label_text := get_character_name_text(character)
 
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
 		name_label.text = name_label_text
@@ -407,6 +392,20 @@ func _ready():
 	var autopause_data: Dictionary = ProjectSettings.get_setting('dialogic/text/autopauses', {})
 	for i in autopause_data.keys():
 		_autopauses[RegEx.create_from_string('(?<!(\\[|\\{))['+i+'](?!([\\w\\s]*!?[\\]\\}]|$))')] = autopause_data[i]
+
+
+## Parses the character's display_name and returns the text that
+## should be rendered. Note that characters may have variables in their
+## name, therefore this function should be called to evaluate
+## any potential variables in a character's name.
+func get_character_name_text(character:DialogicCharacter) -> String:
+	if character:
+		var translated_display_name := character.get_display_name_translated()
+		if dialogic.has_subsystem('VAR'):
+			return dialogic.VAR.parse_variables(translated_display_name)
+		else:
+			return translated_display_name
+	return ""
 
 
 ## Returns the [class DialogicCharacter] of the current speaker.

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -169,7 +169,7 @@ func update_name_label(character:DialogicCharacter):
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)
 
-	var name_label_text := get_character_name_text(character)
+	var name_label_text := get_character_name_parsed(character)
 
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
 		name_label.text = name_label_text
@@ -398,7 +398,7 @@ func _ready():
 ## should be rendered. Note that characters may have variables in their
 ## name, therefore this function should be called to evaluate
 ## any potential variables in a character's name.
-func get_character_name_text(character:DialogicCharacter) -> String:
+func get_character_name_parsed(character:DialogicCharacter) -> String:
 	if character:
 		var translated_display_name := character.get_display_name_translated()
 		if dialogic.has_subsystem('VAR'):


### PR DESCRIPTION
Added `get_character_name_text` method to the text subsystem. This method evaluates and translates character's name and returns the final text that should be displayed. It's now used in the text event, character event, and in the `update_name_label` of the text subsystem.

Fixes #2127 

https://github.com/dialogic-godot/dialogic/assets/25368491/79452ce9-e4bc-4c39-a4e4-8bad22a6ca0c