### PR TITLE
Fixing relative margin scale

### DIFF
--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -5,10 +5,6 @@ class_name DialogicUtil
 ## Used whenever the same thing is needed in different parts of the plugin.
 
 #region EDITOR
-################################################################################
-static func get_editor_scale() -> float:
-	return get_dialogic_plugin().get_editor_interface().get_editor_scale()
-
 
 ## Although this does in fact always return a EditorPlugin node,
 ##  that class is apparently not present in export and referencing it here creates a crash.
@@ -365,7 +361,7 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 			if value != null:
 				input.color = value
 			input.color_changed.connect(DialogicUtil._on_export_color_submitted.bind(property_info.name, property_changed))
-			input.custom_minimum_size.x = get_editor_scale()*50
+			input.custom_minimum_size.x = EditorInterface.get_editor_scale() * 50
 		TYPE_INT:
 			if property_info['hint'] & PROPERTY_HINT_ENUM:
 				input = OptionButton.new()

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.gd
@@ -14,7 +14,7 @@ func _start_opened() -> bool:
 
 func _ready() -> void:
 	# Connecting all necessary signals
-	%ColorPickerButton.custom_minimum_size.x = DialogicUtil.get_editor_scale()*30
+	%ColorPickerButton.custom_minimum_size.x = EditorInterface.get_editor_scale() * 30
 	%ColorPickerButton.color_changed.connect(character_editor.something_changed)
 	%DisplayNameLineEdit.text_changed.connect(character_editor.something_changed)
 	%NicknameLineEdit.text_changed.connect(character_editor.something_changed)

--- a/addons/dialogic/Editor/Common/DCSS.gd
+++ b/addons/dialogic/Editor/Common/DCSS.gd
@@ -44,7 +44,6 @@ static func inline(style:Dictionary) -> StyleBoxFlat:
 	return s
 
 static func style(node, style:Dictionary) -> StyleBoxFlat:
-	var scale:float = EditorInterface.get_editor_scale()
 	var s:StyleBoxFlat = inline(style)
 	
 	node.set('theme_override_styles/normal', s)

--- a/addons/dialogic/Editor/Common/DCSS.gd
+++ b/addons/dialogic/Editor/Common/DCSS.gd
@@ -1,11 +1,8 @@
 @tool
 class_name DCSS
-
-static func get_editor_scale() -> float:
-	return DialogicUtil.get_editor_scale()
 	
 static func inline(style:Dictionary) -> StyleBoxFlat:
-	var scale:float = get_editor_scale()
+	var scale:float = EditorInterface.get_editor_scale()
 	var s := StyleBoxFlat.new()
 	for property in style.keys():
 		match property:
@@ -47,7 +44,7 @@ static func inline(style:Dictionary) -> StyleBoxFlat:
 	return s
 
 static func style(node, style:Dictionary) -> StyleBoxFlat:
-	var scale:float = get_editor_scale()
+	var scale:float = EditorInterface.get_editor_scale()
 	var s:StyleBoxFlat = inline(style)
 	
 	node.set('theme_override_styles/normal', s)

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -22,10 +22,10 @@ func _ready():
 
 	%ContentList.item_selected.connect(func (idx:int): content_item_activated.emit(%ContentList.get_item_text(idx)))
 
-	var editor_scale := DialogicUtil.get_editor_scale()
+	var editor_scale : float = DialogicUtil.get_editor_scale()
 	## ICONS
 	%Logo.texture = load("res://addons/dialogic/Editor/Images/dialogic-logo.svg")
-	%Logo.custom_minimum_size.y = 30*editor_scale
+	%Logo.custom_minimum_size.y = 30 * editor_scale
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
 
 	%CurrentResource.add_theme_stylebox_override('normal', get_theme_stylebox('normal', 'LineEdit'))
@@ -34,8 +34,8 @@ func _ready():
 	%ContentList.add_theme_color_override("font_selected_color", get_theme_color("property_color_z", "Editor"))
 
 	## MARGINS
-	$VBox/Margin.set("theme_override_constants/margin_left", 4 * editor_scale)
-	$VBox/Margin.set("theme_override_constants/margin_bottom", 4 * editor_scale)
+	$VBox/Margin.set("theme_override_constants/margin_left", get_theme_constant("base_margin", "Editor") * editor_scale)
+	$VBox/Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * editor_scale)
 
 	## RIGHT CLICK MENU
 	%RightClickMenu.clear()

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -22,7 +22,7 @@ func _ready():
 
 	%ContentList.item_selected.connect(func (idx:int): content_item_activated.emit(%ContentList.get_item_text(idx)))
 
