### PR TITLE
Fix autosaving in ON_TIMER mode

### DIFF
--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -26,7 +26,7 @@ const AUTO_SAVE_SETTINGS := "dialogic/save/autosave"
 ## The project settings key for the auto-save mode settings.
 const AUTO_SAVE_MODE_SETTINGS := "dialogic/save/autosave_mode"
 
-## The project settings key for the auto-save mode settings.
+## The project settings key for the auto-save delay settings.
 const AUTO_SAVE_TIME_SETTINGS := "dialogic/save/autosave_delay"
 
 ## Temporarily stores a taken screen capture when using [take_slot_image()].
@@ -475,7 +475,8 @@ func _ready() -> void:
 	_result = dialogic.timeline_started.connect(_on_start_or_end_autosave)
 	_result = dialogic.timeline_ended.connect(_on_start_or_end_autosave)
 
-	_on_autosave_timer_timeout()
+	if autosave_enabled:
+		autosave_timer.start(autosave_time)
 
 
 func _on_autosave_timer_timeout() -> void:

--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -80,6 +80,16 @@ var autosave_time := 60:
 func clear_game_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	_make_sure_slot_dir_exists()
 
+
+## Built-in, called by DialogicGameHandler.
+func pause() -> void:
+	autosave_timer.paused = true
+
+
+## Built-in, called by DialogicGameHandler.
+func resume() -> void:
+	autosave_timer.paused = false
+
 #endregion
 
 

--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -66,6 +66,7 @@ var autosave_mode := AutoSaveMode.ON_TIMELINE_JUMPS
 ## `AutoSaveMode.ON_TIMER`.
 var autosave_time := 60:
 	set(timer_time):
+		autosave_time = timer_time
 		autosave_timer.wait_time = timer_time
 
 

--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -26,6 +26,9 @@ const AUTO_SAVE_SETTINGS := "dialogic/save/autosave"
 ## The project settings key for the auto-save mode settings.
 const AUTO_SAVE_MODE_SETTINGS := "dialogic/save/autosave_mode"
 
+## The project settings key for the auto-save mode settings.
+const AUTO_SAVE_TIME_SETTINGS := "dialogic/save/autosave_delay"
+
 ## Temporarily stores a taken screen capture when using [take_slot_image()].
 enum ThumbnailMode {NONE, TAKE_AND_STORE, STORE_ONLY}
 var latest_thumbnail : Image = null
@@ -466,6 +469,7 @@ func _ready() -> void:
 
 	autosave_enabled = ProjectSettings.get_setting(AUTO_SAVE_SETTINGS, autosave_enabled)
 	autosave_mode = ProjectSettings.get_setting(AUTO_SAVE_MODE_SETTINGS, autosave_mode)
+	autosave_time = ProjectSettings.get_setting(AUTO_SAVE_TIME_SETTINGS, autosave_time)
 
 	_result = dialogic.event_handled.connect(_on_dialogic_event_handled)
 	_result = dialogic.timeline_started.connect(_on_start_or_end_autosave)
@@ -478,7 +482,6 @@ func _on_autosave_timer_timeout() -> void:
 	if autosave_mode == AutoSaveMode.ON_TIMER:
 		perform_autosave()
 
-	autosave_time = ProjectSettings.get_setting('dialogic/save/autosave_delay', autosave_time)
 	autosave_timer.start(autosave_time)
 
 


### PR DESCRIPTION
- Make it possible to configure and programmatically set the autosave interval.
- Fix default save corruption during subsystem init.
- Pause the timer while Dialogic.paused.
  - Let me know if you prefer to have an option for it.