### PR TITLE
Remember the Timeline Sidebar Size

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -159,14 +159,14 @@ func _ready() -> void:
 
 	batch_loaded.connect(_on_batch_loaded)
 
-	#await find_parent('EditorView').ready
-	#timeline_editor.editors_manager.sidebar.content_item_activated.connect(_on_content_item_clicked)
+	await find_parent('EditorView').ready
+	timeline_editor.editors_manager.sidebar.content_item_activated.connect(_on_content_item_clicked)
 	%Timeline.child_order_changed.connect(update_content_list)
 
 	var editor_scale := DialogicUtil.get_editor_scale()
-	%RightSidebar.size.x = ProjectSettings.get_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
-	$View.split_offset = -ProjectSettings.get_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
-	sidebar_collapsed = ProjectSettings.get_setting("dialogic/editor/right_sidebar_collapsed", false)
+	%RightSidebar.size.x = DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
+	$View.split_offset = -DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
+	sidebar_collapsed = DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_collapsed", false)
 
 	load_event_buttons()
 	_on_right_sidebar_resized()
@@ -174,7 +174,7 @@ func _ready() -> void:
 
 
 func load_event_buttons() -> void:
-	sidebar_collapsed = ProjectSettings.get_setting("dialogic/editor/right_sidebar_collapsed", false)
+	sidebar_collapsed = DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_collapsed", false)
 
 	# Clear previous event buttons
 	for child in %RightSidebar.get_child(0).get_children():
@@ -970,9 +970,9 @@ func _on_right_sidebar_resized() -> void:
 						button.toggle_name(true)
 
 	if _initialised:
-		ProjectSettings.set_setting("dialogic/editor/right_sidebar_width", %RightSidebar.size.x)
-		ProjectSettings.set_setting("dialogic/editor/right_sidebar_collapsed", sidebar_collapsed)
-		ProjectSettings.save()
+		DialogicUtil.set_editor_setting("dialogic/editor/right_sidebar_width", %RightSidebar.size.x)
+		DialogicUtil.set_editor_setting("dialogic/editor/right_sidebar_collapsed", sidebar_collapsed)
+
 #endregion
 
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -23,7 +23,7 @@ signal timeline_loaded
 var _batches := []
 var _building_timeline := false
 var _timeline_changed_while_loading := false
-var _initialised := false
+var _initialized := false
 
 ################## TIMELINE EVENT MANAGEMENT ###################################
 ################################################################################
@@ -170,7 +170,7 @@ func _ready() -> void:
 
 	load_event_buttons()
 	_on_right_sidebar_resized()
-	_initialised = true
+	_initialized = true
 
 
 func load_event_buttons() -> void:

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -933,7 +933,7 @@ func _on_event_popup_menu_index_pressed(index:int) -> void:
 func _on_right_sidebar_resized() -> void:
 	var _scale := DialogicUtil.get_editor_scale()
 
-	if %RightSidebar.size.x < 160 * _scale and (not sidebar_collapsed or not _initialised):
+	if %RightSidebar.size.x < 160 * _scale and (not sidebar_collapsed or not _initialized):
 		sidebar_collapsed = true
 
 		for section in %RightSidebar.get_node('EventContainer').get_children():
@@ -952,7 +952,7 @@ func _on_right_sidebar_resized() -> void:
 						button.toggle_name(false)
 
 
-	elif %RightSidebar.size.x > 160 * _scale and (sidebar_collapsed or not _initialised):
+	elif %RightSidebar.size.x > 160 * _scale and (sidebar_collapsed or not _initialized):
 		sidebar_collapsed = false
 
 		for section in %RightSidebar.get_node('EventContainer').get_children():
@@ -969,7 +969,7 @@ func _on_right_sidebar_resized() -> void:
 					for button in con.get_children():
 						button.toggle_name(true)
 
-	if _initialised:
+	if _initialized:
 		DialogicUtil.set_editor_setting("dialogic/editor/right_sidebar_width", %RightSidebar.size.x)
 		DialogicUtil.set_editor_setting("dialogic/editor/right_sidebar_collapsed", sidebar_collapsed)
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -23,7 +23,7 @@ signal timeline_loaded
 var _batches := []
 var _building_timeline := false
 var _timeline_changed_while_loading := false
-
+var _initialised := false
 
 ################## TIMELINE EVENT MANAGEMENT ###################################
 ################################################################################