-	var editor_scale : float = EditorInterface.get_editor_scale()
+	var editor_scale := EditorInterface.get_editor_scale()
 	## ICONS
 	%Logo.texture = load("res://addons/dialogic/Editor/Images/dialogic-logo.svg")
 	%Logo.custom_minimum_size.y = 30 * editor_scale

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -22,7 +22,7 @@ func _ready():
 
 	%ContentList.item_selected.connect(func (idx:int): content_item_activated.emit(%ContentList.get_item_text(idx)))
 
-	var editor_scale : float = DialogicUtil.get_editor_scale()
+	var editor_scale : float = EditorInterface.get_editor_scale()
 	## ICONS
 	%Logo.texture = load("res://addons/dialogic/Editor/Images/dialogic-logo.svg")
 	%Logo.custom_minimum_size.y = 30 * editor_scale

--- a/addons/dialogic/Editor/Common/toolbar.gd
+++ b/addons/dialogic/Editor/Common/toolbar.gd
@@ -9,8 +9,7 @@ extends HBoxContainer
 func _ready():
 	if owner.get_parent() is SubViewport:
 		return
-	var editor_scale := DialogicUtil.get_editor_scale()
-	%CustomButtons.custom_minimum_size.y = 33*editor_scale
+	%CustomButtons.custom_minimum_size.y = 33 * EditorInterface.get_editor_scale()
 	
 	for child in get_children():
 		if child is Button:

--- a/addons/dialogic/Editor/Events/BranchEnd.gd
+++ b/addons/dialogic/Editor/Events/BranchEnd.gd
@@ -16,7 +16,7 @@ var selected := false
 
 func _ready() -> void:
 	$Icon.icon = get_theme_icon("GuiSpinboxUpdown", "EditorIcons")
-	$Spacer.custom_minimum_size.x = 90*DialogicUtil.get_editor_scale()
+	$Spacer.custom_minimum_size.x = 90 * EditorInterface.get_editor_scale()
 	visual_deselect()
 	parent_node_changed()
 
@@ -59,7 +59,7 @@ func update_hidden_events_indicator(hidden_events_count:int = 0) -> void:
 
 ## Called by the visual timeline editor
 func set_indent(indent: int) -> void:
-	$Indent.custom_minimum_size = Vector2(indent_size * indent*DialogicUtil.get_editor_scale(), 0)
+	$Indent.custom_minimum_size = Vector2(indent_size * indent * EditorInterface.get_editor_scale(), 0)
 	$Indent.visible = indent != 0
 	current_indent_level = indent
 	queue_redraw()

--- a/addons/dialogic/Editor/Events/EventBlock/event_block.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_block.gd
@@ -53,7 +53,7 @@ func _ready():
 
 
 func initialize_ui() -> void:
-	var _scale := DialogicUtil.get_editor_scale()
+	var _scale := EditorInterface.get_editor_scale()
 
 	$PanelContainer.self_modulate = get_theme_color("accent_color", "Editor")
 
@@ -138,7 +138,7 @@ func set_warning(text:String= "") -> void:
 
 
 func set_indent(indent: int) -> void:
-	add_theme_constant_override("margin_left", indent_size*indent*DialogicUtil.get_editor_scale())
+	add_theme_constant_override("margin_left", indent_size * indent * EditorInterface.get_editor_scale())
 	current_indent_level = indent
 
 #endregion
@@ -218,7 +218,7 @@ func build_editor(build_header:bool = true, build_body:bool = false) ->  void:
 			else:
 				editor_node.icon = p.display_info.icon
 			editor_node.flat = true
-			editor_node.custom_minimum_size.x = 30*DialogicUtil.get_editor_scale()
+			editor_node.custom_minimum_size.x = 30 * EditorInterface.get_editor_scale()
 			editor_node.pressed.connect(p.display_info.callable)
 
 		## CUSTOM

--- a/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
@@ -29,7 +29,7 @@ var _v_separation := 0
 var _h_separation := 0
 var _icon_margin := 0
 var _line_height := 24
-var _max_height := 200 * DialogicUtil.get_editor_scale()
+var _max_height := 200 * EditorInterface.get_editor_scale()
 
 
 #region FIELD METHODS
@@ -88,7 +88,7 @@ func _ready() -> void:
 	%Suggestions.hide()
 	%Suggestions.item_selected.connect(suggestion_selected)
 	%Suggestions.item_clicked.connect(suggestion_selected)
