### PR TITLE
Improve the variable_changed signals and their info dictionaries

### DIFF
--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -2,9 +2,23 @@ extends DialogicSubsystem
 
 ## Subsystem that manages variables and allows to access them.
 
-## Emitted if a dialogic variable changes
+## Emitted if a dialogic variable changes, gives a dictionary with the following keys:[br]
+## [br]
+## Key         |   Value Type  | Value [br]
+## ----------- | ------------- | ----- [br]
+## `variable`  | [type String] | The name of the variable that is getting changed. [br]
+## `new_value` | [type Variant]| The value that [variable] has after the change (the result). [br]
 signal variable_changed(info:Dictionary)
-## Emitted on any set variable event
+
+## Emitted on a set variable event, gives a dictionary with the following keys:[br]
+## [br]
+## Key         |   Value Type  | Value [br]
+## ----------- | ------------- | ----- [br]
+## `variable`  | [type String] | The name of the variable that is getting changed. [br]
+## `orig_value`| [type Variant]| The value that [variable] had before. [br]
+## `new_value` | [type Variant]| The value that [variable] has after the change (the result). [br]
+## `value`     | [type Variant]| The value that the variable is changed by/to. [br]
+## `value_str` | [type String] | Whatever has been given as the value (not interpreted, so a variable is just a string).[br]
 signal variable_was_set(info:Dictionary)
 
 


### PR DESCRIPTION
Improved documentation and implementation of `Dialogic.VAR.variable_was_set` and `Dialogic.VAR.variable_changed`.

The `variable_was_set` `info` now will consitently contain these keys:
```
## `variable`  | [type String] | The name of the variable that is getting changed. [br]
## `orig_value`| [type Variant]| The value that [variable] had before. [br]
## `new_value` | [type Variant]| The value that [variable] has after the change (the result). [br]
## `value`     | [type Variant]| The value that the variable is changed by/to. [br]
## `value_str` | [type String] | Whatever has been given as the value (not interpreted, so a variable is just a string).[br]
```
 - slightly compatibility breaking