### PR TITLE
Update TimelineResourceLoader.

### DIFF
--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -26,10 +26,14 @@ func _handles_type(typename: StringName) -> bool:
 
 # parse the file and return a resource
 func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int):
-	if ResourceLoader.exists(path):
-		var file := FileAccess.open(path, FileAccess.READ)
-
-		var tml := DialogicTimeline.new()
-		tml.from_text(file.get_as_text())
-
-		return tml
+	var file := FileAccess.open(path, FileAccess.READ)
+	
+	if not file:
+		# For now, just let editor know that for some reason you can't
+		# read the file.
+		print("[Dialogic] Error opening file:", FileAccess.get_open_error())
+		return FileAccess.get_open_error()
+	
+	var tml := DialogicTimeline.new()
+	tml.from_text(file.get_as_text())
+	return tml


### PR DESCRIPTION
Add the most generic error handler that will ever exist, just to ensure proper debug on load error.

The editor will probably crash if you're forcing the load somewhere and not verifying that `ResourceLoader.load` returns `null` (same as before this PR, but without a log that indicates where)