-	%Suggestions.fixed_icon_size = Vector2i(16, 16) * DialogicUtil.get_editor_scale()
+	%Suggestions.fixed_icon_size = Vector2i(16, 16) * EditorInterface.get_editor_scale()
 
 	_v_separation = %Suggestions.get_theme_constant("v_separation")
 	_h_separation = %Suggestions.get_theme_constant("h_separation")
@@ -162,7 +162,7 @@ func _on_Search_text_changed(new_text:String, just_update:bool = false) -> void:
 
 	var total_height: int = 0
 	for item in %Suggestions.item_count:
-		total_height += _line_height * DialogicUtil.get_editor_scale() + _v_separation
+		total_height += _line_height * EditorInterface.get_editor_scale() + _v_separation
 	total_height += _v_separation * 2
 	if total_height > _max_height:
 		line_length += %Suggestions.get_v_scroll_bar().get_minimum_size().x

--- a/addons/dialogic/Editor/HomePage/home_page.gd
+++ b/addons/dialogic/Editor/HomePage/home_page.gd
@@ -15,7 +15,7 @@ func _ready():
 	self_modulate = get_theme_color("font_color", "Editor")
 	self_modulate.a = 0.2
 
-	var edit_scale := DialogicUtil.get_editor_scale()
+	var edit_scale := EditorInterface.get_editor_scale()
 	%HomePageBox.custom_minimum_size = Vector2(600, 350)*edit_scale
 	%TopPanel.custom_minimum_size.y = 100*edit_scale
 	%VersionLabel.set('theme_override_font_sizes/font_size', 10 * edit_scale)

--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -86,10 +86,9 @@ func update_color_palette() -> void:
 	# Color Palette
 	for child in %Colors.get_children():
 		child.queue_free()
-	var _scale := EditorInterface.get_editor_scale()
 	for color in DialogicUtil.get_color_palette():
 		var button := ColorPickerButton.new()
-		button.custom_minimum_size = Vector2(50 ,50)*scale
+		button.custom_minimum_size = Vector2(50 ,50) * EditorInterface.get_editor_scale()
 		%Colors.add_child(button)
 		button.color = DialogicUtil.get_color(color)
 		button.color_changed.connect(_on_color_change)

--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -86,7 +86,7 @@ func update_color_palette() -> void:
 	# Color Palette
 	for child in %Colors.get_children():
 		child.queue_free()
-	var _scale := DialogicUtil.get_editor_scale()
+	var _scale := EditorInterface.get_editor_scale()
 	for color in DialogicUtil.get_color_palette():
 		var button := ColorPickerButton.new()
 		button.custom_minimum_size = Vector2(50 ,50)*scale

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
@@ -25,12 +25,11 @@ func _ready() -> void:
 
 
 func apply_base_button_style() -> void:
-	var scale := EditorInterface.get_editor_scale()
 	var nstyle :StyleBoxFlat= get_parent().get_theme_stylebox('normal', 'Button').duplicate()
-	nstyle.border_width_left = 5 *scale
+	nstyle.border_width_left = 5 * EditorInterface.get_editor_scale()
 	add_theme_stylebox_override('normal', nstyle)
 	var hstyle :StyleBoxFlat= get_parent().get_theme_stylebox('hover', 'Button').duplicate()
-	hstyle.border_width_left = 5 *scale
+	hstyle.border_width_left = 5 * EditorInterface.get_editor_scale()
 	add_theme_stylebox_override('hover', hstyle)
 	set_color(resource.event_color)
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
@@ -17,7 +17,7 @@ extends Button
 func _ready() -> void:
 	tooltip_text = visible_name
 	
-	custom_minimum_size = Vector2(get_theme_font("font", 'Label').get_string_size(text).x+35,30)* DialogicUtil.get_editor_scale()
+	custom_minimum_size = Vector2(get_theme_font("font", 'Label').get_string_size(text).x+35,30) * EditorInterface.get_editor_scale()
 	
 	add_theme_color_override("font_color", get_theme_color("font_color", "Editor"))
 	add_theme_color_override("font_color_hover", get_theme_color("accent_color", "Editor"))
@@ -25,7 +25,7 @@ func _ready() -> void:
 
 
 func apply_base_button_style() -> void:
-	var scale := DialogicUtil.get_editor_scale()
+	var scale := EditorInterface.get_editor_scale()
 	var nstyle :StyleBoxFlat= get_parent().get_theme_stylebox('normal', 'Button').duplicate()
 	nstyle.border_width_left = 5 *scale
 	add_theme_stylebox_override('normal', nstyle)
