### PR TITLE
Remove unused `dialogic_save` signal

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -155,7 +155,6 @@ func clear_timeline_nodes() -> void:
 ################################################################################
 
 func _ready() -> void:
-	DialogicUtil.get_dialogic_plugin().dialogic_save.connect(save_timeline)
 	event_node = load("res://addons/dialogic/Editor/Events/EventBlock/event_block.tscn")
 
 	batch_loaded.connect(_on_batch_loaded)

--- a/addons/dialogic/plugin.gd
+++ b/addons/dialogic/plugin.gd
@@ -11,10 +11,6 @@ const PLUGIN_ICON_PATH := "res://addons/dialogic/Editor/Images/plugin-icon.svg"
 var editor_view: Control  # the root of the dialogic editor
 
 
-## Signal emitted if godot wants us to save
-signal dialogic_save
-
-
 ## Initialization
 func _init() -> void:
 	self.name = "DialogicPlugin"


### PR DESCRIPTION
This PR removes `dialogic_save` signal which is not emitted anywhere in the code.