@@ -33,7 +33,7 @@ var selected_items : Array = []
 #region CREATE/SAVE/LOAD
 ################################################################################
 
-func something_changed():
+func something_changed() -> void:
 	timeline_editor.current_resource_state = DialogicEditor.ResourceStates.UNSAVED
 
 
@@ -58,7 +58,8 @@ func save_timeline() -> void:
 
 	timeline_editor.current_resource.events = new_events
 	timeline_editor.current_resource.events_processed = true
-	var error :int = ResourceSaver.save(timeline_editor.current_resource, timeline_editor.current_resource.resource_path)
+	var error: int = ResourceSaver.save(timeline_editor.current_resource, timeline_editor.current_resource.resource_path)
+
 	if error != OK:
 		print('[Dialogic] Saving error: ', error)
 
@@ -102,7 +103,7 @@ func load_timeline(resource:DialogicTimeline) -> void:
 	%TimelineArea.scroll_vertical = 0
 
 
-func batch_events(array, size, batch_number):
+func batch_events(array: Array, size: int, batch_number: int) -> Array:
 	return array.slice((batch_number - 1) * size, batch_number * size)
 
 
@@ -121,7 +122,8 @@ func load_batch(data:Array) -> void:
 					opener_events_stack.push_back(piece)
 	batch_loaded.emit()
 
-func _on_batch_loaded():
+
+func _on_batch_loaded() -> void:
 	if _timeline_changed_while_loading:
 		return
 	if _batches.size() > 0:
@@ -131,15 +133,17 @@ func _on_batch_loaded():
 		return
 
 	if opener_events_stack:
+
 		for ev in opener_events_stack:
 			create_end_branch_event(%Timeline.get_child_count(), ev)
+
 	opener_events_stack = []
 	indent_events()
 	update_content_list()
 	_building_timeline = false
 
 
-func clear_timeline_nodes():
+func clear_timeline_nodes() -> void:
 	deselect_all_items()
 	for event in %Timeline.get_children():
 		event.free()
@@ -149,28 +153,41 @@ func clear_timeline_nodes():
 #region SETUP
 ################################################################################
 
-func _ready():
+func _ready() -> void:
 	DialogicUtil.get_dialogic_plugin().dialogic_save.connect(save_timeline)
 	event_node = load("res://addons/dialogic/Editor/Events/EventBlock/event_block.tscn")
 
 	batch_loaded.connect(_on_batch_loaded)
 
-	await find_parent('EditorView').ready
-	timeline_editor.editors_manager.sidebar.content_item_activated.connect(_on_content_item_clicked)
+	#await find_parent('EditorView').ready
+	#timeline_editor.editors_manager.sidebar.content_item_activated.connect(_on_content_item_clicked)
 	%Timeline.child_order_changed.connect(update_content_list)
+
+	var editor_scale := DialogicUtil.get_editor_scale()
+	%RightSidebar.size.x = ProjectSettings.get_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
+	$View.split_offset = -ProjectSettings.get_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
+	sidebar_collapsed = ProjectSettings.get_setting("dialogic/editor/right_sidebar_collapsed", false)
+
+	load_event_buttons()
+	_on_right_sidebar_resized()
+	_initialised = true
 
 
 func load_event_buttons() -> void:
+	sidebar_collapsed = ProjectSettings.get_setting("dialogic/editor/right_sidebar_collapsed", false)
+
 	# Clear previous event buttons
 	for child in %RightSidebar.get_child(0).get_children():
+
 		if child is FlowContainer:
+
 			for button in child.get_children():
 				button.queue_free()
 
 	var scripts := DialogicResourceUtil.get_event_cache()
 
 	# Event buttons
-	var buttonScene := load("res://addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.tscn")
+	var button_scene := load("res://addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.tscn")
 
 	var hidden_buttons :Array = DialogicUtil.get_editor_setting('hidden_event_buttons', [])
 	var sections := {}
@@ -192,7 +209,7 @@ func load_event_buttons() -> void:
 		if event_resource.event_name in hidden_buttons:
 			continue
 
-		var button :Button = buttonScene.instantiate()
+		var button: Button = button_scene.instantiate()
 		button.resource = event_resource
 		button.visible_name = event_resource.event_name
 		button.event_icon = event_resource._get_icon()
@@ -223,6 +240,7 @@ func load_event_buttons() -> void:
 
 
 		sections[event_resource.event_category].add_child(button)