@@ -47,7 +47,7 @@ func set_color(color:Color) -> void:
 func toggle_name(on:= false) -> void:
 	if !on:
 		text = ""
-		custom_minimum_size = Vector2(40, 40)*DialogicUtil.get_editor_scale()
+		custom_minimum_size = Vector2(40, 40) * EditorInterface.get_editor_scale()
 		var style := get_theme_stylebox('normal', 'Button')
 		style.bg_color = style.border_color.darkened(0.2)
 		add_theme_stylebox_override('normal', style)
@@ -56,7 +56,7 @@ func toggle_name(on:= false) -> void:
 		add_theme_stylebox_override('hover', style)
 	else:
 		text = visible_name
-		custom_minimum_size = Vector2(get_theme_font("font", 'Label').get_string_size(text).x+35,30)* DialogicUtil.get_editor_scale()
+		custom_minimum_size = Vector2(get_theme_font("font", 'Label').get_string_size(text).x+35,30) * EditorInterface.get_editor_scale()
 		apply_base_button_style()
 
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
@@ -74,9 +74,8 @@ func finish_dragging():
 ################################################################################
 
 func _draw() -> void:
-	var _scale := EditorInterface.get_editor_scale()
-	var line_width := 5 * _scale
-	var horizontal_line_length := 100 * _scale
+	var line_width := 5 * EditorInterface.get_editor_scale()
+	var horizontal_line_length := 100 * EditorInterface.get_editor_scale()
 	var color_multiplier := Color(1,1,1,0.25)
 	var selected_color_multiplier := Color(1,1,1,1)
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
@@ -74,9 +74,9 @@ func finish_dragging():
 ################################################################################
 
 func _draw() -> void:
-	var _scale := DialogicUtil.get_editor_scale()
+	var _scale := EditorInterface.get_editor_scale()
 	var line_width := 5 * _scale
-	var horizontal_line_length := 100*_scale
+	var horizontal_line_length := 100 * _scale
 	var color_multiplier := Color(1,1,1,0.25)
 	var selected_color_multiplier := Color(1,1,1,1)
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -164,7 +164,7 @@ func _ready() -> void:
 	timeline_editor.editors_manager.sidebar.content_item_activated.connect(_on_content_item_clicked)
 	%Timeline.child_order_changed.connect(update_content_list)
 
-	var editor_scale := DialogicUtil.get_editor_scale()
+	var editor_scale := EditorInterface.get_editor_scale()
 	%RightSidebar.size.x = DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
 	$View.split_offset = -DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_width", 200 * editor_scale)
 	sidebar_collapsed = DialogicUtil.get_editor_setting("dialogic/editor/right_sidebar_collapsed", false)
@@ -257,8 +257,7 @@ func load_event_buttons() -> void:
 			%RightSidebar.get_child(0).move_child(%RightSidebar.get_child(0).get_node(section_name), 0)
 
 	# Resize RightSidebar
-	var _scale := DialogicUtil.get_editor_scale()
-	%RightSidebar.custom_minimum_size.x = 50 * _scale
+	%RightSidebar.custom_minimum_size.x = 50 * EditorInterface.get_editor_scale()
 
 	_on_right_sidebar_resized()
 #endregion
@@ -937,7 +936,7 @@ func _on_event_popup_menu_index_pressed(index:int) -> void:
 
 
 func _on_right_sidebar_resized() -> void:
-	var _scale := DialogicUtil.get_editor_scale()
+	var _scale := EditorInterface.get_editor_scale()
 
 	if %RightSidebar.size.x < 160 * _scale and (not sidebar_collapsed or not _initialized):
 		sidebar_collapsed = true

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -152,8 +152,7 @@ func _ready():
 	%SwitchEditorMode.text = "Text editor"
 	%SwitchEditorMode.icon = get_theme_icon("ArrowRight", "EditorIcons")
 	%SwitchEditorMode.pressed.connect(toggle_editor_mode)
-	var _scale := DialogicUtil.get_editor_scale()
-	%SwitchEditorMode.custom_minimum_size.x = 200 * _scale
+	%SwitchEditorMode.custom_minimum_size.x = 200 * EditorInterface.get_editor_scale()
 
 
 

