### PR TITLE
Fix debug portraits not showing up

### DIFF
--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -32,7 +32,7 @@ enum SizeModes {
 @export var size_mode: SizeModes = SizeModes.FIT_SCALE_HEIGHT :
 	set(mode):
 		size_mode = mode
-		_update_debug_portrait_size_position()
+		_update_debug_portrait_transform()
 
 ## If true, portraits will be mirrored in this position.
 @export var mirrored := false :
@@ -82,6 +82,7 @@ var default_debug_character := load(DialogicUtil.get_module_path('Character').pa
 
 var ignore_resize := false
 
+
 func _ready() -> void:
 	match mode:
 		PositionModes.POSITION:
@@ -129,10 +130,10 @@ func update_portrait_transforms() -> void:
 func get_local_portrait_transform(portrait_rect:Rect2, character_scale:=1.0) -> Rect2:
 	var transform := Rect2()
 	transform.position = _get_origin_position()
-
+	
 	# Mode that ignores the containers size
 	if size_mode == SizeModes.KEEP:
-		transform.size = Vector2(1,1)*character_scale
+		transform.size = Vector2(1,1) * character_scale
 
 	# Mode that makes sure neither height nor width go out of container
 	elif size_mode == SizeModes.FIT_IGNORE_SCALE:
@@ -147,7 +148,7 @@ func get_local_portrait_transform(portrait_rect:Rect2, character_scale:=1.0) -> 
 
 	# Mode that size the character so 100% size fills the height
 	elif size_mode == SizeModes.FIT_SCALE_HEIGHT:
-		transform.size = Vector2(1,1) * size.y/portrait_rect.size.y*character_scale
+		transform.size = Vector2(1,1) * size.y / portrait_rect.size.y*character_scale
 
 	return transform
 
@@ -164,7 +165,7 @@ func is_container(id:Variant) -> bool:
 
 #region DEBUG METHODS
 ################################################################################
-# USE THIS TO DEBUG THE POSITIONS
+### USE THIS TO DEBUG THE POSITIONS
 #func _draw():
 	#draw_rect(Rect2(Vector2(), size), Color(1, 0.3098039329052, 1), false, 2)
 	#draw_string(get_theme_default_font(),get_theme_default_font().get_string_size(container_ids[0], HORIZONTAL_ALIGNMENT_LEFT, 1, get_theme_default_font_size()) , container_ids[0], HORIZONTAL_ALIGNMENT_CENTER)
@@ -182,35 +183,53 @@ func _update_debug_portrait_scene() -> void:
 		for child in get_children():
 			if child != debug_origin:
 				child.free()
-
+	
+	# Get character
 	var character := _get_debug_character()
 	if not character is DialogicCharacter or character.portraits.is_empty():
 		return
-
+	
+	# Determine portrait
 	var debug_portrait := debug_character_portrait
-	if debug_portrait.is_empty(): debug_portrait = character.default_portrait
+	if debug_portrait.is_empty():
+		debug_portrait = character.default_portrait
 	if mode == PositionModes.SPEAKER and !portrait_prefix.is_empty():
 		if portrait_prefix+debug_portrait in character.portraits:
 			debug_portrait = portrait_prefix+debug_portrait
+	
 	var portrait_info: Dictionary = character.get_portrait_info(debug_portrait)
+	
+	# Determine scene
 	var portrait_scene_path: String = portrait_info.get('scene', default_portrait_scene)
-	if portrait_scene_path.is_empty(): portrait_scene_path = default_portrait_scene
+	if portrait_scene_path.is_empty(): 
+		portrait_scene_path = default_portrait_scene
+	
 	debug_character_scene_node = load(portrait_scene_path).instantiate()
+	
 	if !is_instance_valid(debug_character_scene_node):
 		return
+	
+	# Load portrait
+	DialogicUtil.apply_scene_export_overrides(debug_character_scene_node, character.portraits[debug_portrait].get('export_overrides', {}))
 	debug_character_scene_node._update_portrait(character, debug_portrait)
+	
+	# Add character node
 	if !is_instance_valid(debug_character_holder_node):
 		debug_character_holder_node = Node2D.new()
 		add_child(debug_character_holder_node)
+		print(debug_character_holder_node)
+	
+	# Add portrait node
 	debug_character_holder_node.add_child(debug_character_scene_node)
 	move_child(debug_character_holder_node, 0)
 	debug_character_scene_node._set_mirror(character.mirror != mirrored != portrait_info.get('mirror', false))
-	_update_debug_portrait_size_position()
+	
+	_update_debug_portrait_transform()
 
 
 ## Set's the size and position of the holder and scene node
 ## according to the size_mode
-func _update_debug_portrait_size_position() -> void:
+func _update_debug_portrait_transform() -> void:
 	if !Engine.is_editor_hint() or !is_instance_valid(debug_character_scene_node) or !is_instance_valid(debug_origin):
 		return
 	var character := _get_debug_character()
@@ -221,12 +240,13 @@ func _update_debug_portrait_size_position() -> void:
 
 	debug_character_holder_node.scale = transform.size
 
-## Updates the debug origins position. Also calls _update_debug_portrait_size_position()
+
+## Updates the debug origins position. Also calls _update_debug_portrait_transform()
 func _update_debug_origin() -> void:
 	if !Engine.is_editor_hint() or !is_instance_valid(debug_origin):
 		return
 	debug_origin.position = _get_origin_position()
-	_update_debug_portrait_size_position()
+	_update_debug_portrait_transform()
 
 
 

--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -196,6 +196,8 @@ func _update_debug_portrait_scene() -> void:
 	if mode == PositionModes.SPEAKER and !portrait_prefix.is_empty():
 		if portrait_prefix+debug_portrait in character.portraits:
 			debug_portrait = portrait_prefix+debug_portrait
+	if not debug_portrait in character.portraits:
+		debug_portrait = character.default_portrait
 	
 	var portrait_info: Dictionary = character.get_portrait_info(debug_portrait)
 	


### PR DESCRIPTION
On the portrait container, debug portraits didn't show up at all because their export overrides where never loaded. This should now be fixed.
