### PR TITLE
Fix style editor layer icon size

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_icon.svg
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_icon.svg
@@ -1,11 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="100" height="100" viewBox="0 0 26.458333 26.458333" version="1.1" id="svg5" inkscape:export-filename="history-icon.svg" inkscape:export-xdpi="96" inkscape:export-ydpi="96" sodipodi:docname="history_icon.svg" inkscape:version="1.2.2 (732a01da63, 2022-12-09)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview id="namedview7" pagecolor="#464646" bordercolor="#000000" borderopacity="0.25" inkscape:showpageshadow="2" inkscape:pageopacity="0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#d1d1d1" inkscape:document-units="mm" showgrid="false" showguides="true" inkscape:zoom="2.2483786" inkscape:cx="-42.25267" inkscape:cy="23.572542" inkscape:window-width="1920" inkscape:window-height="1017" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="svg5" />
-  <defs id="defs2" />
-  <path style="fill:none;stroke:#ffffff;stroke-width:2.65094;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none" d="M 6.1359282,18.910319 5.4203664,23.372726 11.663155,21.491432" id="path289" sodipodi:nodetypes="ccc" />
-  <path style="fill:none;stroke:#ffffff;stroke-width:2.65094;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none" d="m 3.159021,12.614769 1.5724854,2.472905 1.4948485,-2.524272 z" id="path953" sodipodi:nodetypes="cccc" />
-  <path style="fill:none;stroke:#ffffff;stroke-width:2.65094;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none" d="m 13.180799,10.327332 0.375868,2.759275 4.600189,1.449067" id="path2562" inkscape:transform-center-x="-1.9871441" inkscape:transform-center-y="-1.6393937" sodipodi:nodetypes="ccc" />
-  <path id="path11412" style="fill:none;stroke:#ffffff;stroke-width:2.65094;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none" d="m 4.6976666,12.429736 c 0,-5.1366728 4.164097,-9.300769 9.3007704,-9.300769 5.136672,0 9.300769,4.1640962 9.300769,9.300769 0,5.136675 -4.164097,9.300771 -9.300769,9.300771 -0.740795,0 -1.461361,-0.0866 -2.152126,-0.250247" sodipodi:nodetypes="csssc" />
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg5" inkscape:export-filename="history-icon.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" sodipodi:docname="history_icon.svg" inkscape:export-ydpi="96" inkscape:export-xdpi="96" inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px"
+	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<sodipodi:namedview  id="namedview7" inkscape:pagecheckerboard="0" inkscape:cy="23.572542" inkscape:zoom="2.2483786" inkscape:cx="-42.25267" pagecolor="#464646" showgrid="false" borderopacity="0.25" bordercolor="#000000" inkscape:document-units="mm" inkscape:deskcolor="#d1d1d1" inkscape:pageopacity="0" inkscape:showpageshadow="2" inkscape:current-layer="svg5" inkscape:window-y="-8" inkscape:window-x="-8" inkscape:window-height="1017" inkscape:window-width="1920" showguides="true" inkscape:window-maximized="1">
+	</sodipodi:namedview>
+<g>
+	<path fill="#FFFFFF" d="M50.037,53.276l17.386,5.477c0.4,0.126,0.805,0.186,1.203,0.186c1.7,0,3.276-1.092,3.814-2.799
+		c0.663-2.107-0.507-4.354-2.613-5.018l-14.968-4.714l-1.078-7.916c-0.299-2.189-2.311-3.721-4.504-3.423
+		c-2.189,0.298-3.722,2.314-3.423,4.503l1.421,10.429C47.484,51.535,48.56,52.811,50.037,53.276z"/>
+	<path fill="#FFFFFF" d="M52.908,7.826c-20.465,0-37.303,15.785-39.001,35.818l-2.034,0.034c-1.447,0.024-2.769,0.829-3.455,2.104
+		c-0.687,1.274-0.63,2.821,0.146,4.042l5.943,9.347c0.735,1.155,2.009,1.854,3.375,1.854c0.021,0,0.042,0,0.063-0.001
+		c1.391-0.021,2.669-0.765,3.378-1.961l5.65-9.541c0.738-1.247,0.745-2.795,0.017-4.048s-2.067-2.012-3.525-1.99l-1.513,0.025
+		c1.731-15.55,14.95-27.684,30.956-27.684c17.178,0,31.152,13.975,31.152,31.152c0,17.178-13.975,31.152-31.152,31.152
+		c-2.438,0-4.866-0.282-7.213-0.838c-0.543-0.129-1.086-0.138-1.604-0.048c-0.385-0.001-0.775,0.035-1.164,0.152l-17.479,5.268
+		l1.693-10.559c0.35-2.182-1.135-4.233-3.316-4.583c-2.182-0.357-4.233,1.135-4.583,3.315l-2.705,16.865
+		c-0.218,1.361,0.279,2.738,1.316,3.645c0.739,0.646,1.678,0.989,2.634,0.989c0.386,0,0.774-0.056,1.154-0.17l22.993-6.929
+		c2.707,0.582,5.484,0.892,8.275,0.892c21.589,0,39.152-17.563,39.152-39.152S74.497,7.826,52.908,7.826z"/>
+</g>
 </svg>

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/speaker-textbox-icon.svg
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/speaker-textbox-icon.svg
@@ -1,14 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="100" height="100" viewBox="0 0 26.458333 26.458333" version="1.1" id="svg13076" inkscape:export-filename="bitmap.svg" inkscape:export-xdpi="96" inkscape:export-ydpi="96" sodipodi:docname="textbox_layer_icon.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview id="namedview13078" pagecolor="#505050" bordercolor="#eeeeee" borderopacity="1" inkscape:showpageshadow="0" inkscape:pageopacity="0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#505050" inkscape:document-units="mm" showgrid="true">
-    <inkscape:grid type="xygrid" id="grid14286" />
-  </sodipodi:namedview>
-  <defs id="defs13073" />
-  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1">
-    <path id="rect6772" style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2;stroke-opacity:1" d="m 2.6458333,10.583333 c -0.7328917,0 -1.3229166,0.590026 -1.3229166,1.322917 v 10.583333 c 0,0.732895 0.5900249,1.322917 1.3229166,1.322917 H 23.8125 c 0.732891,0 1.322917,-0.590022 1.322917,-1.322917 V 11.90625 c 0,-0.732891 -0.590026,-1.322917 -1.322917,-1.322917 z m 1.8520834,1.852084 h 3.7041666 c 0.7328922,0 1.3229167,0.590025 1.3229167,1.322916 V 20.6375 c 0,0.732891 -0.5900245,1.322917 -1.3229167,1.322917 H 4.4979167 C 3.7650245,21.960417 3.175,21.370391 3.175,20.6375 v -6.879167 c 0,-0.732891 0.5900245,-1.322916 1.3229167,-1.322916 z M 11.1125,13.49375 h 4.233333 c 0.439738,0 0.79375,0.354013 0.79375,0.79375 0,0.439737 -0.354012,0.79375 -0.79375,0.79375 H 11.1125 c -0.439737,0 -0.79375,-0.354013 -0.79375,-0.79375 0,-0.439737 0.354013,-0.79375 0.79375,-0.79375 z m -0.01602,2.116667 h 11.409123 c 0.430981,0 0.77773,0.346749 0.77773,0.77773 v 0.03204 c 0,0.430981 -0.346749,0.777731 -0.77773,0.777731 H 11.09648 c -0.430978,0 -0.77773,-0.34675 -0.77773,-0.777731 v -0.03204 c 0,-0.430981 0.346752,-0.77773 0.77773,-0.77773 z m 0,2.116666 h 11.409123 c 0.430981,0 0.77773,0.34675 0.77773,0.777731 v 0.03204 c 0,0.430981 -0.346749,0.77773 -0.77773,0.77773 H 11.09648 c -0.430979,0 -0.77773,-0.346749 -0.77773,-0.77773 v -0.03204 c 0,-0.430981 0.346751,-0.777731 0.77773,-0.777731 z m 0,2.116667 h 9.292456 c 0.430981,0 0.777731,0.34675 0.777731,0.77773 v 0.03204 c 0,0.43098 -0.34675,0.77773 -0.777731,0.77773 H 11.09648 c -0.43098,0 -0.77773,-0.34675 -0.77773,-0.77773 v -0.03204 c 0,-0.43098 0.34675,-0.77773 0.77773,-0.77773 z" />
-    <circle style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2;stroke-opacity:1" id="path6939" cx="6.3499999" cy="15.875" r="2.6458333" />
-    <path style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2;stroke-opacity:1" d="M 8.7312499,22.225 H 3.7041666 l 1.0583333,-4.497917 h 2.9104167 z" id="path6995" />
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg13076" inkscape:export-filename="bitmap.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" sodipodi:docname="textbox_layer_icon.svg" inkscape:export-ydpi="96" inkscape:export-xdpi="96"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px"
+	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<g>
+	<circle id="path6939_1_" fill="#FFFFFF" cx="30.504" cy="50.494" r="10.29"/>
+	<path id="path6995_1_" fill="#FFFFFF" d="M39.762,75.19h-19.55l4.117-17.494h11.318L39.762,75.19z"/>
+</g>
+<path fill="#FFFFFF" d="M87,20H13c-4.418,0-8,3.582-8,8v47.875c0,4.418,3.582,8,8,8h74c4.418,0,8-3.582,8-8V28
+	C95,23.582,91.418,20,87,20z M58.585,36.733h12.364c1.888,0,3.42,1.531,3.42,3.419c0,1.888-1.532,3.419-3.42,3.419H58.585
+	c-1.888,0-3.419-1.531-3.419-3.419C55.166,38.264,56.697,36.733,58.585,36.733z M47.546,69.842c0,2.721-2.207,4.928-4.927,4.928
+	h-24.23c-2.72,0-4.927-2.207-4.927-4.928v-35.77c0-2.72,2.207-4.927,4.927-4.927h24.23c2.721,0,4.927,2.208,4.927,4.927V69.842z
+	 M85.08,67.142H58.585c-1.889,0-3.419-1.531-3.419-3.42s1.53-3.42,3.419-3.42H85.08c1.887,0,3.419,1.531,3.419,3.42
+	S86.967,67.142,85.08,67.142z M85.08,55.355H58.585c-1.888,0-3.419-1.529-3.419-3.418s1.531-3.419,3.419-3.419H85.08
+	c1.888,0,3.419,1.53,3.419,3.419S86.968,55.355,85.08,55.355z"/>
 </svg>

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_TextInput/text_input_layer_icon.svg
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_TextInput/text_input_layer_icon.svg
@@ -1,13 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="100" height="100" viewBox="0 0 26.458333 26.458333" version="1.1" id="svg13076" inkscape:export-filename="input_layer_icon.svg" inkscape:export-xdpi="96" inkscape:export-ydpi="96" inkscape:version="1.2.2 (732a01da63, 2022-12-09)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview id="namedview13078" pagecolor="#505050" bordercolor="#eeeeee" borderopacity="1" inkscape:showpageshadow="0" inkscape:pageopacity="0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#505050" inkscape:document-units="mm" showgrid="true" inkscape:zoom="4.185" inkscape:cx="70.728793" inkscape:cy="64.755078" inkscape:window-width="1920" inkscape:window-height="1017" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="layer1">
-    <inkscape:grid type="xygrid" id="grid14286" />
-  </sodipodi:namedview>
-  <defs id="defs13073" />
-  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1">
-    <path d="m 7.6082792,8.3418703 h 1.750743 m 1.7507388,0 H 9.3590222 m 0,0 v 6.7798177 h -1.750743 3.5014818" stroke="#ffffff" stroke-width="1.6241" id="path30124" style="fill:none" />
-    <rect x="4.1067977" y="4.9624462" width="18.382788" height="13.558387" rx="1.7507416" stroke="#ffffff" stroke-width="1.67111" id="rect30126" style="fill:none" />
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg13076" inkscape:export-filename="input_layer_icon.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" inkscape:export-ydpi="96" inkscape:export-xdpi="96" inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px"
+	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<sodipodi:namedview  id="namedview13078" inkscape:pagecheckerboard="0" inkscape:cy="64.755078" inkscape:zoom="4.185" inkscape:cx="70.728793" pagecolor="#505050" showgrid="true" borderopacity="1" bordercolor="#eeeeee" inkscape:document-units="mm" inkscape:deskcolor="#505050" inkscape:pageopacity="0" inkscape:showpageshadow="0" inkscape:current-layer="layer1" inkscape:window-y="-8" inkscape:window-x="-8" inkscape:window-height="1017" inkscape:window-width="1920" inkscape:window-maximized="1">
+	<inkscape:grid  id="grid14286" type="xygrid"></inkscape:grid>
+</sodipodi:namedview>
+<g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
+	<g id="path30124">
+		<polygon fill="#FFFFFF" points="40.03,68.723 24.778,68.723 24.778,60.723 28.403,60.723 28.403,39.191 24.778,39.191 
+			24.778,31.191 40.03,31.191 40.03,39.191 36.403,39.191 36.403,60.723 40.03,60.723 		"/>
+	</g>
+	<g id="rect30126">
+		<path fill="#FFFFFF" d="M81.973,83.529H17.151c-6.41,0-11.625-5.216-11.625-11.626V28.097c0-6.411,5.215-11.626,11.625-11.626
+			h64.821c6.411,0,11.627,5.215,11.627,11.626v43.807C93.6,78.313,88.384,83.529,81.973,83.529z M17.151,24.471
+			c-1.999,0-3.625,1.626-3.625,3.626v43.807c0,1.999,1.626,3.626,3.625,3.626h64.821c2,0,3.627-1.627,3.627-3.626V28.097
+			c0-2-1.627-3.626-3.627-3.626H17.151z"/>
+	</g>
+</g>
 </svg>

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/portrait_layer_icon.svg
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/portrait_layer_icon.svg
@@ -1,17 +1,22 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg width="100" height="100" viewBox="0 0 26.458333 26.458333" version="1.1" id="svg13076" inkscape:export-filename="portrait_layre.svg" inkscape:export-xdpi="96" inkscape:export-ydpi="96" inkscape:version="1.2.2 (732a01da63, 2022-12-09)" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview id="namedview13078" pagecolor="#505050" bordercolor="#eeeeee" borderopacity="1" inkscape:showpageshadow="0" inkscape:pageopacity="0" inkscape:pagecheckerboard="0" inkscape:deskcolor="#505050" inkscape:document-units="mm" showgrid="true" inkscape:zoom="4.185" inkscape:cx="70.728793" inkscape:cy="64.755078" inkscape:window-width="1920" inkscape:window-height="1017" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:current-layer="layer1">
-    <inkscape:grid type="xygrid" id="grid14286" />
-  </sodipodi:namedview>
-  <defs id="defs13073" />
-  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1">
-    <path style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" d="m 1.984375,23.8125 c 1e-7,-3.96875 1e-7,-7.9375 1.3229167,-11.90625 H 7.2760416 C 8.5989584,15.875 8.5989584,19.84375 8.5989583,23.8125 H 1.984375" id="path23636" sodipodi:nodetypes="ccccc" />
-    <ellipse style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.06726;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" id="path23638" ry="3.9668591" rx="3.8058379" cy="7.4438586" cx="5.2916665" />
-    <path style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" d="m 9.921875,23.8125 c 10e-8,-3.96875 10e-8,-7.9375 1.322917,-11.90625 h 3.96875 c 1.322916,3.96875 1.322916,7.9375 1.322916,11.90625 H 9.921875" id="path23640" sodipodi:nodetypes="ccccc" />
-    <ellipse style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.06726;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" id="ellipse23642" ry="3.9668591" rx="3.8058379" cy="7.4438586" cx="13.229167" />
-    <path style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.88;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" d="m 17.859375,23.8125 c 0,-3.96875 0,-7.9375 1.322917,-11.90625 h 3.96875 c 1.322916,3.96875 1.322916,7.9375 1.322916,11.90625 h -6.614583" id="path23644" sodipodi:nodetypes="ccccc" />
-    <ellipse style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.06726;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:3.2" id="ellipse23646" ry="3.9668591" rx="3.8058379" cy="7.4438586" cx="21.166668" />
-  </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1"
+	 id="svg13076" inkscape:export-filename="portrait_layre.svg" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:svg="http://www.w3.org/2000/svg" inkscape:export-ydpi="96" inkscape:export-xdpi="96" inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="100px" height="100px"
+	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<sodipodi:namedview  id="namedview13078" inkscape:pagecheckerboard="0" inkscape:cy="64.755078" inkscape:zoom="4.185" inkscape:cx="70.728793" pagecolor="#505050" showgrid="true" borderopacity="1" bordercolor="#eeeeee" inkscape:document-units="mm" inkscape:deskcolor="#505050" inkscape:pageopacity="0" inkscape:showpageshadow="0" inkscape:current-layer="layer1" inkscape:window-y="-8" inkscape:window-x="-8" inkscape:window-height="1017" inkscape:window-width="1920" inkscape:window-maximized="1">
+	<inkscape:grid  id="grid14286" type="xygrid"></inkscape:grid>
+</sodipodi:namedview>
+<g>
+	<ellipse id="path23638" fill="#FFFFFF" cx="18.793" cy="33.473" rx="13.682" ry="14.261"/>
+	<path id="path23636" sodipodi:nodetypes="ccccc" fill="#FFFFFF" d="M6.903,80.789c0-11.847,0-23.693,4.756-35.539h14.268
+		c4.756,11.846,4.756,23.692,4.756,35.539H6.903"/>
+	<ellipse id="ellipse23642" fill="#FFFFFF" cx="49.999" cy="33.473" rx="13.683" ry="14.261"/>
+	<path id="path23640" sodipodi:nodetypes="ccccc" fill="#FFFFFF" d="M38.108,80.789c0-11.847,0-23.693,4.756-35.539h14.268
+		c4.756,11.846,4.756,23.692,4.756,35.539H38.108"/>
+	<path id="path23644" sodipodi:nodetypes="ccccc" fill="#FFFFFF" d="M69.316,80.789c0-11.847,0-23.693,4.756-35.539H88.34
+		c4.757,11.846,4.757,23.692,4.757,35.539H69.316"/>
+	<ellipse id="ellipse23646" fill="#FFFFFF" cx="81.206" cy="33.473" rx="13.683" ry="14.261"/>
+</g>
 </svg>

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -11,6 +11,8 @@ var customization_editor_info := {}
 ## -1 is the base scene, 0 to n are the layers
 var current_layer_idx := -1
 
