### PR TITLE
Allow expressions as portraits

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -407,4 +407,11 @@ func _on_timeline_ended() -> void:
 				@warning_ignore("unsafe_method_access")
 				self.Styles.get_layout_node().hide()
 
+
+func print_debug_moment() -> void:
+	if not current_timeline:
+		return
+
+	printerr("\tAt event ", current_event_idx+1, " (",current_timeline_events[current_event_idx].event_name, ' Event) in timeline "', DialogicResourceUtil.get_unique_identifier(current_timeline.resource_path), '" (',current_timeline.resource_path,').')
+	print("\n")
 #endregion

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -341,7 +341,7 @@ func add_portrait(portrait_name:String='New portrait', portrait_data:Dictionary=
 			parent = %PortraitTree.get_selected()
 		else:
 			parent = %PortraitTree.get_selected().get_parent()
-	var item :TreeItem = %PortraitTree.add_portrait_item(portrait_name, portrait_data, parent)
+	var item: TreeItem = %PortraitTree.add_portrait_item(portrait_name, portrait_data, parent)
 	item.set_meta('new', true)
 	item.set_editable(0, true)
 	item.select(0)
@@ -350,7 +350,7 @@ func add_portrait(portrait_name:String='New portrait', portrait_data:Dictionary=
 
 
 func add_portrait_group() -> void:
-	var parent_item :TreeItem = %PortraitTree.get_root()
+	var parent_item: TreeItem = %PortraitTree.get_root()
 	if %PortraitTree.get_selected() and %PortraitTree.get_selected().get_metadata(0).has('group'):
 		parent_item = %PortraitTree.get_selected()
 	var item :TreeItem = %PortraitTree.add_portrait_group("Group", parent_item)
@@ -362,7 +362,7 @@ func add_portrait_group() -> void:
 
 func load_portrait_tree() -> void:
 	%PortraitTree.clear_tree()
-	var root:TreeItem = %PortraitTree.create_item()
+	var root: TreeItem = %PortraitTree.create_item()
 
 	for portrait in current_resource.portraits.keys():
 		var portrait_label = portrait
@@ -384,11 +384,11 @@ func load_portrait_tree() -> void:
 		load_selected_portrait()
 
 
-func filter_portrait_list(filter_term:String = '') -> void:
+func filter_portrait_list(filter_term := "") -> void:
 	filter_branch(%PortraitTree.get_root(), filter_term)
 
 
-func filter_branch(parent:TreeItem, filter_term:String) -> bool:
+func filter_branch(parent: TreeItem, filter_term: String) -> bool:
 	var anything_visible := false
 	for item in parent.get_children():
 		if item.get_metadata(0).has('group'):
@@ -402,12 +402,12 @@ func filter_branch(parent:TreeItem, filter_term:String) -> bool:
 	return anything_visible
 
 
-# this is used to save the portrait data
+## This is used to save the portrait data
 func get_updated_portrait_dict() -> Dictionary:
 	return list_portraits(%PortraitTree.get_root().get_children())
 
 
-func list_portraits(tree_items:Array[TreeItem], dict:Dictionary = {}, path_prefix = "") -> Dictionary:
+func list_portraits(tree_items: Array[TreeItem], dict := {}, path_prefix := "") -> Dictionary:
 	for item in tree_items:
 		if item.get_metadata(0).has('group'):
 			dict = list_portraits(item.get_children(), dict, path_prefix+item.get_text(0)+"/")
@@ -416,7 +416,7 @@ func list_portraits(tree_items:Array[TreeItem], dict:Dictionary = {}, path_prefi
 	return dict
 
 
-func load_selected_portrait():
+func load_selected_portrait() -> void:
 	if selected_item and is_instance_valid(selected_item):
 		selected_item.set_editable(0, false)
 
@@ -439,7 +439,7 @@ func load_selected_portrait():
 		update_preview()
 
 
-func delete_portrait_item(item:TreeItem) -> void:
+func delete_portrait_item(item: TreeItem) -> void:
 	if item.get_next_visible(true) and item.get_next_visible(true) != item:
 		item.get_next_visible(true).select(0)
 	else:
@@ -449,11 +449,13 @@ func delete_portrait_item(item:TreeItem) -> void:
 	something_changed()
 
 
-func duplicate_item(item:TreeItem) -> void:
-	%PortraitTree.add_portrait_item(item.get_text(0)+'_duplicated', item.get_metadata(0).duplicate(true), item.get_parent()).select(0)
+func duplicate_item(item: TreeItem) -> void:
+	var new_item: TreeItem = %PortraitTree.add_portrait_item(item.get_text(0)+'_duplicated', item.get_metadata(0).duplicate(true), item.get_parent())
+	new_item.set_meta('new', true)
+	new_item.select(0)
 
 
-func _input(event:InputEvent) -> void:
+func _input(event: InputEvent) -> void:
 	if !is_visible_in_tree() or (get_viewport().gui_get_focus_owner()!= null and !name+'/' in str(get_viewport().gui_get_focus_owner().get_path())):
 		return
 	if event is InputEventKey and event.pressed:
@@ -466,7 +468,7 @@ func _input(event:InputEvent) -> void:
 			get_viewport().set_input_as_handled()
 
 
-func _on_portrait_right_click_menu_index_pressed(id:int) -> void:
+func _on_portrait_right_click_menu_index_pressed(id: int) -> void:
 	# RENAME BUTTON
 	if id == 0:
 		_on_item_activated()
@@ -480,22 +482,22 @@ func _on_portrait_right_click_menu_index_pressed(id:int) -> void:
 		get_settings_section_by_name("Portraits").set_default_portrait(%PortraitTree.get_full_item_name(%PortraitTree.get_selected()))
 
 
-# this removes/and adds the DEFAULT star on the portrait list
-func update_default_portrait_star(default_portrait_name:String) -> void:
-	var item_list : Array = %PortraitTree.get_root().get_children()
+## This removes/and adds the DEFAULT star on the portrait list
+func update_default_portrait_star(default_portrait_name: String) -> void:
+	var item_list: Array = %PortraitTree.get_root().get_children()
 	if item_list.is_empty() == false:
 		while true:
-			var item = item_list.pop_back()
+			var item := item_list.pop_back()
 			if item.get_button_by_id(0, 2) != -1:
 				item.erase_button(0, item.get_button_by_id(0, 2))
 			if %PortraitTree.get_full_item_name(item) == default_portrait_name:
-				item.add_button(0, get_theme_icon('Favorites', 'EditorIcons'), 2, true, 'Default')
+				item.add_button(0, get_theme_icon("Favorites", "EditorIcons"), 2, true, "Default")
 			item_list.append_array(item.get_children())
 			if item_list.is_empty():
 				break
 
 
-func _on_item_edited():
+func _on_item_edited() -> void:
 	selected_item = %PortraitTree.get_selected()
 	something_changed()
 	if selected_item:
@@ -509,14 +511,14 @@ func _on_item_edited():
 	update_preview()
 
 
-func _on_item_activated():
+func _on_item_activated() -> void:
 	if %PortraitTree.get_selected() == null:
 		return
 	%PortraitTree.get_selected().set_editable(0, true)
 	%PortraitTree.edit_selected()
 
 
-func report_name_change(item:TreeItem) -> void:
+func report_name_change(item: TreeItem) -> void:
 	if item.get_metadata(0).has('group'):
 		for s_item in item.get_children():
 			if s_item.get_metadata(0).has('group') or !s_item.has_meta('new'):
@@ -536,7 +538,7 @@ func report_name_change(item:TreeItem) -> void:
 ########### PREVIEW ############################################################
 
 #region Preview
-func update_preview(force:=false) -> void:
+func update_preview(force := false) -> void:
 	%ScenePreviewWarning.hide()
 	if selected_item and is_instance_valid(selected_item) and selected_item.get_metadata(0) != null and !selected_item.get_metadata(0).has('group'):
 		%PreviewLabel.text = 'Preview of "'+%PortraitTree.get_full_item_name(selected_item)+'"'
@@ -652,4 +654,5 @@ func _on_fit_preview_toggle_toggled(button_pressed):
 ## Open the reference manager
 func _on_reference_manger_button_pressed():
 	editors_manager.reference_manager.open()
+	%PortraitChangeInfo.hide()
 

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -3,7 +3,7 @@ extends Tree
 
 ## Tree that displays the portrait list as a hirarchy
 
-var editor = find_parent('Character Editor')
+var editor := find_parent('Character Editor')
 var current_group_nodes := {}
 
 
@@ -19,8 +19,8 @@ func clear_tree() -> void:
 	current_group_nodes = {}
 
 
-func add_portrait_item(portrait_name:String, portrait_data:Dictionary, parent_item:TreeItem, previous_name:String = "") -> TreeItem:
-	var item :TreeItem = %PortraitTree.create_item(parent_item)
+func add_portrait_item(portrait_name: String, portrait_data: Dictionary, parent_item: TreeItem, previous_name := "") -> TreeItem:
+	var item: TreeItem = %PortraitTree.create_item(parent_item)
 	item.set_text(0, portrait_name)
 	item.set_metadata(0, portrait_data)
 	if previous_name.is_empty():
@@ -32,8 +32,8 @@ func add_portrait_item(portrait_name:String, portrait_data:Dictionary, parent_it
 	return item
 
 
-func add_portrait_group(goup_name:String = "Group", parent_item:TreeItem = get_root(), previous_name:String = "") -> TreeItem:
-	var item :TreeItem = %PortraitTree.create_item(parent_item)
+func add_portrait_group(goup_name := "Group", parent_item: TreeItem = get_root(), previous_name := "") -> TreeItem:
+	var item: TreeItem = %PortraitTree.create_item(parent_item)
 	item.set_icon(0, get_theme_icon("Folder", "EditorIcons"))
 	item.set_text(0, goup_name)
 	item.set_metadata(0, {'group':true})
@@ -44,7 +44,7 @@ func add_portrait_group(goup_name:String = "Group", parent_item:TreeItem = get_r
 	return item
 
 
-func get_full_item_name(item:TreeItem) -> String:
+func get_full_item_name(item: TreeItem) -> String:
 	var item_name := item.get_text(0)
 	while item.get_parent() != get_root() and item != get_root():
 		item_name = item.get_parent().get_text(0)+"/"+item_name
@@ -52,9 +52,9 @@ func get_full_item_name(item:TreeItem) -> String:
 	return item_name
 
 
-# Will create all not yet existing folders in the given path.
-# Returns the last folder (the parent of the portrait item of this path).
-func create_necessary_group_items(path:String) -> TreeItem:
+## Will create all not yet existing folders in the given path.
+## Returns the last folder (the parent of the portrait item of this path).
+func create_necessary_group_items(path: String) -> TreeItem:
 	var last_item := get_root()
 	var item_path := ""
 
@@ -70,7 +70,7 @@ func create_necessary_group_items(path:String) -> TreeItem:
 	return last_item
 
 
-func _on_item_mouse_selected(pos:Vector2, mouse_button_index:int) -> void:
+func _on_item_mouse_selected(pos: Vector2, mouse_button_index: int) -> void:
 	if mouse_button_index == MOUSE_BUTTON_RIGHT:
 		$PortraitRightClickMenu.set_item_disabled(1, get_selected().get_metadata(0).has('group'))
 		$PortraitRightClickMenu.popup_on_parent(Rect2(get_global_mouse_position(),Vector2()))
@@ -80,7 +80,7 @@ func _on_item_mouse_selected(pos:Vector2, mouse_button_index:int) -> void:
 ##					DRAG AND DROP
 ################################################################################
 
-func _get_drag_data(position:Vector2) -> Variant:
+func _get_drag_data(position: Vector2) -> Variant:
 	drop_mode_flags = DROP_MODE_INBETWEEN
 	var preview := Label.new()
 	preview.text = "     "+get_selected().get_text(0)
@@ -90,11 +90,11 @@ func _get_drag_data(position:Vector2) -> Variant:
 	return get_selected()
 
 
-func _can_drop_data(position:Vector2, data:Variant) -> bool:
+func _can_drop_data(position: Vector2, data: Variant) -> bool:
 	return data is TreeItem
 
 
-func _drop_data(position:Vector2, item:Variant) -> void:
+func _drop_data(position: Vector2, item: Variant) -> void:
 	var to_item := get_item_at_position(position)
 	if to_item:
 		var test_item:= to_item
@@ -126,8 +126,8 @@ func _drop_data(position:Vector2, item:Variant) -> void:
 	item.free()
 
 
-func copy_branch_or_item(item:TreeItem, new_parent:TreeItem) -> TreeItem:
-	var new_item :TreeItem = null
+func copy_branch_or_item(item: TreeItem, new_parent: TreeItem) -> TreeItem:
+	var new_item: TreeItem = null
 	if item.get_metadata(0).has('group'):
 		new_item = add_portrait_group(item.get_text(0), new_parent, item.get_meta('previous_name'))
 	else:
@@ -136,4 +136,3 @@ func copy_branch_or_item(item:TreeItem, new_parent:TreeItem) -> TreeItem:
 	for child in item.get_children():
 		copy_branch_or_item(child, new_item)
 	return new_item
-

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -438,6 +438,8 @@ func get_portrait_suggestions(search_text:String) -> Dictionary:
 		suggestions["Don't Change"] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
 	if action == Actions.JOIN:
 		suggestions["Default portrait"] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
+	if "{" in search_text:
+		suggestions[search_text] = {'value':search_text, 'editor_icon':["Variant", "EditorIcons"]}
 	if character != null:
 		for portrait in character.portraits:
 			suggestions[portrait] = {'value':portrait, 'icon':icon.duplicate()}

--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -31,17 +31,17 @@ func execute_string(string:String, default: Variant = null, no_warning := false)
 
 	if expr.parse(string, autoload_names) != OK:
 		if not no_warning:
-			printerr('Dialogic: Expression failed to parse: ', expr.get_error_text())
-			printerr('		Expression: ', string)
-			print("\n")
+			printerr('[Dialogic] Expression "', string, '" failed to parse.')
+			printerr('           ', expr.get_error_text())
+			dialogic.print_debug_moment()
 		return default
 
 	var result: Variant = expr.execute(autoloads, self)
 	if expr.has_execute_failed():
 		if not no_warning:
-			printerr('Dialogic: Expression failed to execute: ', expr.get_error_text())
-			printerr('		Expression: ', string)
-			print("\n")
+			printerr('[Dialogic] Expression "', string, '" failed to parse.')
+			printerr('           ', expr.get_error_text())
+			dialogic.print_debug_moment()
 		return default
 	return result
 

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -399,8 +399,10 @@ func get_character_suggestions(search_text:String) -> Dictionary:
 
 func get_portrait_suggestions(search_text:String) -> Dictionary:
 	var suggestions := {}
-	var icon = load("res://addons/dialogic/Editor/Images/Resources/portrait.svg")
+	var icon := load("res://addons/dialogic/Editor/Images/Resources/portrait.svg")
 	suggestions["Don't change"] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
+	if "{" in search_text:
+		suggestions[search_text] = {'value':search_text, 'editor_icon':["Variant", "EditorIcons"]}
 	if character != null:
 		for portrait in character.portraits:
 			suggestions[portrait] = {'value':portrait, 'icon':icon}


### PR DESCRIPTION
- should close #2199 

You can now use variables as portraits. You can also use expressions, for example if your character can have multiple genders, you could put those portraits in separate groups like this:
```
- male
   - default
   - happy
   - sad
-female
   - default
   - happy
   - sad
```
Then you can now use `{Player.gender}+"/happy"` as your portrait (assuming the Player.gender variable is either "male" or "female").
Note that this will be parsed when the portrait is set. It won't update the portrait live, in case you change the variable later, unless the portrait is set again with this expression!


## Other stuff
- also stops duplicated portrait items from reporting name changes
- also adds a print_debug_moment() method to the DialogicGameHandler that allows to easily print the timeline and event for errors.