### PR TITLE
Implement label display name (translatable) & store last label

### DIFF
--- a/addons/dialogic/Modules/Jump/event_label.gd
+++ b/addons/dialogic/Modules/Jump/event_label.gd
@@ -9,6 +9,8 @@ extends DialogicEvent
 
 ## Used to identify the label. Duplicate names in a timeline will mean it always chooses the first.
 var name: String = ""
+var display_name: String = ""
+
 
 
 ################################################################################
@@ -17,6 +19,13 @@ var name: String = ""
 
 func _execute() -> void:
 	# This event is mainly implemented in the Jump subsystem.
+	dialogic.Jump.passed_label.emit(
+		{
+			"identifier": name,
+			"display_name": get_property_translated("display_name"),
+			"display_name_orig": display_name,
+			"timeline": DialogicResourceUtil.get_unique_identifier(dialogic.current_timeline.resource_path)
+		})
 	finish()
 
 
@@ -39,14 +48,19 @@ func _get_icon() -> Resource:
 ## 						SAVING/LOADING
 ################################################################################
 func to_text() -> String:
-	return "label "+name
+	if display_name.is_empty():
+		return "label "+name
+	else:
+		return "label "+name+ " ("+display_name+")"
+
 
 
 func from_text(string:String) -> void:
-	var regex = RegEx.create_from_string('label +(?<name>.+)')
+	var regex = RegEx.create_from_string(r'label +(?<name>[^(]+)(\((?<display_name>.+)\))?')
 	var result := regex.search(string.strip_edges())
 	if result:
-		name = result.get_string('name')
+		name = result.get_string('name').strip_edges()
+		display_name = result.get_string('display_name').strip_edges()
 
 
 func is_valid_event(string:String) -> bool:
@@ -61,8 +75,19 @@ func get_shortcode_parameters() -> Dictionary:
 	return {
 		#param_name 	: property_info
 		"name" 			: {"property": "name", "default": ""},
+		"display" 		: {"property": "display_name", "default": ""},
 	}
 
+
+func _get_translatable_properties() -> Array:
+	return ["display_name"]
+
+
+func _get_property_original_translation(property_name:String) -> String:
+	match property_name:
+		'display_name':
+			return display_name
+	return ''
 
 ################################################################################
 ## 						EDITOR REPRESENTATION
@@ -70,6 +95,7 @@ func get_shortcode_parameters() -> Dictionary:
 
 func build_event_editor():
 	add_header_edit('name', ValueType.SINGLELINE_TEXT, {'left_text':'Label', 'autofocus':true})
+	add_body_edit('display_name', ValueType.SINGLELINE_TEXT, {'left_text':'Display Name:'})
 
 
 ####################### CODE COMPLETION ########################################

--- a/addons/dialogic/Modules/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Modules/Jump/subsystem_jump.gd
@@ -5,6 +5,7 @@ extends DialogicSubsystem
 signal switched_timeline(info:Dictionary)
 signal jumped_to_label(info:Dictionary)
 signal returned_from_jump(info:Dictionary)
+signal passed_label(info:Dictionary)
 
 
 #region STATE
@@ -12,6 +13,7 @@ signal returned_from_jump(info:Dictionary)
 
 func clear_game_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	dialogic.current_state_info['jump_stack'] = []
+	dialogic.current_state_info.erase("last_label")
 
 
 func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
@@ -21,7 +23,7 @@ func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
 #endregion
 
 
-#region MAIN METHODS
+#region MAIN METHODS JUMP
 ####################################################################################################
 
 func jump_to_label(label:String) -> void:
@@ -39,7 +41,7 @@ func jump_to_label(label:String) -> void:
 			break
 		if event is DialogicLabelEvent and event.name == label:
 			break
-	dialogic.current_event_idx = idx
+	dialogic.current_event_idx = idx-1
 	jumped_to_label.emit({'timeline':dialogic.current_timeline, 'label':label})
 
 
@@ -57,4 +59,32 @@ func resume_from_last_jump() -> void:
 func is_jump_stack_empty() -> bool:
 	return len(dialogic.current_state_info['jump_stack']) < 1
 
+#endregion
+
+
+#region MAIN MEHTODS LABELS
+####################################################################################################
+
+func _ready() -> void:
+	passed_label.connect(_on_passed_label)
+
+
+func _on_passed_label(info:Dictionary) -> void:
+	dialogic.current_state_info["last_label"] = info
+
+
+## Returns the identifier name of the last passed label
+func get_last_label_identifier() -> String:
+	if not dialogic.current_state_info.has("last_label"):
+		return ""
+
+	return dialogic.current_state_info["last_label"].identifier
+
+
+## Returns the display name of the last passed label (translated if translation are enabled)
+func get_last_label_name() -> String:
+	if not dialogic.current_state_info.has("last_label"):
+		return ""
+
+	return dialogic.current_state_info["last_label"].display_name
 #endregion

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -57,8 +57,6 @@ var event_color: Color = Color("FBB13C")
 var dialogic_color_name: String = ''
 ## To sort the buttons shown in the editor. Lower index is placed at the top of a category
 var event_sorting_index: int = 0
-## If false the name is not displayed on the event.
-var display_name: bool = true
 ## If true the event will not have a button in the visual editor sidebar
 var disable_editor_button: bool = false
 ## If false the event will hide it's body by default. Recommended for most events


### PR DESCRIPTION
Label events can now be given a "display name", which can be translated. This way you can display the current story section, for example on a save.

The syntax for this is:
`label MyLabel (My Label Display Name)`
e.g.
`label Beginning (The beginning)`

Info about the last passed label can be accessed with Jump.get_lastl_label_identifier and Jump.get_last_label_name() (this might be translated).

- implements #1891
- Might be enough to consider #1918 fixed