### PR TITLE
Add option to include simple and/or full event history in savegame

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -321,6 +321,9 @@ func get_full_state() -> Dictionary:
 		current_state_info['current_event_idx'] = -1
 		current_state_info['current_timeline'] = null
 
+	for subsystem in get_children():
+		(subsystem as DialogicSubsystem).save_game_state()
+
 	return current_state_info.duplicate(true)
 
 

--- a/addons/dialogic/Core/Dialogic_Subsystem.gd
+++ b/addons/dialogic/Core/Dialogic_Subsystem.gd
@@ -25,6 +25,13 @@ func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
 
 
 # To be overriden by sub-classes
+# Fill in everything that should be saved into the dialogic_game_handler.current_state_info
+# This is called when a save is saved
+func save_game_state() -> void:
+	pass
+
+
+# To be overriden by sub-classes
 func pause() -> void:
 	pass
 

--- a/addons/dialogic/Modules/History/settings_history.gd
+++ b/addons/dialogic/Modules/History/settings_history.gd
@@ -8,7 +8,9 @@ func _get_priority() -> int:
 
 func _ready() -> void:
 	%SimpleHistoryEnabled.toggled.connect(setting_toggled.bind('dialogic/history/simple_history_enabled'))
+	%SimpleHistorySave.toggled.connect(setting_toggled.bind('dialogic/history/simple_history_save'))
 	%FullHistoryEnabled.toggled.connect(setting_toggled.bind('dialogic/history/full_history_enabled'))
+	%FullHistorySave.toggled.connect(setting_toggled.bind('dialogic/history/full_history_save'))
 	%AlreadyReadHistoryEnabled.toggled.connect(setting_toggled.bind('dialogic/history/visited_event_history_enabled'))
 	%SaveOnAutoSaveToggle.toggled.connect(setting_toggled.bind('dialogic/history/save_on_autosave'))
 	%SaveOnSaveToggle.toggled.connect(setting_toggled.bind('dialogic/history/save_on_save'))
@@ -16,7 +18,9 @@ func _ready() -> void:
 
 func _refresh() -> void:
 	%SimpleHistoryEnabled.button_pressed = ProjectSettings.get_setting('dialogic/history/simple_history_enabled', false)
+	%SimpleHistorySave.button_pressed = ProjectSettings.get_setting('dialogic/history/simple_history_save', false)
 	%FullHistoryEnabled.button_pressed = ProjectSettings.get_setting('dialogic/history/full_history_enabled', false)
+	%FullHistorySave.button_pressed = ProjectSettings.get_setting('dialogic/history/full_history_save', false)
 	%AlreadyReadHistoryEnabled.button_pressed = ProjectSettings.get_setting('dialogic/history/visited_event_history_enabled', false)
 
 

--- a/addons/dialogic/Modules/History/settings_history.tscn
+++ b/addons/dialogic/Modules/History/settings_history.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" path="res://addons/dialogic/Modules/History/settings_history.gd" id="1_hbhst"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_wefye"]
 
