### PR TITLE
Fix event_clear.gd class_name typo

### DIFF
--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -1,5 +1,5 @@
 @tool
-class_name DialogiClearEvent
+class_name DialogicClearEvent
 extends DialogicEvent
 
 ## Event that clears audio & visuals (not variables).


### PR DESCRIPTION
class_name was DialogiClearEvent
Changed to DialogicClearEvent