### PR TITLE
don't emit `Dialogic.timeline_ended` until `Timeline#clean` has been called

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -240,7 +240,7 @@ func preload_timeline(timeline_resource:Variant) -> Variant:
 
 ## Clears and stops the current timeline.
 func end_timeline() -> void:
-	clear(ClearFlags.TIMELINE_INFO_ONLY)
+	await clear(ClearFlags.TIMELINE_INFO_ONLY)
 	_on_timeline_ended()
 	timeline_ended.emit()
 
@@ -295,7 +295,7 @@ func clear(clear_flags := ClearFlags.FULL_CLEAR) -> bool:
 
 	# Resetting variables
 	if current_timeline:
-		current_timeline.clean()
+		await current_timeline.clean()
 
 	current_timeline = null
 	current_event_idx = -1


### PR DESCRIPTION
this fixes a bug where starting a timeline in a callback attached to `Dialogic.timeline_ended` will lock, since `Timeline#clean` fires a frame after it's called (and after `timeline_ended` is emitted), which will then disconnect the signals on the _new_ timeline.

(easy repro:
```gdscript
func _ready():
    Dialogic.start("whatever.dtl")
    Dialogic.timeline_ended.connect(Dialogic.start.bind("whatever.dtl")
```

causes the timeline to run once, and then to start a second time without input working.)