### PR TITLE
Fix limitless typo

### DIFF
--- a/addons/dialogic/Editor/HomePage/tips.txt
+++ b/addons/dialogic/Editor/HomePage/tips.txt
@@ -5,7 +5,7 @@ Did you know that dialogic supports translations? It does!; editor://Settings->T
 You can use [b]bbcode effects[/b] in text events! What are they though???; https://docs.godotengine.org/en/latest/tutorials/ui/bbcode_in_richtextlabel.html
 Writing [/i]<Oh hi/Hello you/Well, well>[i] in a text event will pick a random one of the three strings!
 There are a number of cool text effects like [pause=x], [speed=x] and [portrait=x]. Try them out!; editor://Settings->Text
-You can use scenes as portraits! This gives you basically limiteless freedom.; https://dialogic-docs.coppolaemilio.com/custom-portraits.html
+You can use scenes as portraits! This gives you basically limitless freedom.; https://dialogic-docs.coppolaemilio.com/custom-portraits.html
 You can use scenes as backgrounds. This way they can be animated or whatever you want!
 Dialogic has a built in save and load system! It's pretty powerful!; editor://Settings->Saving
 You can add multiple glossary files, each containing words that can be hovered for information!; editor://GlossaryEditor


### PR DESCRIPTION
This PR fixes the "limiteless" typo in the tips.