### PR TITLE
Fix bug where 2 copies of a character are created on state load

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -30,6 +30,8 @@ func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
 		dialogic.current_state_info["portraits"] = {}
 
 	var portraits_info: Dictionary = dialogic.current_state_info.portraits.duplicate()
+	if load_flag != LoadFlags.ONLY_DNODES:
+		leave_all_characters("InstantInOrOut", 0.0, false)
 	dialogic.current_state_info.portraits = {}
 	for character_path in portraits_info:
 		var character_info: Dictionary = portraits_info[character_path]


### PR DESCRIPTION
When you load from state, currently the portraits get loaded twice - once during style load, and a second time during portrait subsystem load.

The reason is this line here:
`dialogic.current_state_info.portraits = {}`

when a character is added, it's supposed to clear out old copies of itself, but since it's not in the current state info on the second pass, it doesn't see that the character is already there, and makes a second copy.

This gets awkward when you try to continue the story and oops - the character animates out but the second copy stays, so the character doesn't leave.

Bug fix is that, if we're going to be setting portraits to {}, first have all present characters instantly leave.