### PR TITLE
Add simple context menu to resource sidebar

### DIFF
--- a/addons/dialogic/Editor/Common/side_bar.tscn
+++ b/addons/dialogic/Editor/Common/side_bar.tscn
@@ -77,6 +77,7 @@ size_flags_vertical = 3
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
+tooltip_text = "Label events in your timeline will appear here, allowing you to jump to them."
 theme_override_styles/selected = SubResource("StyleBoxEmpty_gxwm6")
 theme_override_styles/selected_focus = SubResource("StyleBoxEmpty_n8rql")
 allow_reselect = true
@@ -89,6 +90,11 @@ text = "Some Version"
 flat = true
 clip_text = true
 
+[node name="RightClickMenu" type="PopupMenu" parent="."]
+unique_name_in_owner = true
+size = Vector2i(164, 100)
+
 [connection signal="gui_input" from="VBox/Margin/VSplitContainer/VBox/Logo" to="." method="_on_logo_gui_input"]
 [connection signal="text_changed" from="VBox/Margin/VSplitContainer/VBox/Search" to="." method="_on_search_text_changed"]
 [connection signal="pressed" from="VBox/CurrentVersion" to="." method="_on_current_version_pressed"]
+[connection signal="id_pressed" from="RightClickMenu" to="." method="_on_right_click_menu_id_pressed"]

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -37,6 +37,13 @@ func _ready():
 	$VBox/Margin.set("theme_override_constants/margin_left", 4 * editor_scale)
 	$VBox/Margin.set("theme_override_constants/margin_bottom", 4 * editor_scale)
 
+	## RIGHT CLICK MENU
+	%RightClickMenu.clear()
+	%RightClickMenu.add_icon_item(get_theme_icon("Remove", "EditorIcons"), "Remove From List", 1)
+	%RightClickMenu.add_separator()
+	%RightClickMenu.add_icon_item(get_theme_icon("Filesystem", "EditorIcons"), "Show in FileSystem", 2)
+	%RightClickMenu.add_icon_item(get_theme_icon("ExternalLink", "EditorIcons"), "Open in External Program", 3)
+
 
 ################################################################################
 ## 						RESOURCE LIST
@@ -112,13 +119,11 @@ func _on_resources_list_item_selected(index:int) -> void:
 
 func _on_resources_list_item_clicked(index: int, at_position: Vector2, mouse_button_index: int) -> void:
 	# If clicked with the middle mouse button, remove the item from the list
-	if mouse_button_index == 3:
-		var new_list := []
-		for entry in DialogicUtil.get_editor_setting('last_resources', []):
-			if entry != %ResourcesList.get_item_metadata(index):
-				new_list.append(entry)
-		DialogicUtil.set_editor_setting('last_resources', new_list)
-		%ResourcesList.remove_item(index)
+	if mouse_button_index == MOUSE_BUTTON_MIDDLE:
+		remove_item_from_list(index)
+	if mouse_button_index == MOUSE_BUTTON_RIGHT:
+		%RightClickMenu.popup_on_parent(Rect2(get_global_mouse_position(), Vector2()))
+		%RightClickMenu.set_meta('item_index', index)
 
 
 func _on_search_text_changed(new_text:String) -> void:
@@ -165,3 +170,19 @@ func update_content_list(list:PackedStringArray) -> void:
 
 	DialogicResourceUtil.set_label_cache(label_directory)
 
+func remove_item_from_list(index) -> void:
+	var new_list := []
+	for entry in DialogicUtil.get_editor_setting('last_resources', []):
+		if entry != %ResourcesList.get_item_metadata(index):
+			new_list.append(entry)
+	DialogicUtil.set_editor_setting('last_resources', new_list)
+	%ResourcesList.remove_item(index)
+
+func _on_right_click_menu_id_pressed(id:int) -> void:
+	match id:
+		1: # REMOVE ITEM FROM LIST
+			remove_item_from_list(%RightClickMenu.get_meta("item_index"))
+		2: # OPEN IN FILESYSTEM
+			EditorInterface.get_file_system_dock().navigate_to_path(%ResourcesList.get_item_metadata(%RightClickMenu.get_meta("item_index")))
+		3: # OPEN IN EXTERNAL EDITOR
+			OS.shell_open(ProjectSettings.globalize_path(%ResourcesList.get_item_metadata(%RightClickMenu.get_meta("item_index"))))

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
@@ -37,19 +37,13 @@ func _close():
 func _ready() -> void:
 	%ReferenceInfo.get_node('Label').add_theme_color_override('font_color', get_theme_color("warning_color", "Editor"))
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
+
 #region RENAMING
 
 func variable_renamed(old_name:String, new_name:String):
+	if old_name == new_name:
+		return
 	editors_manager.reference_manager.add_variable_ref_change(old_name, new_name)
-	%ReferenceInfo.show()
-
-
-func group_renamed(old_name:String, new_name:String, group_data:Dictionary):
-	for i in group_data:
-		if group_data[i] is Dictionary:
-			group_renamed(old_name+'.'+i, new_name+'.'+i, group_data[i])
-		else:
-			editors_manager.reference_manager.add_variable_ref_change(old_name+'.'+i, new_name+'.'+i)
 	%ReferenceInfo.show()
 
 

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
@@ -49,6 +49,7 @@ func variable_renamed(old_name:String, new_name:String):
 
 func _on_reference_manager_pressed():
 	editors_manager.reference_manager.open()
+	%ReferenceInfo.hide()
 
 #endregion
 


### PR DESCRIPTION
- Also fixes a wrong warning appearing when not renaming variables in the variable editor.
![grafik](https://github.com/dialogic-godot/dialogic/assets/42868150/95611af5-51f7-447d-8065-73f4d6322d2e)
