### PR TITLE
Fix conditions contained in {brackets}

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -20,6 +20,9 @@ func execute_string(string:String, default: Variant = null, no_warning := false)
 	for res in regex.search_all(string):
 		var value: Variant = dialogic.VAR.get_variable(res.get_string())
 		string = string.replace(res.get_string(), var_to_str(value))
+	
+	if string.begins_with("{") and string.ends_with('}') and string.count("{") == 1:
+		string = string.trim_prefix("{").trim_suffix("}")
 
 	var expr := Expression.new()
 


### PR DESCRIPTION
Conditions that where sorrounded  by brackets (like is required in the conditional modifier) would sometimes not be correctly resolved. This should fix this.

- fixes #2378