### PR TITLE
Fix and improve auto-pauses regex

### DIFF
--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -396,7 +396,7 @@ func _ready() -> void:
 	_autopauses = {}
 	var autopause_data: Dictionary = ProjectSettings.get_setting('dialogic/text/autopauses', {})
 	for i in autopause_data.keys():
-		_autopauses[RegEx.create_from_string(r"(?<!(\[|\{))[.,](?!([\w\s]*!?[\]\}]|$))")] = autopause_data[i]
+		_autopauses[RegEx.create_from_string(r"(?<!(\[|\{))["+i+r"](?!([^{}\[\]]*[\]\}]|$))")] = autopause_data[i]
 
 
 ## Parses the character's display_name and returns the text that


### PR DESCRIPTION
This had been completely broken... My bad.
It is now also improved to better handle {Variables.Some} {Expressions.some(2.x)} and [effect=so.me].
