### PR TITLE
Hide textbubble exampleat start

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Base_TextBubble/text_bubble_base.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Base_TextBubble/text_bubble_base.tscn
@@ -13,6 +13,7 @@ bg_color = Color(0, 0, 0, 0.654902)
 script = ExtResource("1_urqwc")
 
 [node name="Example" type="Control" parent="."]
+visible = false
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0


### PR DESCRIPTION
The textbubble example message is now hidden by default, which should avoid possible flicker if there is a frame before the first text event.

- should fix #2338
