### PR TITLE
Update subsystem history.

### DIFF
--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -65,7 +65,7 @@ func _update_saved_connection(to_connect: bool) -> void:
 	if to_connect:
 
 		if not DialogicUtil.autoload().Save.saved.is_connected(_on_save):
-			var _result := DialogicUtil.autoload().Save.saved.connect(_on_save)
+			var _result:int = DialogicUtil.autoload().Save.saved.connect(_on_save)
 
 	else:
 

--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -63,12 +63,10 @@ var save_visited_history_on_save := false:
 ## Starts and stops the connection to the [subsystem Save] subsystem's [signal saved] signal.
 func _update_saved_connection(to_connect: bool) -> void:
 	if to_connect:
-
 		if not DialogicUtil.autoload().Save.saved.is_connected(_on_save):
-			var _result:int = DialogicUtil.autoload().Save.saved.connect(_on_save)
+			DialogicUtil.autoload().Save.saved.connect(_on_save)
 
 	else:
-
 		if DialogicUtil.autoload().Save.saved.is_connected(_on_save):
 			DialogicUtil.autoload().Save.saved.disconnect(_on_save)
 


### PR DESCRIPTION
_Hello everyone, did you miss me?_

Update variable type for _result instead of letting the engine guessing the type. 

For some reason in 4.3 (https://github.com/godotengine/godot/issues/92021 probably) can't guess the type of _that very specific line_, maybe because can't even parse the referenced class so it just throw it as variant and let it work until fails?

This _kinda_ works (as is just a solution in place that solved Emi traceback). Tested with https://github.com/dialogic-godot/test-project exporting to linux, using Godot v4.3.dev6.official [64520fe67].

It may fix https://github.com/dialogic-godot/dialogic/issues/2231 ? I'm not sure, that traceback seems more related to Editor* classes being referenced in exported game

