### PR TITLE
Never disable the Colour Picker

### DIFF
--- a/addons/dialogic/Modules/Glossary/glossary_editor.gd
+++ b/addons/dialogic/Modules/Glossary/glossary_editor.gd
@@ -197,7 +197,6 @@ func _on_EntryList_item_selected(idx: int) -> void:
 
 	%EntryColor.color = entry_info.get('color', %DefaultColor.color)
 	%EntryCustomColor.button_pressed = entry_info.has('color')
-	%EntryColor.disabled = !entry_info.has('color')
 
 	_check_entry_alternatives(alternatives)
 	_check_entry_name(current_entry_name, current_entry)


### PR DESCRIPTION
The Colour Picker was disabled, if the Glossary Entry was lacking the `color` entry. However, the Entries are kept minimal on purpose, if they use the default colour.

This removes the behaviour of disabling the Colour Picker.

Closes #2175 