### PR TITLE
Fix follow viewport export order

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Base_Default/default_layout_base.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Base_Default/default_layout_base.gd
@@ -4,13 +4,13 @@ extends DialogicLayoutBase
 ## The default layout base scene.
 
 @export var canvas_layer: int = 1
+@export var follow_viewport: bool = false
 
 @export_subgroup("Global")
 @export var global_bg_color: Color = Color(0, 0, 0, 0.9)
 @export var global_font_color: Color = Color("white")
 @export_file('*.ttf', '*.tres') var global_font: String = ""
 @export var global_font_size: int = 18
-@export var follow_viewport: bool = false
 
 
 func _apply_export_overrides() -> void:


### PR DESCRIPTION
Fixes the order of the `follow_viewport` export added by #2309. I'm sorry for the silly mistake!