### PR TITLE
Fix UID issues on custom style layers

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main.gd
@@ -66,32 +66,10 @@ func create_new_portrait_scene(target_file: String, info: Dictionary) -> void:
 
 func make_portrait_preset_custom(target_file:String, info: Dictionary) -> String:
 	var previous_file: String = info.path
-
-	var target_folder := target_file.get_base_dir()
-	target_file = target_file.get_file()
-
-	DirAccess.make_dir_absolute(target_folder)
-
-	DirAccess.copy_absolute(previous_file, target_folder.path_join(target_file))
-
-	var file := FileAccess.open(target_folder.path_join(target_file), FileAccess.READ)
-	var scene_text := file.get_as_text()
-	file.close()
-	if scene_text.begins_with('[gd_scene'):
-		var base_path: String = previous_file.get_base_dir()
-
-		var result := RegEx.create_from_string("\\Q\""+base_path+"\\E(?<file>[^\"]*)\"").search(scene_text)
-		while result:
-			DirAccess.copy_absolute(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
-			scene_text = scene_text.replace(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
-			result = RegEx.create_from_string("\\Q\""+base_path+"\\E(?<file>[^\"]*)\"").search(scene_text)
-
-	file = FileAccess.open(target_folder.path_join(target_file), FileAccess.WRITE)
-	file.store_string(scene_text)
-	file.close()
-
-	find_parent('EditorView').plugin_reference.get_editor_interface().get_resource_filesystem().scan_sources()
-	return target_folder.path_join(target_file)
+	
+	var result_path := DialogicUtil.make_file_custom(previous_file, target_file.get_base_dir(), target_file.get_file())
+	
+	return result_path
 
 
 func set_scene_path(path:String) -> void:
@@ -121,4 +99,3 @@ func reload_ui(data: Dictionary) -> void:
 		%SceneLabel.tooltip_text = path
 		%SceneLabel.add_theme_color_override("font_color", get_theme_color("property_color_x", "Editor"))
 		%OpenSceneButton.show()
-

--- a/addons/dialogic/Modules/StyleEditor/style_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_editor.gd
@@ -150,13 +150,18 @@ func load_style_list() -> void:
 	var idx := 0
 	for style in styles:
 		%StyleList.add_item(style.name, get_theme_icon("PopupMenu", "EditorIcons"))
+		%StyleList.set_item_tooltip(idx, style.resource_path)
+		%StyleList.set_item_metadata(idx, style)
+		
 		if style.resource_path == default_style:
 			%StyleList.set_item_icon_modulate(idx, get_theme_color("warning_color", "Editor"))
+		if style.resource_path.begins_with("res://addons/dialogic"):
+			%StyleList.set_item_icon_modulate(idx, get_theme_color("property_color_z", "Editor"))
+			%StyleList.set_item_tooltip(idx, "This is a default style. Only edit it if you know what you are doing!")
+			%StyleList.set_item_custom_bg_color(idx, get_theme_color("property_color_z", "Editor").lerp(get_theme_color("dark_color_3", "Editor"), 0.8))
 		if style.name == latest:
 			%StyleList.select(idx)
 			load_style(style)
-		%StyleList.set_item_tooltip(idx, style.resource_path)
-		%StyleList.set_item_metadata(idx, style)
 		idx += 1
 
 	if len(styles) == 0:
@@ -388,4 +393,3 @@ func _get_new_name(base_name:String) -> String:
 	return new_name
 
 #endregion
-

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -250,46 +250,22 @@ func _on_make_custom_layout_file_selected(file:String) -> void:
 
 
 func make_layer_custom(target_folder:String, custom_name := "") -> void:
-	if not ResourceLoader.exists(current_style.get_layer_info(current_layer_idx).path):
-		printerr("[Dialogic] Unable to copy layer that has no scene path specified!")
-		return
-
-	var target_file := ""
-	var previous_file: String = current_style.get_layer_info(current_layer_idx).path
+	
+	var original_file: String = current_style.get_layer_info(current_layer_idx).path
+	var custom_new_folder := ""
+	
 	if custom_name.is_empty():
-		target_file = 'custom_' + previous_file.get_file()
-		target_folder = target_folder.path_join(%StyleBrowser.premade_scenes_reference[previous_file].name.to_pascal_case())
-	else:
-		if not custom_name.ends_with('.tscn'):
-			custom_name += ".tscn"
-		target_file = custom_name
+		custom_name = "custom_"+%StyleBrowser.premade_scenes_reference[original_file].name.to_snake_case()
+		custom_new_folder = %StyleBrowser.premade_scenes_reference[original_file].name.to_pascal_case()
+	
+	var result_path := DialogicUtil.make_file_custom(
+		original_file,
+		target_folder,
+		custom_name,
+		custom_new_folder,
+		)
 
-	DirAccess.make_dir_absolute(target_folder)
-
-	DirAccess.copy_absolute(previous_file, target_folder.path_join(target_file))
-
-	var file := FileAccess.open(target_folder.path_join(target_file), FileAccess.READ)
-	var scene_text := file.get_as_text()
-	file.close()
-	if scene_text.begins_with('[gd_scene'):
-		var base_path: String = previous_file.get_base_dir()
-		
-		var remove_uuid_regex := r'\[gd_scene .* (?<uid>uid="uid:[^"]*")'
-		var result := RegEx.create_from_string(remove_uuid_regex).search(scene_text)
-		scene_text = scene_text.replace(result.get_string("uid"), "")
-		
-		var file_regex := r'\Q"'+base_path+r'\E(?<file>[^"]*)"'
-		result = RegEx.create_from_string(file_regex).search(scene_text)
-		while result:
-			DirAccess.copy_absolute(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
-			scene_text = scene_text.replace(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
-			result = RegEx.create_from_string(file_regex).search(scene_text)
-
-	file = FileAccess.open(target_folder.path_join(target_file), FileAccess.WRITE)
-	file.store_string(scene_text)
-	file.close()
-
-	current_style.set_layer_scene(current_layer_idx, target_folder.path_join(target_file))
+	current_style.set_layer_scene(current_layer_idx, result_path)
 
 	load_style_layer_list()
 
@@ -297,8 +273,6 @@ func make_layer_custom(target_folder:String, custom_name := "") -> void:
 		%LayerTree.get_root().select(0)
 	else:
 		%LayerTree.get_root().get_child(%LayerTree.get_selected().get_index()).select(0)
-
-	find_parent('EditorView').plugin_reference.get_editor_interface().get_resource_filesystem().scan_sources()
 
 
 func make_layout_custom(target_folder:String) -> void:

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -273,12 +273,17 @@ func make_layer_custom(target_folder:String, custom_name := "") -> void:
 	file.close()
 	if scene_text.begins_with('[gd_scene'):
 		var base_path: String = previous_file.get_base_dir()
-
-		var result := RegEx.create_from_string("\\Q\""+base_path+"\\E(?<file>[^\"]*)\"").search(scene_text)
+		
+		var remove_uuid_regex := r'\[gd_scene .* (?<uid>uid="uid:[^"]*")'
+		var result := RegEx.create_from_string(remove_uuid_regex).search(scene_text)
+		scene_text = scene_text.replace(result.get_string("uid"), "")
+		
+		var file_regex := r'\Q"'+base_path+r'\E(?<file>[^"]*)"'
+		result = RegEx.create_from_string(file_regex).search(scene_text)
 		while result:
 			DirAccess.copy_absolute(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
 			scene_text = scene_text.replace(base_path.path_join(result.get_string('file')), target_folder.path_join(result.get_string('file')))
-			result = RegEx.create_from_string("\\Q\""+base_path+"\\E(?<file>[^\"]*)\"").search(scene_text)
+			result = RegEx.create_from_string(file_regex).search(scene_text)
 
 	file = FileAccess.open(target_folder.path_join(target_file), FileAccess.WRITE)
 	file.store_string(scene_text)


### PR DESCRIPTION
When making a scene custom it would copy the scene and thus the resulting scene would share the same uid as the original. This would mess with styles created in the future. 

This PR should fix this by removing the UID when making a layer custom. 

I want to make the "make custom" code more modular and re-use it on the custom portrait logic to make sure this fix get's applied everywhere.