### PR TITLE
Cleanup portrait animations and fix speaker portrait slide-off

### DIFF
--- a/addons/dialogic/Modules/Character/DefaultAnimations/bounce.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/bounce.gd
@@ -3,11 +3,10 @@ extends DialogicAnimation
 func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT)
-	var orig_scale: Vector2 = node.scale
-	tween.tween_property(node, 'position:y', orig_pos.y-node.get_viewport().size.y/10, time*0.4).set_trans(Tween.TRANS_EXPO)
-	tween.parallel().tween_property(node, 'scale:y', orig_scale.y*1.05, time*0.4).set_trans(Tween.TRANS_EXPO)
-	tween.tween_property(node, 'position:y', orig_pos.y, time*0.6).set_trans(Tween.TRANS_BOUNCE)
-	tween.parallel().tween_property(node, 'scale:y', orig_scale.y, time*0.6).set_trans(Tween.TRANS_BOUNCE)
+	tween.tween_property(node, 'position:y', base_position.y-node.get_viewport().size.y/10, time*0.4).set_trans(Tween.TRANS_EXPO)
+	tween.parallel().tween_property(node, 'scale:y', base_scale.y*1.05, time*0.4).set_trans(Tween.TRANS_EXPO)
+	tween.tween_property(node, 'position:y', base_position.y, time*0.6).set_trans(Tween.TRANS_BOUNCE)
+	tween.parallel().tween_property(node, 'scale:y', base_scale.y, time*0.6).set_trans(Tween.TRANS_BOUNCE)
 	tween.finished.connect(emit_signal.bind('finished_once'))
 
 

--- a/addons/dialogic/Modules/Character/DefaultAnimations/fade_down_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/fade_down_in_out.gd
@@ -3,15 +3,15 @@ extends DialogicAnimation
 func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 
-	var start_height: float = orig_pos.y - node.get_viewport().size.y / 5
-	var end_height := orig_pos.y
+	var start_height: float = base_position.y - node.get_viewport().size.y / 5
+	var end_height := base_position.y
 
 	var start_modulation := 0.0
 	var end_modulation := 1.0
 
 	if is_reversed:
 		end_height = start_height
-		start_height = orig_pos.y
+		start_height = base_position.y
 		end_modulation = 0.0
 		start_modulation = 1.0
 
@@ -21,7 +21,7 @@ func animate() -> void:
 	tween.set_trans(Tween.TRANS_SINE)
 	tween.set_parallel()
 
-	var end_postion := Vector2(orig_pos.x, end_height)
+	var end_postion := Vector2(base_position.x, end_height)
 	tween.tween_property(node, "position", end_postion, time)
 
 	var property := get_modulation_property()

--- a/addons/dialogic/Modules/Character/DefaultAnimations/fade_up_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/fade_up_in_out.gd
@@ -3,15 +3,15 @@ extends DialogicAnimation
 func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 
-	var start_height: float = orig_pos.y + node.get_viewport().size.y / 5
-	var end_height := orig_pos.y
+	var start_height: float = base_position.y + node.get_viewport().size.y / 5
+	var end_height := base_position.y
 
 	var start_modulation := 0.0
 	var end_modulation := 1.0
 
 	if is_reversed:
 		end_height = start_height
-		start_height = orig_pos.y
+		start_height = base_position.y
 		end_modulation = 0.0
 		start_modulation = 1.0
 
@@ -21,7 +21,7 @@ func animate() -> void:
 	tween.set_trans(Tween.TRANS_SINE)
 	tween.set_parallel()
 
-	var end_postion := Vector2(orig_pos.x, end_height)
+	var end_postion := Vector2(base_position.x, end_height)
 	tween.tween_property(node, "position", end_postion, time)
 
 	var property := get_modulation_property()

--- a/addons/dialogic/Modules/Character/DefaultAnimations/shake_y.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/shake_y.gd
@@ -5,14 +5,14 @@ func animate() -> void:
 	tween.set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)
 
 	var strength: float = node.get_viewport().size.y/40
