### PR TITLE
Remove dedundant text height calculation! Hurray!

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/field_text_multiline.tscn
+++ b/addons/dialogic/Editor/Events/Fields/field_text_multiline.tscn
@@ -14,6 +14,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/normal = ExtResource("1_xq18n")
 wrap_mode = 1
+scroll_fit_content_height = true
 syntax_highlighter = SubResource("SyntaxHighlighter_2q5dk")
 symbol_lookup_on_click = true
 delimiter_strings = Array[String]([])


### PR DESCRIPTION
Due to https://github.com/godotengine/godot/issues/80546 being fixed, we can remove some of our workaround code! Yay. 