### PR TITLE
Implement search in timeline editors

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -250,6 +250,8 @@ func search_navigate(navigate_up := false) -> void:
 
 	pos = search(get_meta("current_search"), 4 if navigate_up else 0, search_from_line, search_from_column)
 	select(pos.y, pos.x, pos.y, pos.x+len(get_meta("current_search")))
+	set_caret_line(pos.y)
+	center_viewport_to_caret()
 	queue_redraw()
 
 

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -240,7 +240,7 @@ func search_navigate(navigate_up := false) -> void:
 					search_from_line = get_line_count()
 				else:
 					search_from_line -= 1
-				search_from_column = get_line(search_from_line).length()-1
+				search_from_column = max(get_line(search_from_line).length()-1,0)
 		else:
 			search_from_line = get_selection_to_line()
 			search_from_column = get_selection_to_column()

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -209,20 +209,21 @@ func _on_content_item_clicked(label:String) -> void:
 			return
 
 
-func _search_timeline(search_text:String) -> void:
+func _search_timeline(search_text:String) -> bool:
 	set_search_text(search_text)
 	queue_redraw()
 	set_meta("current_search", search_text)
 
+	return search(search_text, 0, 0, 0).y != -1
 
-func _get_search_text() -> String:
-	return ""
 
 func _search_navigate_down() -> void:
 	search_navigate(false)
 
+
 func _search_navigate_up() -> void:
 	search_navigate(true)
+
 
 func search_navigate(navigate_up := false) -> void:
 	if not has_meta("current_search"):

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -209,6 +209,49 @@ func _on_content_item_clicked(label:String) -> void:
 			return
 
 
+func _search_timeline(search_text:String) -> void:
+	set_search_text(search_text)
+	queue_redraw()
+	set_meta("current_search", search_text)
+
+
+func _get_search_text() -> String:
+	return ""
+
+func _search_navigate_down() -> void:
+	search_navigate(false)
+
+func _search_navigate_up() -> void:
+	search_navigate(true)
+
+func search_navigate(navigate_up := false) -> void:
+	if not has_meta("current_search"):
+		return
+	var pos: Vector2i
+	var search_from_line := 0
+	var search_from_column := 0
+	if has_selection():
+		if navigate_up:
+			search_from_line = get_selection_from_line()
+			search_from_column = get_selection_from_column()-1
+			if search_from_column == -1:
+				if search_from_line == 0:
+					search_from_line = get_line_count()
+				else:
+					search_from_line -= 1
+				search_from_column = get_line(search_from_line).length()-1
+		else:
+			search_from_line = get_selection_to_line()
+			search_from_column = get_selection_to_column()
+	else:
+		search_from_line = get_caret_line()
+		search_from_column = get_caret_column()
+
+	pos = search(get_meta("current_search"), 4 if navigate_up else 0, search_from_line, search_from_column)
+	select(pos.y, pos.x, pos.y, pos.x+len(get_meta("current_search")))
+	queue_redraw()
+
+
 ################################################################################
 ## 					AUTO COMPLETION
 ################################################################################

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1171,3 +1171,20 @@ func get_previous_character(double_previous := false) -> DialogicCharacter:
 	return character
 
 #endregion
+
+var search_results := []
+func _search_timeline(search_text:String) -> void:
+	search_results.clear()
+
+	for block in %Timeline.get_children():
+		if block.resource is DialogicTextEvent:
+			pass
+
+func _get_search_text() -> String:
+	return ""
+
+func _search_navigate_down() -> void:
+	pass
+
+func _search_navigate_up() -> void:
+	pass

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1172,19 +1172,105 @@ func get_previous_character(double_previous := false) -> DialogicCharacter:
 
 #endregion
 
-var search_results := []
-func _search_timeline(search_text:String) -> void:
+#region SEARCH
+################################################################################
+
+var search_results := {}
+func _search_timeline(search_text:String) -> bool:
+	for event in search_results:
+		if is_instance_valid(search_results[event]):
+			search_results[event].set_search_text("")
+			search_results[event].deselect()
+			search_results[event].queue_redraw()
 	search_results.clear()
 
 	for block in %Timeline.get_children():
 		if block.resource is DialogicTextEvent:
-			pass
+			var text_field: TextEdit = block.get_node("%BodyContent").find_child("Field_Text_Multiline", true, false)
+			text_field.set_search_text(search_text)
+			if text_field.search(search_text, 0, 0, 0).x != -1:
+				search_results[block] = text_field
+				text_field.queue_redraw()
+	set_meta("current_search", search_text)
+	search_navigate(false)
+	return not search_results.is_empty()
 
