### PR TITLE
Add close button to reference manager

### DIFF
--- a/addons/dialogic/Editor/Common/reference_manager.gd
+++ b/addons/dialogic/Editor/Common/reference_manager.gd
@@ -7,6 +7,7 @@ func _ready() -> void:
 		return
 
 	add_theme_stylebox_override("panel", get_theme_stylebox("Background", "EditorStyles"))
+	$Tabs/Close.icon = get_theme_icon("Close", "EditorIcons")
 
 	for tab in $Tabs/Tabs.get_children():
 		tab.add_theme_color_override("font_selected_color", get_theme_color("accent_color", "Editor"))
@@ -31,3 +32,7 @@ func tab_changed(enabled:bool, index:int) -> void:
 func open():
 	show()
 	$Tabs/BrokenReferences.update_indicator()
+
+
+func _on_close_pressed() -> void:
+	get_parent()._on_close_requested()

--- a/addons/dialogic/Editor/Common/reference_manager.tscn
+++ b/addons/dialogic/Editor/Common/reference_manager.tscn
@@ -298,6 +298,11 @@ layout_mode = 2
 text = "You've renamed some identifier(s)! Use the \"Broken References\" tab to check if you have used this identifier (and fix it if so)."
 autowrap_mode = 3
 
+[node name="Close" type="Button" parent="Tabs"]
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Close"
+
 [node name="HelpButton" type="LinkButton" parent="."]
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
@@ -317,3 +322,4 @@ uri = "https://docs.dialogic.pro/reference-manager.html"
 [connection signal="text_changed" from="Tabs/UniqueIdentifiers/VBox/Tools/Search" to="Tabs/UniqueIdentifiers" method="_on_search_text_changed"]
 [connection signal="button_clicked" from="Tabs/UniqueIdentifiers/VBox/IdentifierTable" to="Tabs/UniqueIdentifiers" method="_on_identifier_table_button_clicked"]
 [connection signal="item_edited" from="Tabs/UniqueIdentifiers/VBox/IdentifierTable" to="Tabs/UniqueIdentifiers" method="_on_identifier_table_item_edited"]
+[connection signal="pressed" from="Tabs/Close" to="." method="_on_close_pressed"]


### PR DESCRIPTION
This PR adds a close button to the reference manager popup, so it looks like this in a window manager (like i3):

![image](https://github.com/dialogic-godot/dialogic/assets/33421921/3f85d9bf-dee5-4dd7-b93a-2ce13ffd32e9)


Fixes #2260.