### PR TITLE
input: Ignore InputEventScreenTouch

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_input.gd
+++ b/addons/dialogic/Modules/Core/subsystem_input.gd
@@ -93,7 +93,7 @@ func handle_input() -> void:
 ## Unhandled Input is used for all NON-Mouse based inputs.
 func _unhandled_input(event:InputEvent) -> void:
 	if is_input_pressed(event, true):
-		if event is InputEventMouse:
+		if event is InputEventMouse or event is InputEventScreenTouch:
 			return
 		handle_input()
 


### PR DESCRIPTION
On android, Godot triggers an `InputEventMouseButton` *in addition to* an `InputEventScreenTouch` and `Input.is_action_just_pressed(<mouse action>)` already returns true during the touch event. I don't have an ios device to test it, but I assume it would be the same there as well.

`subsystem_input.gd` currently handles the touch event in `_unhandled_input()` which makes the input catcher more or less meaningless on a touch device.

This PR will break projects with the setting `input_devices/pointing/emulate_mouse_from_touch` disabled unless they provide a custom input catcher or use `TouchScreenButton`s to convert touch into actions. I think thats's an acceptable tradeoff as such a setup also breaks touch input for many other controls like regular `Button`s.