-func _get_search_text() -> String:
-	return ""
 
 func _search_navigate_down() -> void:
-	pass
+	search_navigate(false)
+
 
 func _search_navigate_up() -> void:
-	pass
+	search_navigate(true)
+
+
+func search_navigate(navigate_up := false) -> void:
+	var search_text: String = get_meta("current_search", "")
+
+	if search_results.is_empty() or %Timeline.get_child_count() == 0:
+		return
+	if selected_items.is_empty():
+		select_item(%Timeline.get_child(0), false)
+
+	while not selected_items[0] in search_results:
+		select_item(%Timeline.get_child(wrapi(selected_items[0].get_index()+1, 0, %Timeline.get_child_count()-1)), false)
+
+	var event: Node = selected_items[0]
+	var counter := 0
+	while true:
+		counter += 1
+		var field: TextEdit = search_results[event]
+		field.queue_redraw()
+		var result := search_text_field(field, search_text, navigate_up)
+		var current_line := field.get_selection_from_line() if field.has_selection() else -1
+		var current_column := field.get_selection_from_column() if field.has_selection() else -1
+		var next_is_in_this_event := false
+		if result.y == -1:
+			next_is_in_this_event = false
+		elif navigate_up:
+			if current_line == -1:
+				current_line = field.get_line_count()-1
+				current_column = field.get_line(current_line).length()
+			next_is_in_this_event = result.x < current_column or result.y < current_line
+		else:
+			next_is_in_this_event = result.x > current_column or result.y > current_line
+
+		if next_is_in_this_event:
+			if not event in selected_items:
+				select_item(event, false)
+			%TimelineArea.ensure_control_visible(event)
+			event._on_ToggleBodyVisibility_toggled(true)
+			field.select(result.y, result.x, result.y, result.x+len(search_text))
+			break
+
+		else:
+			field.deselect()
+			var index := search_results.keys().find(event)
+			event = search_results.keys()[wrapi(index+(-1 if navigate_up else 1), 0, search_results.size())]
+
+		if counter > 5:
+			print("FAIL")
+			break
+
+
+func search_text_field(field:TextEdit, search_text := "", navigate_up:= false) -> Vector2i:
+	var search_from_line: int = 0
+	var search_from_column: int = 0
+	if field.has_selection():
+		if navigate_up:
+			search_from_line = field.get_selection_from_line()
+			search_from_column = field.get_selection_from_column()-1
+			if search_from_column == -1:
+				search_from_line -= 1
+				search_from_column = field.get_line(search_from_line).length()-1
+		else:
+			search_from_line = field.get_selection_to_line()
+			search_from_column = field.get_selection_to_column()
+	else:
+		if navigate_up:
+			search_from_line = field.get_line_count()-1
+			search_from_column = field.get_line(search_from_line).length()-1
+	var search := field.search(search_text, 4 if navigate_up else 0, search_from_line, search_from_column)
+	return search
+
+#endregion

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1249,7 +1249,7 @@ func search_navigate(navigate_up := false) -> void:
 			event = search_results.keys()[wrapi(index+(-1 if navigate_up else 1), 0, search_results.size())]
 
 		if counter > 5:
-			print("FAIL")
+			print("[Dialogic] Search failed.")
 			break
 
 
@@ -1262,6 +1262,8 @@ func search_text_field(field:TextEdit, search_text := "", navigate_up:= false) -
 			search_from_column = field.get_selection_from_column()-1
 			if search_from_column == -1:
 				search_from_line -= 1
+				if search_from_line == -1:
+					return Vector2i(-1, -1)
 				search_from_column = field.get_line(search_from_line).length()-1
 		else:
 			search_from_line = field.get_selection_to_line()
@@ -1270,6 +1272,7 @@ func search_text_field(field:TextEdit, search_text := "", navigate_up:= false) -
 		if navigate_up:
 			search_from_line = field.get_line_count()-1
 			search_from_column = field.get_line(search_from_line).length()-1
+
 	var search := field.search(search_text, 4 if navigate_up else 0, search_from_line, search_from_column)
 	return search
 

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -127,7 +127,7 @@ func toggle_editor_mode() -> void:
 			%VisualEditor.load_timeline(current_resource)
 			%VisualEditor.show()
 			%SwitchEditorMode.text = "Text Editor"
-
+	_on_search_text_changed(%Search.text)
 	DialogicUtil.set_editor_setting('timeline_editor_mode', current_editor_mode)
 
 
@@ -206,6 +206,7 @@ func search_timeline() -> void:
 
 func _on_close_search_pressed() -> void:
 	%SearchSection.hide()