+		button.toggle_name(!sidebar_collapsed)
 
 		# Sort event button
 		while event_resource.event_sorting_index < sections[event_resource.event_category].get_child(max(0, button.get_index()-1)).resource.event_sorting_index:
@@ -240,7 +258,6 @@ func load_event_buttons() -> void:
 	var _scale := DialogicUtil.get_editor_scale()
 	%RightSidebar.custom_minimum_size.x = 50 * _scale
 
-	$View.split_offset = -200*_scale
 	_on_right_sidebar_resized()
 #endregion
 
@@ -260,12 +277,17 @@ func _on_content_item_clicked(label:String) -> void:
 				return
 
 
-func update_content_list():
+func update_content_list() -> void:
 	var labels :PackedStringArray = []
+
 	for event in %Timeline.get_children():
+
 		if 'event_name' in event.resource and event.resource is DialogicLabelEvent:
 			labels.append(event.resource.name)
+
 	timeline_editor.editors_manager.sidebar.update_content_list(labels)
+
+
 #endregion
 
 
@@ -273,7 +295,7 @@ func update_content_list():
 #################################################################################
 
 # SIGNAL handles input on the events mainly for selection and moving events
-func _on_event_block_gui_input(event, item: Node):
+func _on_event_block_gui_input(event, item: Node) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
 		if event.is_pressed():
 			if len(selected_items) > 1 and item in selected_items and !Input.is_key_pressed(KEY_CTRL):
@@ -365,13 +387,13 @@ func create_end_branch_event(at_index:int, parent_node:Node) -> Node:
 
 
 # combination of the above that establishes the correct connection between the event and it's end branch
-func add_event_with_end_branch(resource, at_index:int=-1, auto_select:bool = false, indent:bool = false):
+func add_event_with_end_branch(resource, at_index:int=-1, auto_select:bool = false, indent:bool = false) -> void:
 	var event := add_event_node(resource, at_index, auto_select, indent)
 	create_end_branch_event(at_index+1, event)
 
 
 ## Adds an event (either single nodes or with end branches) to the timeline with UndoRedo support
-func add_event_undoable(event_resource: DialogicEvent, at_index: int = -1):
+func add_event_undoable(event_resource: DialogicEvent, at_index: int = -1) -> void:
 		TimelineUndoRedo.create_action("[D] Add "+event_resource.event_name+" event.")
 		if event_resource.can_contain_events:
 			TimelineUndoRedo.add_do_method(add_event_with_end_branch.bind(event_resource, at_index, true, true))
@@ -908,31 +930,49 @@ func _on_event_popup_menu_index_pressed(index:int) -> void:
 		something_changed()
 
 
-func _on_right_sidebar_resized():
+func _on_right_sidebar_resized() -> void:
 	var _scale := DialogicUtil.get_editor_scale()
-	if %RightSidebar.size.x < 160*_scale and !sidebar_collapsed:
+
+	if %RightSidebar.size.x < 160 * _scale and (not sidebar_collapsed or not _initialised):
 		sidebar_collapsed = true
+
 		for section in %RightSidebar.get_node('EventContainer').get_children():
+
 			for con in section.get_children():
+
 				if con.get_child_count() == 0:
 					continue
+
 				if con.get_child(0) is Label:
 					con.get_child(0).hide()
+
 				elif con.get_child(0) is Button:
+
 					for button in con.get_children():
 						button.toggle_name(false)
 
-	elif %RightSidebar.size.x > 160*_scale and sidebar_collapsed:
+
+	elif %RightSidebar.size.x > 160 * _scale and (sidebar_collapsed or not _initialised):
 		sidebar_collapsed = false
+
 		for section in %RightSidebar.get_node('EventContainer').get_children():
+
 			for con in section.get_children():
+
 				if con.get_child_count() == 0:
 					continue
+
 				if con.get_child(0) is Label:
 					con.get_child(0).show()
+
 				elif con.get_child(0) is Button:
 					for button in con.get_children():
 						button.toggle_name(true)
+
+	if _initialised:
+		ProjectSettings.set_setting("dialogic/editor/right_sidebar_width", %RightSidebar.size.x)
+		ProjectSettings.set_setting("dialogic/editor/right_sidebar_collapsed", sidebar_collapsed)
+		ProjectSettings.save()
 #endregion
 
 


### PR DESCRIPTION
When reloading the project, the right sidebar of the timeline editor does not remember its last manually set size.

This pull request saves the size as project setting, assigns the correct size to all relevant containers, and sets the proper event button style.

Closes #2152