### PR TITLE
Fix misspelled apply_export_overrides method

### DIFF
--- a/addons/dialogic/Resources/dialogic_layout_base.gd
+++ b/addons/dialogic/Resources/dialogic_layout_base.gd
@@ -22,7 +22,7 @@ func get_layers() -> Array:
 	return layers
 
 
-func appply_export_overrides() -> void:
+func apply_export_overrides() -> void:
 	_apply_export_overrides()
 	for child in get_children():
 		if child.has_method('_apply_export_overrides'):


### PR DESCRIPTION
Fixes #2305.

The `_apply_export_overrides` method is called by `apply_export_overrides`, though the latter is misspelled and cannot be called by `apply_scene_export_overrides` (in DialogicUtil.gd) since it checks if the method exists before calling it.