### PR TITLE
improve ConditionPicker#is_too_complex

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/field_condition.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_condition.gd
@@ -189,17 +189,16 @@ func something_changed(fake_arg1=null, fake_arg2 = null):
 
 
 func is_too_complex(condition:String) -> bool:
-	return !(condition.is_empty()
-			or ' and ' in condition
-			or ' or ' in condition
-			or ' not ' in condition
-			or condition.count('==') != 1
-			or condition.count('>') != 1
-			or condition.count('<') != 1
-			or condition.count('<=') != 1
-			or condition.count('>=') != 1
-			or condition.count('!=') != 1)
+	if condition.strip_edges().is_empty():
+		return false
 
+	var comparison_count :int = 0
+	for i in ['==', '!=', '<=', '<', '>', '>=']:
+		comparison_count += condition.count(i)
+	if comparison_count == 1:
+		return false
+
+	return true
 
 ## Combines the info from the simple editor fields into a string condition
 func get_simple_condition() -> String:

--- a/addons/dialogic/Editor/Events/Fields/field_condition.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_condition.gd
@@ -192,13 +192,14 @@ func is_too_complex(condition:String) -> bool:
 	if condition.strip_edges().is_empty():
 		return false
 
-	var comparison_count :int = 0
+	var comparison_count: int = 0
 	for i in ['==', '!=', '<=', '<', '>', '>=']:
 		comparison_count += condition.count(i)
 	if comparison_count == 1:
 		return false
 
 	return true
+
 
 ## Combines the info from the simple editor fields into a string condition
 func get_simple_condition() -> String:


### PR DESCRIPTION
Currently, `is_too_complex` requires `condition.count('==') == 1 and condition.count('>') != 1` etc for a condition to be complex, meaning you need something like `== != <= >=` in your expression for it to be counted as complex. This changes the requirement to being empty or having a single comparison operator, which is closer to what the simple condition editor and `complex2simple` use.