### PR TITLE
Add scroll container to Dialogic UI

### DIFF
--- a/addons/dialogic/Editor/Common/reference_manager_window.gd
+++ b/addons/dialogic/Editor/Common/reference_manager_window.gd
@@ -5,7 +5,7 @@ extends Window
 ## Other scripts can call the add_ref_change() method to register changes directly
 ##   or use the helpers add_variable_ref_change() and add_portrait_ref_change()
 
-@onready var editors_manager := get_node("../Margin/EditorsManager")
+@onready var editors_manager := get_node("../Scroll/Margin/EditorsManager")
 @onready var broken_manager := get_node("Manager/Tabs/BrokenReferences")
 enum Where {EVERYWHERE, BY_CHARACTER, TEXTS_ONLY}
 enum Types {TEXT, VARIABLE, PORTRAIT, CHARACTER_NAME, TIMELINE_NAME}

--- a/addons/dialogic/Editor/editor_main.gd
+++ b/addons/dialogic/Editor/editor_main.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 		return
 
 	## REFERENCES
-	editors_manager = $Margin/EditorsManager
+	editors_manager = $Scroll/Margin/EditorsManager
 	var button :Button = editors_manager.add_icon_button(get_theme_icon("MakeFloating", "EditorIcons"), 'Make floating')
 	button.pressed.connect(toggle_floating_window)
 
@@ -27,9 +27,9 @@ func _ready() -> void:
 	$BG.color = get_theme_color("base_color", "Editor")
 	editor_tab_bg.border_color = get_theme_color("base_color", "Editor")
 	editor_tab_bg.bg_color = get_theme_color("dark_color_2", "Editor")
-	$Margin/EditorsManager.editors_holder.add_theme_stylebox_override('panel', editor_tab_bg)
-	$Margin.set("theme_override_constants/margin_right", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
-	$Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
+	$Scroll/Margin/EditorsManager.editors_holder.add_theme_stylebox_override('panel', editor_tab_bg)
+	$Scroll/Margin.set("theme_override_constants/margin_right", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
+	$Scroll/Margin.set("theme_override_constants/margin_bottom", get_theme_constant("base_margin", "Editor") * DialogicUtil.get_editor_scale())
 
 	# File dialog
 	editor_file_dialog = EditorFileDialog.new()

--- a/addons/dialogic/Editor/editor_main.tscn
+++ b/addons/dialogic/Editor/editor_main.tscn
@@ -71,20 +71,26 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.0588235, 0.0980392, 0.141176, 1)
 
-[node name="Margin" type="MarginContainer" parent="."]
-layout_mode = 2
+[node name="Scroll" type="ScrollContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+
+[node name="Margin" type="MarginContainer" parent="Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 2
 
-[node name="EditorsManager" type="Control" parent="Margin"]
+[node name="EditorsManager" type="Control" parent="Scroll/Margin"]
 layout_mode = 2
 script = ExtResource("2_pe2tl")
 
-[node name="HSplit" type="HSplitContainer" parent="Margin/EditorsManager"]
+[node name="HSplit" type="HSplitContainer" parent="Scroll/Margin/EditorsManager"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -95,24 +101,24 @@ size_flags_vertical = 3
 theme_override_constants/separation = 0
 split_offset = 150
 
-[node name="Sidebar" parent="Margin/EditorsManager/HSplit" instance=ExtResource("3_lp6hj")]
+[node name="Sidebar" parent="Scroll/Margin/EditorsManager/HSplit" instance=ExtResource("3_lp6hj")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(20, 0)
 layout_mode = 2
 split_offset = 0
 
-[node name="VBox" type="VBoxContainer" parent="Margin/EditorsManager/HSplit"]
+[node name="VBox" type="VBoxContainer" parent="Scroll/Margin/EditorsManager/HSplit"]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="Toolbar" type="HBoxContainer" parent="Margin/EditorsManager/HSplit/VBox"]
+[node name="Toolbar" type="HBoxContainer" parent="Scroll/Margin/EditorsManager/HSplit/VBox"]
 layout_mode = 2
 size_flags_vertical = 0
 mouse_filter = 2
 alignment = 2
 script = ExtResource("4_6cx8s")
 
-[node name="EditorTabBar" type="TabBar" parent="Margin/EditorsManager/HSplit/VBox/Toolbar"]
+[node name="EditorTabBar" type="TabBar" parent="Scroll/Margin/EditorsManager/HSplit/VBox/Toolbar"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 8
@@ -132,15 +138,15 @@ tab_5/icon = ExtResource("9_k4reh")
 tab_6/title = "Settings"
 tab_6/icon = SubResource("ImageTexture_drcn6")
 
-[node name="CustomButtons" type="HBoxContainer" parent="Margin/EditorsManager/HSplit/VBox/Toolbar"]
+[node name="CustomButtons" type="HBoxContainer" parent="Scroll/Margin/EditorsManager/HSplit/VBox/Toolbar"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Editors" type="PanelContainer" parent="Margin/EditorsManager/HSplit/VBox"]
+[node name="Editors" type="PanelContainer" parent="Scroll/Margin/EditorsManager/HSplit/VBox"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="CodeCompletionHelper" type="Node" parent="Margin/EditorsManager"]
+[node name="CodeCompletionHelper" type="Node" parent="Scroll/Margin/EditorsManager"]
 script = ExtResource("11_fyce4")
 
 [node name="SaveConfirmationDialog" type="AcceptDialog" parent="."]


### PR DESCRIPTION
This PR wraps the Dialogic UI in a `ScrollContainer` node in order so that the contents are restricted and do not overflow. Fixes #2267.

![image](https://github.com/dialogic-godot/dialogic/assets/33421921/d03a69b9-13b5-40ed-aa87-ad2b2c5793f3)