--- a/addons/dialogic/Editor/editor_main.gd
+++ b/addons/dialogic/Editor/editor_main.gd
@@ -28,6 +28,8 @@ func _ready() -> void:
 	editor_tab_bg.border_color = get_theme_color("base_color", "Editor")
 	editor_tab_bg.bg_color = get_theme_color("dark_color_2", "Editor")
 	$Margin/EditorsManager.editors_holder.add_theme_stylebox_override('panel', editor_tab_bg)
+	$Margin.set("theme_override_constants/margin_right", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
+	$Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
 
 	# File dialog
 	editor_file_dialog = EditorFileDialog.new()

--- a/addons/dialogic/Editor/editor_main.gd
+++ b/addons/dialogic/Editor/editor_main.gd
@@ -28,8 +28,8 @@ func _ready() -> void:
 	editor_tab_bg.border_color = get_theme_color("base_color", "Editor")
 	editor_tab_bg.bg_color = get_theme_color("dark_color_2", "Editor")
 	$Margin/EditorsManager.editors_holder.add_theme_stylebox_override('panel', editor_tab_bg)
-	$Margin.set("theme_override_constants/margin_right", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
-	$Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
+	$Margin.set("theme_override_constants/margin_right", get_theme_constant("base_margin", "Editor") * EditorInterface.get_editor_scale())
+	$Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * EditorInterface.get_editor_scale())
 
 	# File dialog
 	editor_file_dialog = EditorFileDialog.new()

--- a/addons/dialogic/Editor/editors_manager.gd
+++ b/addons/dialogic/Editor/editors_manager.gd
@@ -7,6 +7,7 @@ signal resource_opened(resource)
 signal editor_changed(previous, current)
 
 ### References
+@onready var hsplit = $HSplit
 @onready var sidebar = $HSplit/Sidebar
 @onready var editors_holder = $HSplit/VBox/Editors
 @onready var toolbar = $HSplit/VBox/Toolbar
@@ -64,6 +65,8 @@ func _ready() -> void:
 
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_file_system_dock().files_moved.connect(_on_file_moved)
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_file_system_dock().file_removed.connect(_on_file_removed)
+	
+	hsplit.set("theme_override_constants/separation", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
 
 
 func _add_editor(path:String) -> void:

--- a/addons/dialogic/Editor/editors_manager.gd
+++ b/addons/dialogic/Editor/editors_manager.gd
@@ -66,7 +66,7 @@ func _ready() -> void:
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_file_system_dock().files_moved.connect(_on_file_moved)
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_file_system_dock().file_removed.connect(_on_file_removed)
 	
-	hsplit.set("theme_override_constants/separation", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
+	hsplit.set("theme_override_constants/separation", get_theme_constant("base_margin", "Editor") * EditorInterface.get_editor_scale())
 
 
 func _add_editor(path:String) -> void:

--- a/addons/dialogic/Modules/StyleEditor/Components/StyleItem.gd
+++ b/addons/dialogic/Modules/StyleEditor/Components/StyleItem.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
 		return
 
 	%Name.add_theme_font_override("font", get_theme_font("bold", "EditorFonts"))
-	custom_minimum_size = base_size*Vector2(200, 150)*DialogicUtil.get_editor_scale()
+	custom_minimum_size = base_size*Vector2(200, 150) * EditorInterface.get_editor_scale()
 	%CurrentIcon.texture = get_theme_icon("Favorites", "EditorIcons")
 	if %Image.texture == null:
 		%Image.texture = get_theme_icon("ImportFail", "EditorIcons")

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -27,7 +27,7 @@ func _ready() -> void:
 	%ReplaceLayerButton.get_popup().index_pressed.connect(_on_replace_layer_menu_pressed)
 	%MakeCustomButton.get_popup().index_pressed.connect(_on_make_custom_menu_pressed)
 	%LayerTree.item_selected.connect(_on_layer_selected)
-	_minimum_tree_item_height = int(DialogicUtil.get_editor_scale() * 32)
+	_minimum_tree_item_height = int(EditorInterface.get_editor_scale() * 32)
 	%LayerTree.add_theme_constant_override("icon_max_width", _minimum_tree_item_height)
 
 


### PR DESCRIPTION
The calculation of the margin based on the editor scale and the new godot editor theme were not properly set (used magic numbers). 

## Before
<img width="1512" alt="image" src="https://github.com/dialogic-godot/dialogic/assets/2206700/0ca9ccf1-2e7a-44ba-b49f-a189a8e6c838">

## After
<img width="1511" alt="image" src="https://github.com/dialogic-godot/dialogic/assets/2206700/15aa8211-4b00-4c02-8359-11ef4be544be">