+	%Search.text = ""
 	_on_search_text_changed('')
 
 
@@ -214,9 +215,11 @@ func _on_search_text_changed(new_text: String) -> void:
 	var anything_found: bool = get_current_editor()._search_timeline(new_text)
 	if anything_found or new_text.is_empty():
 		%SearchLabel.hide()
+		%Search.add_theme_color_override("font_color", get_theme_color("font_color", "Editor"))
 	else:
 		%SearchLabel.show()
 		%SearchLabel.add_theme_color_override("font_color", get_theme_color("error_color", "Editor"))
+		%Search.add_theme_color_override("font_color", get_theme_color("error_color", "Editor"))
 		%SearchLabel.text = "No Match"
 
 

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -84,12 +84,18 @@ func _save() -> void:
 
 
 func _input(event: InputEvent) -> void:
-	var keycode := KEY_F5
-	if OS.get_name() == "macOS":
-		keycode = KEY_B
-	if event is InputEventKey and event.keycode == keycode and event.pressed:
-		if Input.is_key_pressed(KEY_CTRL):
-			play_timeline()
+	if event is InputEventKey:
+		var keycode := KEY_F5
+		if OS.get_name() == "macOS":
+			keycode = KEY_B
+		if event.keycode == keycode and event.pressed:
+			if Input.is_key_pressed(KEY_CTRL):
+				play_timeline()
+
+		if event.keycode == KEY_F and event.pressed:
+			if Input.is_key_pressed(KEY_CTRL):
+				if is_ancestor_of(get_viewport().gui_get_focus_owner()):
+					search_timeline()
 
 
 ## Method to play the current timeline. Connected to the button in the sidebar.
@@ -154,7 +160,9 @@ func _ready() -> void:
 	%SwitchEditorMode.pressed.connect(toggle_editor_mode)
 	%SwitchEditorMode.custom_minimum_size.x = 200 * DialogicUtil.get_editor_scale()
 
-
+	%SearchClose.icon = get_theme_icon("Close", "EditorIcons")
+	%SearchUp.icon = get_theme_icon("MoveUp", "EditorIcons")
+	%SearchDown.icon = get_theme_icon("MoveDown", "EditorIcons")
 
 
 
@@ -177,3 +185,51 @@ func _clear() -> void:
 			%TextEditor.clear_timeline()
 	$NoTimelineScreen.show()
 	play_timeline_button.disabled = true
+
+
+#region SEARCH
+
+func search_timeline() -> void:
+	%SearchSection.show()
+	if get_viewport().gui_get_focus_owner() is TextEdit:
+		%Search.text = get_viewport().gui_get_focus_owner().get_selected_text()
+		_on_search_text_changed(%Search.text)
+	else:
+		%Search.text = ""
+	%Search.grab_focus()
+
+
+func _on_close_search_pressed() -> void:
+	%SearchSection.hide()
+	_on_search_text_changed('')
+
+
+func _on_search_text_changed(new_text: String) -> void:
+	var editor: Node = null
+	match current_editor_mode:
+		0:
+			editor = %VisualEditor
+		1:
+			editor = %TextEditor
+	editor._search_timeline(new_text)
+	%SearchLabel.text = editor._get_search_text()
+
+
+
+func _on_search_down_pressed() -> void:
+	match current_editor_mode:
+		0:
+			%VisualEditor._search_navigate_down()
+		1:
+			%TextEditor._search_navigate_down()
+
+func _on_search_up_pressed() -> void:
+	match current_editor_mode:
+		0:
+			%VisualEditor._search_navigate_up()
+		1:
+			%TextEditor._search_navigate_up()
+
+#endregion
+
+

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -187,6 +187,11 @@ func _clear() -> void:
 	play_timeline_button.disabled = true
 
 
+func get_current_editor() -> Node:
+	if current_editor_mode == 1:
+		return %TextEditor
+	return %VisualEditor
+
 #region SEARCH
 
 func search_timeline() -> void:
@@ -206,29 +211,21 @@ func _on_close_search_pressed() -> void:
 
 func _on_search_text_changed(new_text: String) -> void:
 	var editor: Node = null
-	match current_editor_mode:
-		0:
-			editor = %VisualEditor
-		1:
-			editor = %TextEditor
-	editor._search_timeline(new_text)
-	%SearchLabel.text = editor._get_search_text()
-
+	var anything_found: bool = get_current_editor()._search_timeline(new_text)
+	if anything_found or new_text.is_empty():
+		%SearchLabel.hide()
+	else:
+		%SearchLabel.show()
+		%SearchLabel.add_theme_color_override("font_color", get_theme_color("error_color", "Editor"))
+		%SearchLabel.text = "No Match"
 
 
 func _on_search_down_pressed() -> void:
