### PR TITLE
Set tooltip for buttons in event blocks

### DIFF
--- a/addons/dialogic/Editor/Events/EventBlock/event_block.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_block.gd
@@ -218,6 +218,7 @@ func build_editor(build_header:bool = true, build_body:bool = false) ->  void:
 		elif p.field_type == resource.ValueType.BUTTON:
 			editor_node = Button.new()
 			editor_node.text = p.display_info.text
+			editor_node.tooltip_text = p.display_info.get('tooltip', '')
 			if typeof(p.display_info.icon) == TYPE_ARRAY:
 				editor_node.icon = callv('get_theme_icon', p.display_info.icon)
 			else:


### PR DESCRIPTION
This PR fixes the `tooltip` field of `display_info` being ignored (and hence not shown) for event block buttons, like the external link button to the variables editor:

![image](https://github.com/dialogic-godot/dialogic/assets/33421921/8f4799b2-2d35-435d-b123-f82d5cd30f76)