-[sub_resource type="Image" id="Image_3h4fk"]
+[sub_resource type="Image" id="Image_3clns"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -12,8 +12,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_8li2l"]
-image = SubResource("Image_3h4fk")
+[sub_resource type="ImageTexture" id="ImageTexture_irr0a"]
+image = SubResource("Image_3clns")
 
 [node name="History" type="PanelContainer"]
 anchors_preset = 15
@@ -45,11 +45,28 @@ text = "Enabled"
 layout_mode = 2
 tooltip_text = "When enabled, some events (Text, Join, Leave, Choice) will store a log.
 Also, the default layout will feature the log panel option."
-texture = SubResource("ImageTexture_8li2l")
+texture = SubResource("ImageTexture_irr0a")
 hint_text = "When enabled, some events (Text, Join, Leave, Choice) will store a log.
 Also, the default layout will feature the log panel option."
 
 [node name="SimpleHistoryEnabled" type="CheckBox" parent="HistoryOptions/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="HistoryOptions"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HistoryOptions/HBoxContainer2"]
+layout_mode = 2
+text = "Save and Load"
+
+[node name="HintTooltip" parent="HistoryOptions/HBoxContainer2" instance=ExtResource("2_wefye")]
+layout_mode = 2
+tooltip_text = "When enabled, the simple history is included in the savegame."
+texture = SubResource("ImageTexture_irr0a")
+hint_text = "When enabled, the simple history is included in the savegame. Also, it is reset on Dialogic.clear(FULL_CLEAR)."
+
+[node name="SimpleHistorySave" type="CheckBox" parent="HistoryOptions/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -68,10 +85,27 @@ text = "Enabled"
 [node name="HintTooltip" parent="HistoryOptions/HBoxContainer5" instance=ExtResource("2_wefye")]
 layout_mode = 2
 tooltip_text = "When enabled, stores a copy of each event."
-texture = SubResource("ImageTexture_8li2l")
+texture = SubResource("ImageTexture_irr0a")
 hint_text = "When enabled, stores a copy of each event."
 
 [node name="FullHistoryEnabled" type="CheckBox" parent="HistoryOptions/HBoxContainer5"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HBoxContainer6" type="HBoxContainer" parent="HistoryOptions"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="HistoryOptions/HBoxContainer6"]
+layout_mode = 2
+text = "Save and Load"
+
+[node name="HintTooltip" parent="HistoryOptions/HBoxContainer6" instance=ExtResource("2_wefye")]
+layout_mode = 2
+tooltip_text = "When enabled, the full history is included in the savegame."
+texture = SubResource("ImageTexture_irr0a")
+hint_text = "When enabled, the full history is included in the savegame. Also, it is reset on Dialogic.clear(FULL_CLEAR)."
+
+[node name="FullHistorySave" type="CheckBox" parent="HistoryOptions/HBoxContainer6"]
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -92,7 +126,7 @@ layout_mode = 2
 tooltip_text = "Remembers whether events were already met in the timeline.
 When enabled the signals \"Dialogic.History.visited_event\" and \"Dialogic.History.unvisited_event\" are emitted.
 "
-texture = SubResource("ImageTexture_8li2l")
+texture = SubResource("ImageTexture_irr0a")
 hint_text = "Remembers whether events were already met in the timeline.
 When enabled the signals \"Dialogic.History.visited_event\" and \"Dialogic.History.unvisited_event\" are emitted.
 "
@@ -112,7 +146,7 @@ text = "Save on Auto-Save signal"
 layout_mode = 2
 tooltip_text = "Stores the already-visited history in a global save file when an Auto-Save occurs.
 The Auto-Save is part of the Save settings."
-texture = SubResource("ImageTexture_8li2l")
+texture = SubResource("ImageTexture_irr0a")
 hint_text = "Stores the already-visited history in a global save file when an Auto-Save occurs.
 The Auto-Save is part of the Save settings."
 
@@ -132,7 +166,7 @@ layout_mode = 2
 tooltip_text = "Stores the already-visited history in a global save file when a normal Save occurs.
 This can be done via the Dialogic.Save.save method.
 This setting ignores Auto-Saves."
-texture = SubResource("ImageTexture_8li2l")
+texture = SubResource("ImageTexture_irr0a")
 hint_text = "Stores the already-visited history in a global save file when a normal Save occurs.
 This can be done via the Dialogic.Save.save method.
 This setting ignores Auto-Saves."

--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -19,7 +19,7 @@ var full_event_history_save := false
 
 ## The full history of all Dialogic events encountered.
 ## Requires [member full_event_history_enabled] to be true.
-var full_event_history_content : Array[DialogicEvent] = []
+var full_event_history_content: Array[DialogicEvent] = []
 
 ## Emitted if a new event has been inserted into the full event history.
 signal full_event_history_changed
@@ -105,7 +105,7 @@ func post_install() -> void:
 	save_visited_history_on_save = ProjectSettings.get_setting('dialogic/history/save_on_save', save_visited_history_on_save)
 
 
-func clear_game_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
+func clear_game_state(clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	if clear_flag == DialogicGameHandler.ClearFlags.FULL_CLEAR:
 		if simple_history_save:
 			simple_history_content = []
@@ -115,22 +115,22 @@ func clear_game_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> 
 			dialogic.current_state_info.erase("history_full")
 
 
-func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
+func load_game_state(load_flag := LoadFlags.FULL_LOAD) -> void:
 	if load_flag == LoadFlags.FULL_LOAD:
-		if simple_history_save && dialogic.current_state_info.has("history_simple"):
+		if simple_history_save and dialogic.current_state_info.has("history_simple"):
 			simple_history_content.assign(dialogic.current_state_info["history_simple"])
-		if full_event_history_save && dialogic.current_state_info.has("history_full"):
+
+		if full_event_history_save and dialogic.current_state_info.has("history_full"):
 			full_event_history_content = []
-			var event_cache = DialogicResourceUtil.get_event_cache()
+
 			for event_text in dialogic.current_state_info["history_full"]:
 				var event: DialogicEvent
-				for i in event_cache:
+				for i in DialogicResourceUtil.get_event_cache():
 					if i.is_valid_event(event_text):
 						event = i.duplicate()
 						break
 				event.from_text(event_text)
 				full_event_history_content.append(event)
-		pass
 
 
 func save_game_state() -> void:

--- a/addons/dialogic/Modules/History/subsystem_history.gd
+++ b/addons/dialogic/Modules/History/subsystem_history.gd
@@ -9,15 +9,17 @@ signal close_requested
 ## Simple history that stores limited information
 ## Used for the history display
 var simple_history_enabled := false
+var simple_history_save := false
 var simple_history_content : Array[Dictionary] = []
 signal simple_history_changed
 
 ## Whether to keep a history of every Dialogic event encountered.
 var full_event_history_enabled := false
+var full_event_history_save := false
 
 ## The full history of all Dialogic events encountered.
 ## Requires [member full_event_history_enabled] to be true.
-var full_event_history_content := []
+var full_event_history_content : Array[DialogicEvent] = []
 
 ## Emitted if a new event has been inserted into the full event history.
 signal full_event_history_changed
@@ -80,8 +82,10 @@ func _ready() -> void:
 	dialogic.event_handled.connect(store_full_event)
 	dialogic.event_handled.connect(_check_seen)
 
-	simple_history_enabled = ProjectSettings.get_setting('dialogic/history/simple_history_enabled', simple_history_enabled )
+	simple_history_enabled = ProjectSettings.get_setting('dialogic/history/simple_history_enabled', simple_history_enabled)
+	simple_history_save = ProjectSettings.get_setting('dialogic/history/simple_history_save', simple_history_save)
 	full_event_history_enabled = ProjectSettings.get_setting('dialogic/history/full_history_enabled', full_event_history_enabled)
+	full_event_history_save = ProjectSettings.get_setting('dialogic/history/full_history_save', full_event_history_save)
 	visited_event_history_enabled = ProjectSettings.get_setting('dialogic/history/visited_event_history_enabled', visited_event_history_enabled)
 
 
@@ -99,6 +103,47 @@ func _on_save(info: Dictionary) -> void:
 func post_install() -> void:
 	save_visited_history_on_autosave = ProjectSettings.get_setting('dialogic/history/save_on_autosave', save_visited_history_on_autosave)
 	save_visited_history_on_save = ProjectSettings.get_setting('dialogic/history/save_on_save', save_visited_history_on_save)
+
+
+func clear_game_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
+	if clear_flag == DialogicGameHandler.ClearFlags.FULL_CLEAR:
+		if simple_history_save:
+			simple_history_content = []
+			dialogic.current_state_info.erase("history_simple")
+		if full_event_history_save:
+			full_event_history_content = []
+			dialogic.current_state_info.erase("history_full")
+
+
+func load_game_state(load_flag:=LoadFlags.FULL_LOAD) -> void:
+	if load_flag == LoadFlags.FULL_LOAD:
+		if simple_history_save && dialogic.current_state_info.has("history_simple"):
+			simple_history_content.assign(dialogic.current_state_info["history_simple"])
+		if full_event_history_save && dialogic.current_state_info.has("history_full"):
+			full_event_history_content = []
+			var event_cache = DialogicResourceUtil.get_event_cache()
+			for event_text in dialogic.current_state_info["history_full"]:
+				var event: DialogicEvent
+				for i in event_cache:
+					if i.is_valid_event(event_text):
+						event = i.duplicate()
+						break
+				event.from_text(event_text)
+				full_event_history_content.append(event)
+		pass
+
+
+func save_game_state() -> void:
+	if simple_history_save:
+		dialogic.current_state_info["history_simple"] = Array(simple_history_content)
+	else:
+		dialogic.current_state_info.erase("history_simple")
+	if full_event_history_save:
+		dialogic.current_state_info["history_full"] = []
+		for event in full_event_history_content:
+			dialogic.current_state_info["history_full"].append(event.to_text())
+	else:
+		dialogic.current_state_info.erase("history_full")
 
 
 func open_history() -> void:

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -95,14 +95,11 @@ func _execute() -> void:
 		split_text.append([i.get_string().trim_prefix('[n]').trim_prefix('[n+]')])
 		split_text[-1].append(i.get_string().begins_with('[n+]'))
 
-	dialogic.current_state_info['text_sub_idx'] = dialogic.current_state_info.get('text_sub_idx', 0)
+	dialogic.current_state_info['text_sub_idx'] = dialogic.current_state_info.get('text_sub_idx', -1)
 
-	var reveal_next_segment := true
+	var reveal_next_segment : bool = dialogic.current_state_info['text_sub_idx'] == -1
 
-	if dialogic.current_state_info['text_sub_idx'] > 0:
-		reveal_next_segment = false
-
-	for section_idx in range(min(dialogic.current_state_info['text_sub_idx'], len(split_text)-1), len(split_text)):
+	for section_idx in range(min(max(0, dialogic.current_state_info['text_sub_idx']), len(split_text)-1), len(split_text)):
 		dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))
 
 		if reveal_next_segment:
@@ -165,7 +162,7 @@ func _execute() -> void:
 
 
 func end_text_event() -> void:
-	dialogic.current_state_info['text_sub_idx'] = 0
+	dialogic.current_state_info['text_sub_idx'] = -1
 
 	_disconnect_signals()
 	finish()

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -97,7 +97,7 @@ func _execute() -> void:
 
 	dialogic.current_state_info['text_sub_idx'] = dialogic.current_state_info.get('text_sub_idx', -1)
 
-	var reveal_next_segment : bool = dialogic.current_state_info['text_sub_idx'] == -1
+	var reveal_next_segment: bool = dialogic.current_state_info['text_sub_idx'] == -1
 
 	for section_idx in range(min(max(0, dialogic.current_state_info['text_sub_idx']), len(split_text)-1), len(split_text)):
 		dialogic.Inputs.block_input(ProjectSettings.get_setting('dialogic/text/text_reveal_skip_delay', 0.1))


### PR DESCRIPTION
Simple and full event history can be toggled separately. If one option is enabled:
- Include that history in Dialogic.get_full_state() / Save.save().
- On Dialogic.load_full_state() / Save.load() replace that history with the history from the savegame.
  - If the savegame doesn't contain that history, clear it.
  - Events appended to the full event history between the clear_game_state() and the load_game_state() are dropped intentionally.
- On Dialogic.clear(FULL_CLEAR), clear that history.

The changes to the text event are needed to avoid duplicating the last entry in the simple history after a save+load. This also makes the text show up immediately after loading instead of the normal typing style.

Feel free to suggest a better option name or tooltip.