-	tween.tween_property(node, 'position:y', orig_pos.y+strength, time*0.2)
-	tween.tween_property(node, 'position:y', orig_pos.y-strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y+strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y-strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y+strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y-strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y+strength, time*0.1)
-	tween.tween_property(node, 'position:y', orig_pos.y, time*0.2)
+	tween.tween_property(node, 'position:y', base_position.y + strength, time * 0.2)
+	tween.tween_property(node, 'position:y', base_position.y - strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y + strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y - strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y + strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y - strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y + strength, time * 0.1)
+	tween.tween_property(node, 'position:y', base_position.y, time * 0.2)
 
 	tween.finished.connect(emit_signal.bind('finished_once'))
 

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_down_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_down_in_out.gd
@@ -4,12 +4,12 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var target_position := end_position.y
+	var target_position := base_position.y
 	var start_position: float = -node.get_viewport().size.y
 
 	if is_reversed:
 		target_position = -node.get_viewport().size.y
-		start_position = end_position.y
+		start_position = base_position.y
 
 	node.position.y = start_position
 

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_left_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_left_in_out.gd
@@ -5,7 +5,7 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var end_position_x: float = node.position.x
+	var end_position_x: float = base_position.x
 
 	if is_reversed:
 		end_position_x = -node.get_viewport().size.x / 2

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_right_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_right_in_out.gd
@@ -7,10 +7,10 @@ func animate() -> void:
 	var viewport_x: float = node.get_viewport().size.x
 
 	var start_position_x: float = viewport_x + viewport_x / 5
-	var end_position_x := end_position.x
+	var end_position_x := base_position.x
 
 	if is_reversed:
-		start_position_x = end_position.x
+		start_position_x = base_position.x
 		end_position_x = viewport_x + node.get_viewport().size.x / 5
 
 

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_up_in.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_up_in.gd
@@ -5,10 +5,10 @@ func animate() -> void:
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
 	var start_position_y: float = node.get_viewport().size.y * 2
-	var end_position_y := end_position.y
+	var end_position_y := base_position.y
 
 	if is_reversed:
-		start_position_y = end_position.y
+		start_position_y = base_position.y
 		end_position_y = node.get_viewport().size.y * 2
 
 	node.position.y = start_position_y

--- a/addons/dialogic/Modules/Character/DefaultAnimations/zoom_center_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/zoom_center_in_out.gd
@@ -12,7 +12,7 @@ func animate() -> void:
 
 	else:
 		node.scale = Vector2(0, 0)
-		node.position.y = end_position.y - node.get_viewport().size.y * 0.5
+		node.position.y = base_position.y - node.get_viewport().size.y * 0.5
 
 		var original_modulation: Color = node.get(modulate_property)
 		original_modulation.a = 0.0
@@ -22,7 +22,7 @@ func animate() -> void:
 	tween.set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_EXPO)
 	tween.set_parallel(true)
 	tween.tween_property(node, "scale", end_scale, time)
-	tween.tween_property(node, "position", end_position, time)
+	tween.tween_property(node, "position", base_position, time)
 	tween.tween_property(node,  modulate_alpha_property, end_modulation_alpha, time)
 
 	await tween.finished

--- a/addons/dialogic/Modules/Character/class_dialogic_animation.gd
+++ b/addons/dialogic/Modules/Character/class_dialogic_animation.gd
@@ -14,11 +14,11 @@ var node: Node
 ## Set at runtime, will be the length of the animation.
 var time: float
 
-## Set at runtime, will be the position at which to end the animation.
-var end_position: Vector2
-
-## Set at runtime. The position the node started at.
-var orig_pos: Vector2
+## Set at runtime, will be the base position of the node.
+## Depending on the animation, this might be the start, end or both.
+var base_position: Vector2
+## Set at runtime, will be the base scale of the node.
+var base_scale: Vector2
 
 ## Used to repeate the animation for a number of times.
 var repeats: int
@@ -33,7 +33,7 @@ func _ready() -> void:
 
 
 ## To be overridden. Do the actual animating/tweening in here.
-## Use the properties [member node], [member time], [member end_position], [member orig_pos].
+## Use the properties [member node], [member time], [member base_position], etc.
 func animate() -> void:
 	pass
 


### PR DESCRIPTION
This renames DialogicAnimation `end_position` and `orig_position` (which where the same) to `base_position` and also adds `base_scale`. A slightly breaking change for people who made their own custom portrait animations.

It also adds an `await.process_frame` on change_speaker() when joining a character as it can happen that this is called before the textbox is shown and thus before the portrait container is correctly sized. This previously caused the speaker portrait to not work (just the first time when joining) when having a portrait-in animation setup.

Disables the non-functional signal `portrait_animating` for now until I find the time to make a proper re-implementation.
