### PR TITLE
Choice event enhancements

### DIFF
--- a/addons/dialogic/Editor/Events/EventBlock/event_block.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_block.gd
@@ -324,6 +324,8 @@ func recalculate_field_visibility() -> void:
 		else:
 			if _evaluate_visibility_condition(p):
 				if p.node != null:
+					if p.node.visible == false and p.has("property"):
+						p.node._set_value(resource.get(p.property))
 					p.node.show()
 				if p.location == 1:
 					has_any_enabled_body_content = true

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -114,10 +114,13 @@ func get_current_question_info() -> Dictionary:
 			var hide := choice_event.else_action == DialogicChoiceEvent.ElseActions.HIDE
 			hide = hide or choice_event.else_action == DialogicChoiceEvent.ElseActions.DEFAULT and default_false_behaviour == DialogicChoiceEvent.ElseActions.HIDE
 			choice_info['visible'] = not hide
+
 			if not hide:
 				button_idx += 1
 
 		choice_info.text = dialogic.Text.parse_text(choice_info.text, true, true, false, true, false, false)
+
+		choice_info.merge(choice_event.extra_data)
 
 		if dialogic.has_subsystem('History'):
 			choice_info['visited_before'] = dialogic.History.has_event_been_visited(choice_index)

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -321,7 +321,10 @@ func store_to_shortcode_parameters() -> String:
 			_:
 				value_as_string = var_to_str(value)
 
-		result_string += " " + parameter + '="' + value_as_string.replace('"', '\\"') + '"'
+		if not ((value_as_string.begins_with("[") and value_as_string.ends_with("]")) or (value_as_string.begins_with("{") and value_as_string.ends_with("}"))):
+			value_as_string.replace('"', '\\"')
+
+		result_string += " " + parameter + '="' + value_as_string + '"'
 	return result_string.strip_edges()
 
 
@@ -382,7 +385,7 @@ func is_string_full_event(string: String) -> bool:
 ## Used to get all the shortcode parameters in a string as a dictionary.
 func parse_shortcode_parameters(shortcode: String) -> Dictionary:
 	var regex: RegEx = RegEx.new()
-	regex.compile(r'((?<parameter>[^\s=]*)\s*=\s*"(?<value>([^"]|\\")*)(?<!\\)")')
+	regex.compile(r'(?<parameter>[^\s=]*)\s*=\s*"(?<value>(\{[^}]*\}|\[[^]]*\]|([^"]|\\")*|))(?<!\\)\"')
 	var dict: Dictionary = {}
 	for result in regex.search_all(shortcode):
 		dict[result.get_string('parameter')] = result.get_string('value')


### PR DESCRIPTION
This changes the syntax of the choice event a bit:
```
- Choice Text | [if Condition] [shortcode="value"]
- Choice Text | [shortcode="value"]
- Choice Text
```
*The old syntax without | still works though.*

This also adds a new extra_data field to choices. This data will be provided to choice buttons so they can now be uniquely identified and given arbitrary information. This would be even cooler, if the dictionary field would be nicer looking. 
- fixes #2286

This also makes it so you have to press a button to enable the condition on choices, which looks much better. 
- fixes the UX problem #2272

This also fixes a bug with visual editor fields not having the correct value if they start hidden and are then revealed by a condition changing.