### PR TITLE
Fix to autoskip and wait event pausing

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -48,6 +48,7 @@ func resume() -> void:
 func post_install() -> void:
 	dialogic.Settings.connect_to_change('autoadvance_delay_modifier', auto_advance._update_autoadvance_delay_modifier)
 	auto_skip.toggled.connect(_on_autoskip_toggled)
+	auto_skip._init()
 	add_child(input_block_timer)
 	input_block_timer.one_shot = true
 

--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -77,8 +77,8 @@ func _update_saved_connection(to_connect: bool) -> void:
 ####################################################################################################
 
 func _ready() -> void:
-	var _result := dialogic.event_handled.connect(store_full_event)
-	_result = dialogic.event_handled.connect(_check_seen)
+	dialogic.event_handled.connect(store_full_event)
+	dialogic.event_handled.connect(_check_seen)
 
 	simple_history_enabled = ProjectSettings.get_setting('dialogic/history/simple_history_enabled', simple_history_enabled )
 	full_event_history_enabled = ProjectSettings.get_setting('dialogic/history/full_history_enabled', full_event_history_enabled)

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -28,7 +28,7 @@ func _execute() -> void:
 		dialogic.Text.update_dialog_text('')
 		dialogic.Text.hide_textbox()
 	dialogic.current_state = dialogic.States.WAITING
-	await dialogic.get_tree().create_timer(time, true, DialogicUtil.is_physics_timer()).timeout
+	await dialogic.get_tree().create_timer(time, false, DialogicUtil.is_physics_timer()).timeout
 	dialogic.current_state = dialogic.States.IDLE
 
 	finish()


### PR DESCRIPTION
## Fix autoskip enable_on_visited and disable_on_unread_text
These were not working correctly because autoskip did a has_subsystem check before the history subsystem was initialized.

## Make sure wait event timer stops when scene tree is paused
This might be breaking things for people who use the scene tree pausing for dialog, but that's just a bad use of it.