+var _minimum_tree_item_height: int
+
 
 
 func _ready() -> void:
@@ -25,6 +27,8 @@ func _ready() -> void:
 	%ReplaceLayerButton.get_popup().index_pressed.connect(_on_replace_layer_menu_pressed)
 	%MakeCustomButton.get_popup().index_pressed.connect(_on_make_custom_menu_pressed)
 	%LayerTree.item_selected.connect(_on_layer_selected)
+	_minimum_tree_item_height = int(DialogicUtil.get_editor_scale() * 32)
+	%LayerTree.add_theme_constant_override("icon_max_width", _minimum_tree_item_height)
 
 
 func load_style(style:DialogicStyle) -> void:
@@ -49,6 +53,7 @@ func load_style_layer_list() -> void:
 	tree.clear()
 
 	var root := tree.create_item()
+	root.custom_minimum_height = _minimum_tree_item_height
 	var base_scene := current_style.get_inheritance_root().get_base_scene().resource_path
 	if %StyleBrowser.is_premade_style_part(base_scene):
 		if ResourceLoader.exists(%StyleBrowser.premade_scenes_reference[base_scene].get('icon', '')):
@@ -62,6 +67,7 @@ func load_style_layer_list() -> void:
 
 	for layer_scene in current_style.get_layer_list():
 		var layer_item := tree.create_item(root)
+		layer_item.custom_minimum_height = _minimum_tree_item_height
 		if %StyleBrowser.is_premade_style_part(layer_scene):
 			if ResourceLoader.exists(%StyleBrowser.premade_scenes_reference[layer_scene].get('icon', '')):
 				layer_item.set_icon(0, load(%StyleBrowser.premade_scenes_reference[layer_scene].get('icon')))


### PR DESCRIPTION
Fixes #2140 

![fixed](https://github.com/dialogic-godot/dialogic/assets/25368491/76a95de9-ebe2-439f-8c93-10d2811e7a46)

**Changes**
- Layer icons are now forced to a maximum width of 32px (Scaled with editor scale)
- Adjusted some layer icons to make them more readable
- Expanded outlined layer icon svgs to make them appear consistent across different DPIs (Outlined svgs produce inconsistent results when scaled up)
- Height of each layer item is now forced to 32px (Scaled with editor scale)
  - Ensures layer items without icons are the same height as layer items with icons