-	match current_editor_mode:
-		0:
-			%VisualEditor._search_navigate_down()
-		1:
-			%TextEditor._search_navigate_down()
+	get_current_editor()._search_navigate_down()
+
 
 func _on_search_up_pressed() -> void:
-	match current_editor_mode:
-		0:
-			%VisualEditor._search_navigate_up()
-		1:
-			%TextEditor._search_navigate_up()
+	get_current_editor()._search_navigate_up()
 
 #endregion
 

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://defdeav8rli6o" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn" id="3_up2bn"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd" id="4_1t6bf"]
 
-[sub_resource type="Image" id="Image_3cd31"]
+[sub_resource type="Image" id="Image_43fqw"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -15,13 +15,13 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_wvrw5"]
-image = SubResource("Image_3cd31")
+[sub_resource type="ImageTexture" id="ImageTexture_lvr8x"]
+image = SubResource("Image_43fqw")
 
 [sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_7lpql"]
 script = ExtResource("4_1t6bf")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_3migc"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lpeon"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -62,11 +62,11 @@ text = "Cool Name"
 
 [node name="NameTooltip" parent="VBox/HBox" instance=ExtResource("2_yqd26")]
 layout_mode = 2
-tooltip_text = "The name of the timeline is determined from the file name. 
+tooltip_text = "This unique identifier is based on the file name. You can change it in the Reference Manager.
 This is what you should use in a jump event to reference this timeline.
 
-Besides the file path, you can also use this name in Dialogic.start()"
-texture = SubResource("ImageTexture_wvrw5")
+You can also use this name in Dialogic.start()."
+texture = SubResource("ImageTexture_lvr8x")
 hint_text = "This unique identifier is based on the file name. You can change it in the Reference Manager.
 This is what you should use in a jump event to reference this timeline.
 
@@ -80,7 +80,7 @@ size_flags_horizontal = 10
 size_flags_vertical = 4
 tooltip_text = "Switch between Text Editor and Visual Editor"
 text = "Text editor"
-icon = SubResource("ImageTexture_wvrw5")
+icon = SubResource("ImageTexture_lvr8x")
 
 [node name="VisualEditor" parent="VBox" instance=ExtResource("2_qs7vc")]
 unique_name_in_owner = true
@@ -100,6 +100,34 @@ symbol_lookup_on_click = true
 line_folding = false
 gutters_draw_fold_gutter = false
 
+[node name="SearchSection" type="HBoxContainer" parent="VBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="Search" type="LineEdit" parent="VBox/SearchSection"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Search"
+
+[node name="SearchLabel" type="Label" parent="VBox/SearchSection"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="SearchUp" type="Button" parent="VBox/SearchSection"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="SearchDown" type="Button" parent="VBox/SearchSection"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="SearchClose" type="Button" parent="VBox/SearchSection"]
+unique_name_in_owner = true
+layout_mode = 2
+
 [node name="NoTimelineScreen" type="PanelContainer" parent="."]
 visible = false
 layout_mode = 1
@@ -108,7 +136,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_3migc")
+theme_override_styles/panel = SubResource("StyleBoxFlat_lpeon")
 
 [node name="CenterContainer" type="CenterContainer" parent="NoTimelineScreen"]
 layout_mode = 2
@@ -128,4 +156,8 @@ autowrap_mode = 3
 layout_mode = 2
 text = "Create New Timeline"
 
+[connection signal="text_changed" from="VBox/SearchSection/Search" to="." method="_on_search_text_changed"]
+[connection signal="pressed" from="VBox/SearchSection/SearchUp" to="." method="_on_search_up_pressed"]
+[connection signal="pressed" from="VBox/SearchSection/SearchDown" to="." method="_on_search_down_pressed"]
+[connection signal="pressed" from="VBox/SearchSection/SearchClose" to="." method="_on_close_search_pressed"]
 [connection signal="pressed" from="NoTimelineScreen/CenterContainer/VBoxContainer/CreateTimelineButton" to="." method="_on_create_timeline_button_pressed"]


### PR DESCRIPTION
- fixes #1854

The search in the visual editor only searches inside text events, while the search in the text editor searches the whole document.

![grafik](https://github.com/dialogic-godot/dialogic/assets/42868150/23b47402-c615-49cd-8e68-92cd4799a62c)
![grafik](https://github.com/dialogic-godot/dialogic/assets/42868150/e785d94b-5912-4a05-9bde-dc5999fa0e26)
