### PR TITLE
Export follow_viewport for default layout base

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Base_Default/default_layout_base.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Base_Default/default_layout_base.gd
@@ -10,10 +10,12 @@ extends DialogicLayoutBase
 @export var global_font_color: Color = Color("white")
 @export_file('*.ttf', '*.tres') var global_font: String = ""
 @export var global_font_size: int = 18
+@export var follow_viewport: bool = false
 
 
 func _apply_export_overrides() -> void:
 	# apply layer
 	set(&'layer', canvas_layer)
+	set(&'follow_viewport_enabled', follow_viewport)
 
 


### PR DESCRIPTION
This PR adds a `follow_viewport` property that is able to be changed through the layer settings under the styles tab. `follow_viewport` sets `follow_viewport_enabled` for `CanvasLayer` layout base scenes.