### PR TITLE
Fix new text event getting stuck if Dialogic.start() is called during another text event

### DIFF
--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -44,6 +44,10 @@ signal advance
 #region EXECUTION
 ################################################################################
 
+func _clear_state() -> void:
+	dialogic.current_state_info.erase('text_sub_idx')
+	_disconnect_signals()
+
 func _execute() -> void:
 	if text.is_empty():
 		finish()
@@ -129,12 +133,14 @@ func _execute() -> void:
 				await dialogic.Text.text_finished
 
 			state = States.IDLE
+		else:
+			reveal_next_segment = true
 
 		# Handling potential Choice Events.
 		if section_idx == len(split_text)-1 and dialogic.has_subsystem('Choices') and dialogic.Choices.is_question(dialogic.current_event_idx):
 			dialogic.Text.show_next_indicators(true)
 
-			end_text_event()
+			finish()
 			return
 
 		elif dialogic.Inputs.auto_advance.is_enabled():
@@ -159,13 +165,6 @@ func _execute() -> void:
 			await advance
 
 
-	end_text_event()
-
-
-func end_text_event() -> void:
-	dialogic.current_state_info['text_sub_idx'] = -1
-
-	_disconnect_signals()
 	finish()
 
 

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -127,6 +127,14 @@ func finish() -> void:
 	event_finished.emit(self)
 
 
+## Called before executing the next event or before clear(any flags) / load_full_state().
+##
+## Should be overridden if the event stores temporary state into dialogic.current_state_info
+## or some other cleanup is needed before another event can run.
+func _clear_state() -> void:
+	pass
+
+
 ## To be overridden by subclasses.
 func _execute() -> void:
 	finish()


### PR DESCRIPTION
The text event stores its state in `dialogic.current_state_info['text_sub_idx'] `which is needed for save+load to work correctly. Unfortunately it stays across a `Dialogic.clear()` (flags doesn't matter) so the first text event of a new timeline tries to resume in the middle of the event which would only work correctly directly after a `Dialogic.load_full_state()`.

Steps to reproduce the behavior:
1. Start the Visual Novel from dialogic-test-project.
2. Click on 'New Game'.
3. Textbox appears correctly.
4. Click the menu button and then the door button.
5. Click on 'New Game'.
6. Textbox is missing.

`clear_state()` is called on every `Dialogic.clear()` and also before the next event is executed so events can centralize their cleanup code. In case of a `Dialogic.load_full_state()`, it is called right at the start so when it starts executing the event, there is no previous event to clear and the next event sees the loaded state.

The text event uses this to erase `dialogic.current_state_info['text_sub_idx']` and to disconnect signals.

This PR also fixes the issue where loading into the middle of a multi section text event caused it not to update the textbox when advancing to the remaining sections.