### PR TITLE
Text Reveal Skippable Potential Fix

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -30,8 +30,8 @@ func clear_game_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) 
 	if not is_node_ready():
 		await ready
 
-	manual_advance.enabled_until_next_event = false
-	manual_advance.enabled_forced = true
+	manual_advance.disabled_until_next_event = false
+	manual_advance.system_enabled = true
 
 
 func pause() -> void:

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -6,6 +6,7 @@ extends DialogicEvent
 ## Should be shown by a DialogicNode_DialogText.
 
 
+
 ### Settings
 
 ## This is the content of the text event.
@@ -159,7 +160,6 @@ func _execute() -> void:
 		else:
 			await advance
 
-
 	end_text_event()
 
 
@@ -218,12 +218,14 @@ func _on_dialogic_input_action() -> void:
 			if dialogic.Text.is_text_reveal_skippable():
 				dialogic.Text.skip_text_reveal()
 				dialogic.Inputs.stop_timers()
-				dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))
+				# add a small input block to prevent accidental skipping.
+				dialogic.Inputs.block_input(0.3)
 		_:
 			if dialogic.Inputs.manual_advance.is_enabled():
 				advance.emit()
 				dialogic.Inputs.stop_timers()
-				dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))
+				# add a small input block to prevent accidental skipping.
+				dialogic.Inputs.block_input(0.3)
 
 
 func _on_dialogic_input_autoadvance() -> void:


### PR DESCRIPTION
`Text Reveal Skippable` timer doesn't trigger at the very first dialogue text that appears, and to dialogues right after a choice. This fixes that by connecting the signals in `DialogicGameHandler` `timeline_started()`, `timeline_ended()`, and `state_changed()` to `event_text.gd`.

This fixes unintended behaviours where supposedly unskippable texts somehow got skip, and player getting stuck waiting for the remainder of `Text Reveal Skippable Delay` to finish even though texts is already finished (This one is an edge case, for example if your delay timer is above 3s or 5s).