### PR TITLE
Styles: Rework internal structure of styles

### DIFF
--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -130,7 +130,7 @@ func update_portrait_transforms() -> void:
 func get_local_portrait_transform(portrait_rect:Rect2, character_scale:=1.0) -> Rect2:
 	var transform := Rect2()
 	transform.position = _get_origin_position()
-	
+
 	# Mode that ignores the containers size
 	if size_mode == SizeModes.KEEP:
 		transform.size = Vector2(1,1) * character_scale
@@ -183,12 +183,12 @@ func _update_debug_portrait_scene() -> void:
 		for child in get_children():
 			if child != debug_origin:
 				child.free()
-	
+
 	# Get character
 	var character := _get_debug_character()
 	if not character is DialogicCharacter or character.portraits.is_empty():
 		return
-	
+
 	# Determine portrait
 	var debug_portrait := debug_character_portrait
 	if debug_portrait.is_empty():
@@ -198,34 +198,33 @@ func _update_debug_portrait_scene() -> void:
 			debug_portrait = portrait_prefix+debug_portrait
 	if not debug_portrait in character.portraits:
 		debug_portrait = character.default_portrait
-	
+
 	var portrait_info: Dictionary = character.get_portrait_info(debug_portrait)
-	
+
 	# Determine scene
 	var portrait_scene_path: String = portrait_info.get('scene', default_portrait_scene)
-	if portrait_scene_path.is_empty(): 
+	if portrait_scene_path.is_empty():
 		portrait_scene_path = default_portrait_scene
-	
+
 	debug_character_scene_node = load(portrait_scene_path).instantiate()
-	
+
 	if !is_instance_valid(debug_character_scene_node):
 		return
-	
+
 	# Load portrait
 	DialogicUtil.apply_scene_export_overrides(debug_character_scene_node, character.portraits[debug_portrait].get('export_overrides', {}))
 	debug_character_scene_node._update_portrait(character, debug_portrait)
-	
+
 	# Add character node
 	if !is_instance_valid(debug_character_holder_node):
 		debug_character_holder_node = Node2D.new()
 		add_child(debug_character_holder_node)
-		print(debug_character_holder_node)
-	
+
 	# Add portrait node
 	debug_character_holder_node.add_child(debug_character_scene_node)
 	move_child(debug_character_holder_node, 0)
 	debug_character_scene_node._set_mirror(character.mirror != mirrored != portrait_info.get('mirror', false))
-	
+
 	_update_debug_portrait_transform()
 
 

--- a/addons/dialogic/Modules/DefaultLayoutParts/Style_SpeakerTextbox/speaker_textbox_style.tres
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Style_SpeakerTextbox/speaker_textbox_style.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="DialogicStyle" load_steps=17 format=3 uid="uid://dgkmuyvy5qc35"]
+[gd_resource type="Resource" script_class="DialogicStyle" load_steps=18 format=3 uid="uid://dgkmuyvy5qc35"]
 
 [ext_resource type="PackedScene" uid="uid://c1k5m0w3r40xf" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.tscn" id="1_sde84"]
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style_layer.gd" id="2_i34tx"]
@@ -10,37 +10,41 @@
 [ext_resource type="PackedScene" uid="uid://lx24i8fl6uo" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_layer.tscn" id="8_00chv"]
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style.gd" id="9_sdr6x"]
 
-[sub_resource type="Resource" id="Resource_35sbo"]
+[sub_resource type="Resource" id="Resource_1cyj6"]
+script = ExtResource("2_i34tx")
+overrides = {}
+
+[sub_resource type="Resource" id="Resource_jk75o"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("1_sde84")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_x576n"]
+[sub_resource type="Resource" id="Resource_l2hgc"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("4_8y2vo")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_gc1b5"]
+[sub_resource type="Resource" id="Resource_iqsmu"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("3_epko4")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_otikm"]
+[sub_resource type="Resource" id="Resource_axty6"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("5_ll78j")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_w8ec6"]
+[sub_resource type="Resource" id="Resource_xh5pc"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("6_36eid")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_qmo1y"]
+[sub_resource type="Resource" id="Resource_ytmk0"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("7_hx5el")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_legp8"]
+[sub_resource type="Resource" id="Resource_yjxtw"]
 script = ExtResource("2_i34tx")
 scene = ExtResource("8_00chv")
 overrides = {}
@@ -48,7 +52,17 @@ overrides = {}
 [resource]
 script = ExtResource("9_sdr6x")
 name = "Speaker Textbox Style"
-base_overrides = {
-"global_bg_color": "Color(0.298039, 0.2, 0.113725, 0.901961)"
+layer_list = Array[String](["10", "11", "12", "13", "14", "15", "16"])
+layer_info = {
+"": SubResource("Resource_1cyj6"),
+"10": SubResource("Resource_jk75o"),
+"11": SubResource("Resource_l2hgc"),
+"12": SubResource("Resource_iqsmu"),
+"13": SubResource("Resource_axty6"),
+"14": SubResource("Resource_xh5pc"),
+"15": SubResource("Resource_ytmk0"),
+"16": SubResource("Resource_yjxtw")
 }
-layers = Array[ExtResource("2_i34tx")]([SubResource("Resource_35sbo"), SubResource("Resource_x576n"), SubResource("Resource_gc1b5"), SubResource("Resource_otikm"), SubResource("Resource_w8ec6"), SubResource("Resource_qmo1y"), SubResource("Resource_legp8")])
+base_overrides = {}
+layers = Array[ExtResource("2_i34tx")]([])
+metadata/_latest_layer = ""

--- a/addons/dialogic/Modules/DefaultLayoutParts/Style_TextBubbles/textbubble_style.tres
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Style_TextBubbles/textbubble_style.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="DialogicStyle" load_steps=8 format=3 uid="uid://b0sbwssin2kuk"]
+[gd_resource type="Resource" script_class="DialogicStyle" load_steps=9 format=3 uid="uid://b0sbwssin2kuk"]
 
 [ext_resource type="PackedScene" uid="uid://syki6k0e6aac" path="res://addons/dialogic/Modules/DefaultLayoutParts/Base_TextBubble/text_bubble_base.tscn" id="1_a7s28"]
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style.gd" id="1_q3xp1"]
@@ -6,12 +6,17 @@
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style_layer.gd" id="3_3a5cc"]
 [ext_resource type="PackedScene" uid="uid://cn674foxwedqu" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_Input/full_advance_input_layer.tscn" id="4_rr4hm"]
 
-[sub_resource type="Resource" id="Resource_xt3fr"]
+[sub_resource type="Resource" id="Resource_u2jf8"]
+script = ExtResource("3_3a5cc")
+scene = ExtResource("1_a7s28")
+overrides = {}
+
+[sub_resource type="Resource" id="Resource_ajt4g"]
 script = ExtResource("3_3a5cc")
 scene = ExtResource("4_rr4hm")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_inc2n"]
+[sub_resource type="Resource" id="Resource_phvdv"]
 script = ExtResource("3_3a5cc")
 scene = ExtResource("2_ctkoo")
 overrides = {}
@@ -19,6 +24,12 @@ overrides = {}
 [resource]
 script = ExtResource("1_q3xp1")
 name = "Textbubble Style"
-base_scene = ExtResource("1_a7s28")
+layer_list = Array[String](["10", "11"])
+layer_info = {
+"": SubResource("Resource_u2jf8"),
+"10": SubResource("Resource_ajt4g"),
+"11": SubResource("Resource_phvdv")
+}
 base_overrides = {}
-layers = Array[ExtResource("3_3a5cc")]([SubResource("Resource_xt3fr"), SubResource("Resource_inc2n")])
+layers = Array[ExtResource("3_3a5cc")]([])
+metadata/_latest_layer = ""

--- a/addons/dialogic/Modules/DefaultLayoutParts/Style_VN_Default/default_vn_style.tres
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Style_VN_Default/default_vn_style.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="DialogicStyle" load_steps=19 format=3 uid="uid://8t1mr302tmqs"]
+[gd_resource type="Resource" script_class="DialogicStyle" load_steps=20 format=3 uid="uid://8t1mr302tmqs"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style.gd" id="1_mvpc0"]
 [ext_resource type="Script" path="res://addons/dialogic/Resources/dialogic_style_layer.gd" id="2_3b8ue"]
@@ -11,42 +11,46 @@
 [ext_resource type="PackedScene" uid="uid://cvgf4c6gg0tsy" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_TextInput/text_input_layer.tscn" id="9_tufw5"]
 [ext_resource type="PackedScene" uid="uid://lx24i8fl6uo" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_layer.tscn" id="10_8v8jj"]
 
-[sub_resource type="Resource" id="Resource_x8thn"]
+[sub_resource type="Resource" id="Resource_3dixn"]
+script = ExtResource("2_3b8ue")
+overrides = {}
+
+[sub_resource type="Resource" id="Resource_gen8e"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("2_dtgi6")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_g5yti"]
+[sub_resource type="Resource" id="Resource_nit0s"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("4_q1t5h")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_eqyxb"]
+[sub_resource type="Resource" id="Resource_1ak3n"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("6_j6olx")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_adxfb"]
+[sub_resource type="Resource" id="Resource_05bhv"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("5_o6sv8")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_nmutb"]
+[sub_resource type="Resource" id="Resource_pvwog"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("7_vw5f4")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_dwo52"]
+[sub_resource type="Resource" id="Resource_spe5r"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("8_tc6v1")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_by0l6"]
+[sub_resource type="Resource" id="Resource_jf1ol"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("9_tufw5")
 overrides = {}
 
-[sub_resource type="Resource" id="Resource_fd6co"]
+[sub_resource type="Resource" id="Resource_gs5pl"]
 script = ExtResource("2_3b8ue")
 scene = ExtResource("10_8v8jj")
 overrides = {}
@@ -54,5 +58,18 @@ overrides = {}
 [resource]
 script = ExtResource("1_mvpc0")
 name = "Visual Novel Style"
+layer_list = Array[String](["10", "11", "12", "13", "14", "15", "16", "17"])
+layer_info = {
+"": SubResource("Resource_3dixn"),
+"10": SubResource("Resource_gen8e"),
+"11": SubResource("Resource_nit0s"),
+"12": SubResource("Resource_1ak3n"),
+"13": SubResource("Resource_05bhv"),
+"14": SubResource("Resource_pvwog"),
+"15": SubResource("Resource_spe5r"),
+"16": SubResource("Resource_jf1ol"),
+"17": SubResource("Resource_gs5pl")
+}
 base_overrides = {}
-layers = Array[ExtResource("2_3b8ue")]([SubResource("Resource_x8thn"), SubResource("Resource_g5yti"), SubResource("Resource_eqyxb"), SubResource("Resource_adxfb"), SubResource("Resource_nmutb"), SubResource("Resource_dwo52"), SubResource("Resource_by0l6"), SubResource("Resource_fd6co")])
+layers = Array[ExtResource("2_3b8ue")]([])
+metadata/_latest_layer = "17"

--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -52,10 +52,12 @@ func load_style(style_name := "", parent: Node = null, is_base_style := true, st
 
 		# If this has the same scene setup, just apply the new overrides
 		elif previous_layout.get_meta('style') == style.get_inheritance_root():
-			DialogicUtil.apply_scene_export_overrides(previous_layout, style.get_layer_inherited_info(-1).overrides)
+			DialogicUtil.apply_scene_export_overrides(previous_layout, style.get_layer_inherited_info("").overrides)
 			var index := 0
 			for layer in previous_layout.get_layers():
-				DialogicUtil.apply_scene_export_overrides(layer, style.get_layer_inherited_info(index).overrides)
+				DialogicUtil.apply_scene_export_overrides(
+					layer,
+					style.get_layer_inherited_info(style.get_layer_id_at_index(index)).overrides)
 				index += 1
 
 			previous_layout.set_meta('style', style)
@@ -74,7 +76,7 @@ func load_style(style_name := "", parent: Node = null, is_base_style := true, st
 		# Preserve process_mode on style changes
 		if previous_layout:
 			new_layout.process_mode = previous_layout.process_mode
-		
+
 		new_layout.ready.connect(reload_current_info_into_new_style)
 
 	style_changed.emit(signal_info)
@@ -96,11 +98,11 @@ func create_layout(style: DialogicStyle, parent: Node = null) -> DialogicLayoutB
 	base_scene.name = "DialogicLayout_"+style.name.to_pascal_case()
 
 	# Apply base scene overrides
-	DialogicUtil.apply_scene_export_overrides(base_scene, style.get_layer_inherited_info(-1).overrides)
+	DialogicUtil.apply_scene_export_overrides(base_scene, style.get_layer_inherited_info("").overrides)
 
 	# Load layers
-	for layer_idx in range(style.get_layer_count()):
-		var layer := style.get_layer_inherited_info(layer_idx)
+	for layer_id in style.get_layer_inherited_list():
+		var layer := style.get_layer_inherited_info(layer_id)
 
 		if not ResourceLoader.exists(layer.path):
 			continue
@@ -152,7 +154,7 @@ func has_active_layout_node() -> bool:
 	)
 
 
-func get_layout_node() -> Node:
+func get_layout_node() -> DialogicLayoutBase:
 	if has_active_layout_node():
 		return get_tree().get_meta('dialogic_layout_node')
 	return null

--- a/addons/dialogic/Modules/StyleEditor/style_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_editor.gd
@@ -84,7 +84,7 @@ func add_style(file_path:String, style:DialogicStyle, inherits:DialogicStyle= nu
 	style.resource_path = file_path
 	style.inherits = inherits
 
-	if style.layers.is_empty() and style.inherits != null:
+	if style.layer_list.is_empty() and style.inherits_anything():
 		for id in style.get_layer_inherited_list():
 			style.add_layer('', {}, id)
 

--- a/addons/dialogic/Modules/StyleEditor/style_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_editor.gd
@@ -10,7 +10,7 @@ var default_style := ""
 
 var premade_style_parts := {}
 
-
+@onready var StyleList: ItemList = %StyleList
 
 #region EDITOR MANAGEMENT
 ################################################################################
@@ -28,7 +28,7 @@ func _register() -> void:
 	alternative_text = "Change the look of the dialog in your game"
 
 
-func _open(extra_info:Variant = null) -> void:
+func _open(_extra_info:Variant = null) -> void:
 	load_style_list()
 
 
@@ -57,7 +57,6 @@ func collect_styles() -> void:
 	var style_list: Array = ProjectSettings.get_setting('dialogic/layout/style_list', [])
 	for style in style_list:
 		if ResourceLoader.exists(style):
-			var style_res := load(style)
 			if style != null:
 				styles.append(ResourceLoader.load(style, "DialogicStyle"))
 			else:
@@ -84,13 +83,18 @@ func save_style() -> void:
 func add_style(file_path:String, style:DialogicStyle, inherits:DialogicStyle= null) -> void:
 	style.resource_path = file_path
 	style.inherits = inherits
+
 	if style.layers.is_empty() and style.inherits != null:
-		for l in style.get_layer_list():
-			style.add_layer('', {})
+		for id in style.get_layer_inherited_list():
+			style.add_layer('', {}, id)
+
 	ResourceSaver.save(style, file_path)
+
 	styles.append(style)
+
 	if len(styles) == 1:
 		default_style = style.resource_path
+
 	save_style_list()
 	load_style_list()
 	select_style(style)
@@ -135,32 +139,32 @@ func setup_ui() -> void:
 	%TestStyleButton.icon = get_theme_icon("PlayCustom", "EditorIcons")
 	%MakeDefaultButton.icon = get_theme_icon("Favorites", "EditorIcons")
 
-	%StyleList.item_selected.connect(_on_stylelist_selected)
+	StyleList.item_selected.connect(_on_stylelist_selected)
 	%AddButton.get_popup().index_pressed.connect(_on_AddStyleMenu_selected)
 	%AddButton.about_to_popup.connect(_on_AddStyleMenu_about_to_popup)
 	%InheritanceButton.get_popup().index_pressed.connect(_on_inheritance_index_pressed)
-	%StyleList.set_drag_forwarding(_on_stylelist_drag, _on_stylelist_can_drop, _on_style_list_drop)
+	StyleList.set_drag_forwarding(_on_stylelist_drag, _on_stylelist_can_drop, _on_style_list_drop)
 	%StyleView.hide()
 	%NoStyleView.show()
 
 func load_style_list() -> void:
 	var latest: String = DialogicUtil.get_editor_setting('latest_layout_style', 'Default')
 
-	%StyleList.clear()
+	StyleList.clear()
 	var idx := 0
 	for style in styles:
-		%StyleList.add_item(style.name, get_theme_icon("PopupMenu", "EditorIcons"))
-		%StyleList.set_item_tooltip(idx, style.resource_path)
-		%StyleList.set_item_metadata(idx, style)
-		
+		StyleList.add_item(style.name, get_theme_icon("PopupMenu", "EditorIcons"))
+		StyleList.set_item_tooltip(idx, style.resource_path)
+		StyleList.set_item_metadata(idx, style)
+
 		if style.resource_path == default_style:
-			%StyleList.set_item_icon_modulate(idx, get_theme_color("warning_color", "Editor"))
+			StyleList.set_item_icon_modulate(idx, get_theme_color("warning_color", "Editor"))
 		if style.resource_path.begins_with("res://addons/dialogic"):
-			%StyleList.set_item_icon_modulate(idx, get_theme_color("property_color_z", "Editor"))
-			%StyleList.set_item_tooltip(idx, "This is a default style. Only edit it if you know what you are doing!")
-			%StyleList.set_item_custom_bg_color(idx, get_theme_color("property_color_z", "Editor").lerp(get_theme_color("dark_color_3", "Editor"), 0.8))
+			StyleList.set_item_icon_modulate(idx, get_theme_color("property_color_z", "Editor"))
+			StyleList.set_item_tooltip(idx, "This is a default style. Only edit it if you know what you are doing!")
+			StyleList.set_item_custom_bg_color(idx, get_theme_color("property_color_z", "Editor").lerp(get_theme_color("dark_color_3", "Editor"), 0.8))
 		if style.name == latest:
-			%StyleList.select(idx)
+			StyleList.select(idx)
 			load_style(style)
 		idx += 1
 
@@ -168,20 +172,20 @@ func load_style_list() -> void:
 		%StyleView.hide()
 		%NoStyleView.show()
 
-	elif !%StyleList.is_anything_selected():
-		%StyleList.select(0)
-		load_style(%StyleList.get_item_metadata(0))
+	elif !StyleList.is_anything_selected():
+		StyleList.select(0)
+		load_style(StyleList.get_item_metadata(0))
 
 
 func _on_stylelist_selected(index:int) -> void:
-	load_style(%StyleList.get_item_metadata(index))
+	load_style(StyleList.get_item_metadata(index))
 
 
 func select_style(style:DialogicStyle) -> void:
 	DialogicUtil.set_editor_setting('latest_layout_style', style.name)
-	for idx in range(%StyleList.item_count):
-		if %StyleList.get_item_metadata(idx) == style:
-			%StyleList.select(idx)
+	for idx in range(StyleList.item_count):
+		if StyleList.get_item_metadata(idx) == style:
+			StyleList.select(idx)
 			return
 
 
@@ -216,7 +220,7 @@ func load_style(style:DialogicStyle) -> void:
 
 
 func _on_AddStyleMenu_about_to_popup() -> void:
-	%AddButton.get_popup().set_item_disabled(3, not %StyleList.is_anything_selected())
+	%AddButton.get_popup().set_item_disabled(3, not StyleList.is_anything_selected())
 
 
 func _on_AddStyleMenu_selected(index:int) -> void:
@@ -241,7 +245,7 @@ func _on_AddStyleMenu_selected(index:int) -> void:
 			"Select folder for new style")
 
 	if index == 3:
-		if %StyleList.get_selected_items().is_empty():
+		if StyleList.get_selected_items().is_empty():
 			return
 		find_parent('EditorView').godot_file_dialog(
 			add_style_undoable.bind(DialogicStyle.new(), current_style),
@@ -270,7 +274,7 @@ func add_style_undoable(file_path:String, style:DialogicStyle, inherits:Dialogic
 
 
 func _on_duplicate_button_pressed() -> void:
-	if !%StyleList.is_anything_selected():
+	if !StyleList.is_anything_selected():
 		return
 	find_parent('EditorView').godot_file_dialog(
 		add_style_undoable.bind(current_style.clone(), null),
@@ -280,7 +284,7 @@ func _on_duplicate_button_pressed() -> void:
 
 
 func _on_remove_button_pressed() -> void:
-	if !%StyleList.is_anything_selected():
+	if !StyleList.is_anything_selected():
 		return
 
 	if current_style.name == default_style:
@@ -296,7 +300,7 @@ func _on_edit_name_button_pressed() -> void:
 	%LayoutStyleName.select_all()
 
 
-func _on_layout_style_name_text_submitted(new_text:String) -> void:
+func _on_layout_style_name_text_submitted(_new_text:String) -> void:
 	_on_layout_style_name_focus_exited()
 
 

--- a/addons/dialogic/Modules/StyleEditor/style_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_editor.gd
@@ -153,6 +153,8 @@ func load_style_list() -> void:
 	StyleList.clear()
 	var idx := 0
 	for style in styles:
+		# TODO remove when going Beta
+		style.update_from_pre_alpha16()
 		StyleList.add_item(style.name, get_theme_icon("PopupMenu", "EditorIcons"))
 		StyleList.set_item_tooltip(idx, style.resource_path)
 		StyleList.set_item_metadata(idx, style)

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -8,11 +8,13 @@ var current_style: DialogicStyle = null
 
 var customization_editor_info := {}
 
-## -1 is the base scene, 0 to n are the layers
-var current_layer_idx := -1
+## The id of the currently selected layer.
+## "" is the base scene.
+var current_layer_id := ""
 
 var _minimum_tree_item_height: int
 
+@onready var tree: Tree = %LayerTree
 
 
 func _ready() -> void:
@@ -34,10 +36,10 @@ func _ready() -> void:
 func load_style(style:DialogicStyle) -> void:
 	current_style = style
 
-	if current_style.has_meta('_latest_layer'):
-		current_layer_idx = current_style.get_meta('_latest_layer', -1)
+	if current_style.has_meta("_latest_layer"):
+		current_layer_id = str(current_style.get_meta("_latest_layer", ""))
 	else:
-		current_layer_idx = -1
+		current_layer_id = ""
 
 	%AddLayerButton.disabled = style.inherits_anything()
 	%ReplaceLayerButton.disabled = style.inherits_anything()
@@ -48,58 +50,57 @@ func load_style(style:DialogicStyle) -> void:
 
 
 func load_style_layer_list() -> void:
-	var tree: Tree = %LayerTree
-
 	tree.clear()
 
 	var root := tree.create_item()
-	root.custom_minimum_height = _minimum_tree_item_height
-	var base_scene := current_style.get_inheritance_root().get_base_scene().resource_path
-	if %StyleBrowser.is_premade_style_part(base_scene):
-		if ResourceLoader.exists(%StyleBrowser.premade_scenes_reference[base_scene].get('icon', '')):
-			root.set_icon(0, load(%StyleBrowser.premade_scenes_reference[base_scene].get('icon')))
-		root.set_text(0, %StyleBrowser.premade_scenes_reference[base_scene].get('name', 'Layer'))
-	else:
-		root.set_text(0, clean_scene_name(base_scene))
-		root.add_button(0, get_theme_icon("PackedScene", "EditorIcons"))
-		root.set_button_tooltip_text(0, 0, 'Open Scene')
-	root.set_meta('scene', base_scene)
 
-	for layer_scene in current_style.get_layer_list():
+	var base_layer_info := current_style.get_layer_inherited_info("")
+	setup_layer_tree_item(base_layer_info, root)
+
+	for layer_id in current_style.get_layer_inherited_list():
+		var layer_info := current_style.get_layer_inherited_info(layer_id)
 		var layer_item := tree.create_item(root)
-		layer_item.custom_minimum_height = _minimum_tree_item_height
-		if %StyleBrowser.is_premade_style_part(layer_scene):
-			if ResourceLoader.exists(%StyleBrowser.premade_scenes_reference[layer_scene].get('icon', '')):
-				layer_item.set_icon(0, load(%StyleBrowser.premade_scenes_reference[layer_scene].get('icon')))
+		setup_layer_tree_item(layer_info, layer_item)
 
-			layer_item.set_text(0, %StyleBrowser.premade_scenes_reference[layer_scene].get('name', 'Layer'))
-		else:
-			layer_item.set_text(0, clean_scene_name(layer_scene))
-			layer_item.add_button(0, get_theme_icon("PackedScene", "EditorIcons"))
-			layer_item.set_button_tooltip_text(0, 0, 'Open Scene')
+	select_layer(current_layer_id)
 
-		layer_item.set_meta('scene', layer_scene)
 
-	if current_layer_idx == -1:
-		root.select(0)
+func select_layer(id:String) -> void:
+	if id == "":
+		tree.get_root().select(0)
 	else:
-		root.get_child(current_layer_idx).select(0)
+		for child in tree.get_root().get_children():
+			if child.get_meta("id", "") == id:
+				child.select(0)
+				return
+
+
+func setup_layer_tree_item(info:Dictionary, item:TreeItem) -> void:
+	item.custom_minimum_height = _minimum_tree_item_height
+
+	if %StyleBrowser.is_premade_style_part(info.path):
+		if ResourceLoader.exists(%StyleBrowser.premade_scenes_reference[info.path].get('icon', '')):
+			item.set_icon(0, load(%StyleBrowser.premade_scenes_reference[info.path].get("icon")))
+		item.set_text(0, %StyleBrowser.premade_scenes_reference[info.path].get("name", "Layer"))
+
+	else:
+		item.set_text(0, clean_scene_name(info.path))
+		item.add_button(0, get_theme_icon("PackedScene", "EditorIcons"))
+		item.set_button_tooltip_text(0, 0, "Open Scene")
+	item.set_meta("scene", info.path)
+	item.set_meta("id", info.id)
 
 
 func _on_layer_selected() -> void:
 	var item: TreeItem = %LayerTree.get_selected()
-	if item == %LayerTree.get_root():
-		load_layer(-1)
-	else:
-		load_layer(item.get_index())
+	load_layer(item.get_meta("id", ""))
 
 
+func load_layer(layer_id:=""):
+	current_layer_id = layer_id
+	current_style.set_meta('_latest_layer', current_layer_id)
 
-func load_layer(layer_idx:=-1):
-	current_layer_idx = layer_idx
-
-	current_style.set_meta('_latest_layer', current_layer_idx)
-	var layer_info := current_style.get_layer_inherited_info(layer_idx)
+	var layer_info := current_style.get_layer_inherited_info(layer_id)
 
 	%SmallLayerPreview.hide()
 	if %StyleBrowser.is_premade_style_part(layer_info.get('path', 'Unkown Layer')):
@@ -117,16 +118,17 @@ func load_layer(layer_idx:=-1):
 		%SmallLayerAuthor.text = "Custom Layer"
 		%SmallLayerDescription.text = layer_info.get('path', 'Unkown Layer')
 
-	%DeleteLayerButton.disabled = layer_idx == -1 or current_style.inherits_anything()
+	%DeleteLayerButton.disabled = layer_id == "" or current_style.inherits_anything()
 
 	%SmallLayerScene.text = layer_info.get('path', 'Unkown Layer').get_file()
 	%SmallLayerScene.tooltip_text = layer_info.get('path', '')
 
-	var inherited_layer_info := current_style.get_layer_inherited_info(layer_idx, true)
+	var inherited_layer_info := current_style.get_layer_inherited_info(layer_id, true)
 	load_layout_scene_customization(
 			layer_info.path,
 			layer_info.overrides,
 			inherited_layer_info.overrides)
+
 
 
 func add_layer(scene_path:="", overrides:= {}):
@@ -137,27 +139,26 @@ func add_layer(scene_path:="", overrides:= {}):
 
 
 func delete_layer() -> void:
-	if current_layer_idx == -1:
+	if current_layer_id == "":
 		return
-	current_style.delete_layer(current_layer_idx)
+
+	current_style.delete_layer(current_layer_id)
 	load_style_layer_list()
 	%LayerTree.get_root().select(0)
 
 
 func move_layer(from_idx:int, to_idx:int) -> void:
 	current_style.move_layer(from_idx, to_idx)
+
 	load_style_layer_list()
-	%LayerTree.get_root().get_child(to_idx).select(0)
+	select_layer(current_style.get_layer_id_at_index(to_idx))
 
 
-func replace_layer(layer_index:int, scene_path:String) -> void:
-	current_style.set_layer_scene(layer_index, scene_path)
+func replace_layer(layer_id:String, scene_path:String) -> void:
+	current_style.set_layer_scene(layer_id, scene_path)
+
 	load_style_layer_list()
-
-	if layer_index == -1:
-		%LayerTree.get_root().select(0)
-	else:
-		%LayerTree.get_root().get_child(layer_index).select(0)
+	select_layer(layer_id)
 
 
 func _on_add_layer_menu_pressed(index:int) -> void:
@@ -190,10 +191,7 @@ func _on_replace_layer_menu_pressed(index:int) -> void:
 		%StyleBrowser.load_parts()
 		var picked_info: Dictionary = await %StyleBrowserWindow.get_picked_info()
 		if not picked_info.is_empty():
-			if %LayerTree.get_selected() == %LayerTree.get_root():
-				replace_layer(-1, picked_info.get('path', ''))
-			elif %LayerTree.get_selected() != null:
-				replace_layer(%LayerTree.get_selected().get_index(), picked_info.get('path', ''))
+			replace_layer(%LayerTree.get_selected().get_meta("id", ""), picked_info.get('path', ''))
 
 	# Adding a custom scene as a layer
 	else:
@@ -209,18 +207,14 @@ func _on_add_custom_layer_file_selected(file_path:String) -> void:
 
 
 func _on_replace_custom_layer_file_selected(file_path:String) -> void:
-	if %LayerTree.get_selected() == %LayerTree.get_root():
-		replace_layer(-1, file_path)
-	elif %LayerTree.get_selected() != null:
-		replace_layer(%LayerTree.get_selected().get_index(), file_path)
-
+	replace_layer(%LayerTree.get_selected().get_meta("id", ""), file_path)
 
 
 func _on_make_custom_button_about_to_popup() -> void:
 	%MakeCustomButton.get_popup().set_item_disabled(2, false)
 	%MakeCustomButton.get_popup().set_item_disabled(3, false)
 
-	if not %StyleBrowser.is_premade_style_part(current_style.get_layer_info(current_layer_idx).path):
+	if not %StyleBrowser.is_premade_style_part(current_style.get_layer_info(current_layer_id).path):
 		%MakeCustomButton.get_popup().set_item_disabled(2, true)
 
 
@@ -250,14 +244,14 @@ func _on_make_custom_layout_file_selected(file:String) -> void:
 
 
 func make_layer_custom(target_folder:String, custom_name := "") -> void:
-	
-	var original_file: String = current_style.get_layer_info(current_layer_idx).path
+
+	var original_file: String = current_style.get_layer_info(current_layer_id).path
 	var custom_new_folder := ""
-	
+
 	if custom_name.is_empty():
 		custom_name = "custom_"+%StyleBrowser.premade_scenes_reference[original_file].name.to_snake_case()
 		custom_new_folder = %StyleBrowser.premade_scenes_reference[original_file].name.to_pascal_case()
-	
+
 	var result_path := DialogicUtil.make_file_custom(
 		original_file,
 		target_folder,
@@ -265,7 +259,7 @@ func make_layer_custom(target_folder:String, custom_name := "") -> void:
 		custom_new_folder,
 		)
 
-	current_style.set_layer_scene(current_layer_idx, result_path)
+	current_style.set_layer_scene(current_layer_id, result_path)
 
 	load_style_layer_list()
 
@@ -283,16 +277,17 @@ func make_layout_custom(target_folder:String) -> void:
 	make_layer_custom(target_folder, "custom_" + current_style.name.to_snake_case())
 
 
-	var target_path := current_style.get_base_scene().resource_path
+	var base_layer_info := current_style.get_layer_info("")
+	var target_path: String = base_layer_info.path
 
 	# Load base scene
-	var base_scene_pck: PackedScene = current_style.get_base_scene().duplicate()
+	var base_scene_pck: PackedScene = load(base_layer_info.path).duplicate()
 	var base_scene := base_scene_pck.instantiate()
 	base_scene.name = "Custom" + clean_scene_name(base_scene_pck.resource_path).to_pascal_case()
 
 	# Load layers
-	for layer_idx in range(current_style.get_layer_count()):
-		var layer_info := current_style.get_layer_inherited_info(layer_idx)
+	for layer_id in current_style.get_layer_inherited_list():
+		var layer_info := current_style.get_layer_inherited_info(layer_id)
 
 		if not ResourceLoader.exists(layer_info.path):
 			continue
@@ -488,15 +483,15 @@ func collect_settings(properties:Array[Dictionary]) -> Array[Dictionary]:
 
 func set_export_override(property_name:String, value:String = "") -> void:
 	if str_to_var(value) != customization_editor_info[property_name]['orig']:
-		current_style.set_layer_setting(current_layer_idx, property_name, value)
+		current_style.set_layer_setting(current_layer_id, property_name, value)
 		customization_editor_info[property_name]['reset'].disabled = false
 	else:
-		current_style.remove_layer_setting(current_layer_idx, property_name)
+		current_style.remove_layer_setting(current_layer_id, property_name)
 		customization_editor_info[property_name]['reset'].disabled = true
 
 
 func _on_export_override_reset(property_name:String) -> void:
-	current_style.remove_layer_setting(current_layer_idx, property_name)
+	current_style.remove_layer_setting(current_layer_id, property_name)
 	customization_editor_info[property_name]['reset'].disabled = true
 	set_customization_value(property_name, customization_editor_info[property_name]['orig'])
 

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -21,13 +21,6 @@ class_name DialogicStyle
 	"" : DialogicStyleLayer.new()
 }
 
-# TODO  Deprecated
-var base_scene: PackedScene = null
-# TODO Deprecated
-var base_overrides := {}
-# TODO Deprecated, only for Styles before alpha 16!
-var layers: Array[DialogicStyleLayer] = []
-
 
 
 
@@ -35,10 +28,39 @@ func _init(_name := "") -> void:
 	if not _name.is_empty():
 		name = _name
 
-	# TODO deprecated when going into beta
+#region UPDATE OLD STYLES
+# TODO deprecated when going into beta
+
+# TODO  Deprecated, only for Styles before alpha 16!
+@export var base_scene: PackedScene = null
+# TODO Deprecated, only for Styles before alpha 16!
+@export var base_overrides := {}
+# TODO Deprecated, only for Styles before alpha 16!
+@export var layers: Array[DialogicStyleLayer] = []
+
+func update_from_pre_alpha16() -> void:
 	if not layers.is_empty():
+		var idx := 0
 		for layer in layers:
-			pass
+			var id := "##"
+			if inherits_anything():
+				id = get_layer_inherited_list()[idx]
+			if layer.scene:
+				add_layer(layer.scene.resource_path, layer.overrides, id)
+			else:
+				add_layer("", layer.overrides, id)
+			idx += 1
+		layers.clear()
+
+	if not base_scene == null:
+		set_layer_scene("", base_scene.resource_path)
+		base_scene = null
+	if not base_overrides.is_empty():
+		set_layer_overrides("", base_overrides)
+		base_overrides.clear()
+
+#endregion
+
 
 #region BASE METHODS
 # These methods are local, meaning they do NOT take inheritance into account.
@@ -144,6 +166,14 @@ func set_layer_scene(layer_id:String, scene:String) -> void:
 		return
 
 	layer_info[layer_id].scene = load(scene)
+	changed.emit()
+
+
+func set_layer_overrides(layer_id:String, overrides:Dictionary) -> void:
+	if not has_layer(layer_id):
+		return
+
+	layer_info[layer_id].overrides = overrides
 	changed.emit()
 
 

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -28,38 +28,6 @@ func _init(_name := "") -> void:
 	if not _name.is_empty():
 		name = _name
 
-#region UPDATE OLD STYLES
-# TODO deprecated when going into beta
-
-# TODO  Deprecated, only for Styles before alpha 16!
-@export var base_scene: PackedScene = null
-# TODO Deprecated, only for Styles before alpha 16!
-@export var base_overrides := {}
-# TODO Deprecated, only for Styles before alpha 16!
-@export var layers: Array[DialogicStyleLayer] = []
-
-func update_from_pre_alpha16() -> void:
-	if not layers.is_empty():
-		var idx := 0
-		for layer in layers:
-			var id := "##"
-			if inherits_anything():
-				id = get_layer_inherited_list()[idx]
-			if layer.scene:
-				add_layer(layer.scene.resource_path, layer.overrides, id)
-			else:
-				add_layer("", layer.overrides, id)
-			idx += 1
-		layers.clear()
-
-	if not base_scene == null:
-		set_layer_scene("", base_scene.resource_path)
-		base_scene = null
-	if not base_overrides.is_empty():
-		set_layer_overrides("", base_overrides)
-		base_overrides.clear()
-
-#endregion
 
 
 #region BASE METHODS
@@ -245,17 +213,18 @@ func get_layer_inherited_info(id:String, inherited_only := false) -> Dictionary:
 	return info
 
 
+## Returns the layer list of the root style.
 func get_layer_inherited_list() -> Array:
-	var style := self
 	var list := layer_list
 
-	while style.inherits_anything():
-		style = style.inherits
-		list = style.layer_list
+	if inherits_anything():
+		list = get_inheritance_root().layer_list
 
 	return list
 
 
+## Applies inherited info to the local layers.
+## Then removes inheritance.
 func realize_inheritance() -> void:
 	layer_list = get_layer_inherited_list()
 
@@ -269,8 +238,9 @@ func realize_inheritance() -> void:
 	changed.emit()
 
 
-##endregion
+#endregion
 
+## Creates a fresh new style with the same settings.
 func clone() -> DialogicStyle:
 	var style := DialogicStyle.new()
 	style.name = name
@@ -284,7 +254,42 @@ func clone() -> DialogicStyle:
 	return style
 
 
+## Starts preloading all the scenes used by this style.
 func prepare() -> void:
 	for id in layer_info:
 		if layer_info[id].scene:
 			ResourceLoader.load_threaded_request(layer_info[id].scene.resource_path)
+
+
+#region UPDATE OLD STYLES
+# TODO deprecated when going into beta
+
+# TODO  Deprecated, only for Styles before alpha 16!
+@export var base_scene: PackedScene = null
+# TODO Deprecated, only for Styles before alpha 16!
+@export var base_overrides := {}
+# TODO Deprecated, only for Styles before alpha 16!
+@export var layers: Array[DialogicStyleLayer] = []
+
+func update_from_pre_alpha16() -> void:
+	if not layers.is_empty():
+		var idx := 0
+		for layer in layers:
+			var id := "##"
+			if inherits_anything():
+				id = get_layer_inherited_list()[idx]
+			if layer.scene:
+				add_layer(layer.scene.resource_path, layer.overrides, id)
+			else:
+				add_layer("", layer.overrides, id)
+			idx += 1
+		layers.clear()
+
+	if not base_scene == null:
+		set_layer_scene("", base_scene.resource_path)
+		base_scene = null
+	if not base_overrides.is_empty():
+		set_layer_overrides("", base_overrides)
+		base_overrides.clear()
+
+#endregion

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -14,180 +14,246 @@ class_name DialogicStyle
 
 @export var inherits: DialogicStyle = null
 
-@export var base_scene: PackedScene = null
-@export var base_overrides := {}
+## Stores the layer order
+@export var layer_list: Array[String] = []
+## Stores the layer infos
+@export var layer_info := {
+	"" : DialogicStyleLayer.new()
+}
 
-@export var layers: Array[DialogicStyleLayer] = []
+# TODO  Deprecated
+var base_scene: PackedScene = null
+# TODO Deprecated
+var base_overrides := {}
+# TODO Deprecated, only for Styles before alpha 16!
+var layers: Array[DialogicStyleLayer] = []
 
 
 
-func _init(_name:="") -> void:
+
+func _init(_name := "") -> void:
 	if not _name.is_empty():
 		name = _name
 
+	# TODO deprecated when going into beta
+	if not layers.is_empty():
+		for layer in layers:
+			pass
 
-## This always returns the inheritance root's scene!
-func get_base_scene() -> PackedScene:
-	if base_scene == null:
-		return DialogicUtil.get_default_layout_base()
-
-	return get_inheritance_root().base_scene
-
-
-## This always returns the full inherited roots layers!
-func get_layer_list() -> PackedStringArray:
-	return PackedStringArray(get_inheritance_root().layers.map(func(x:DialogicStyleLayer): return x.scene.resource_path))
+#region BASE METHODS
+# These methods are local, meaning they do NOT take inheritance into account.
 
 
+## Returns the amount of layers (the base layer is not included).
 func get_layer_count() -> int:
-	return layers.size()
+	return layer_list.size()
 
 
-func get_layer_info(index:int) -> Dictionary:
+## Returns the index of the layer with [param id] in the layer list.
+## Returns -1 for the base layer (id=="") which is not in the layer list.
+func get_layer_index(id:String) -> int:
+	return layer_list.find(id)
+
+
+## Returns `true` if [param id] is a valid id for a layer.
+func has_layer(id:String) -> bool:
+	return id in layer_info or id == ""
+
+
+## Returns `true` if [param index] is a valid index for a layer.
+func has_layer_index(index:int) -> bool:
+	return index < layer_list.size()
+
+
+## Returns the id of the layer at [param index].
+func get_layer_id_at_index(index:int) -> String:
 	if index == -1:
-		return {'path':get_base_scene().resource_path, 'overrides':base_overrides.duplicate()}
-
-	if index < layers.size():
-		if layers[index].scene != null:
-			return {'path':layers[index].scene.resource_path, 'overrides':layers[index].overrides.duplicate()}
-		else:
-			return {'path':'', 'overrides':layers[index].overrides.duplicate()}
-
-	return {'path':'', 'overrides':{}}
+		return ""
+	if has_layer_index(index):
+		return layer_list[index]
+	return ""
 
 
-func get_layer_inherited_info(index:int, inherited_only:=false) -> Dictionary:
-	var style := self
-	var info := {'path':'', 'overrides':{}}
-	if not inherited_only:
-		info = get_layer_info(index)
+func get_layer_info(id:String) -> Dictionary:
+	var info := {"id": id, "path": "", "overrides": {}}
 
-	while style.inherits != null:
-		style = style.inherits
-		info = merge_layer_infos(info, style.get_layer_info(index))
+	if has_layer(id):
+		var layer_resource: DialogicStyleLayer = layer_info[id]
+
+		if layer_resource.scene != null:
+			info.path = layer_resource.scene.resource_path
+		elif id == "":
+			info.path = DialogicUtil.get_default_layout_base().resource_path
+
+		info.overrides = layer_resource.overrides.duplicate()
 
 	return info
 
+#endregion
 
-func add_layer(scene:String, overrides:Dictionary = {}) -> void:
-	layers.append(DialogicStyleLayer.new(scene, overrides))
+
+#region MODIFICATION METHODS
+# These methods modify the layers of this style.
+
+
+## Returns a new layer id not yet in use.
+func get_new_layer_id() -> String:
+	var i := 16
+	while String.num_int64(i, 16) in layer_info:
+		i += 1
+	return String.num_int64(i, 16)
+
+
+## Adds a layer with the given scene and overrides.
+## Returns the new layers id.
+func add_layer(scene:String, overrides:Dictionary = {}, id:="##") -> String:
+	if id == "##":
+		id = get_new_layer_id()
+	layer_info[id] = DialogicStyleLayer.new(scene, overrides)
 	changed.emit()
+	return id
 
 
-func delete_layer(layer_index:int) -> void:
-	if not has_layer(layer_index):
+## Deletes the layer with the given id.
+## Deleting the base layer is not allowed.
+func delete_layer(id:String) -> void:
+	if not has_layer(id) or id == "":
 		return
 
-	layers.remove_at(layer_index)
+	layer_info.erase(id)
+	layer_list.erase(id)
+
 	changed.emit()
 
 
+## Moves the layer at [param from_index] to [param to_index].
 func move_layer(from_index:int, to_index:int) -> void:
-	if not has_layer(from_index) or not has_layer(to_index-1):
+	if not has_layer_index(from_index) or not has_layer_index(to_index-1):
 		return
 
-	var info: Resource = layers.pop_at(from_index)
-	layers.insert(to_index, info)
-	changed.emit()
-
-
-func set_layer_scene(layer_index:int, scene:String) -> void:
-	if not has_layer(layer_index):
-		return
-
-	if layer_index == -1:
-		base_scene = load(scene)
-	else:
-		layers[layer_index].scene = load(scene)
+	var id := layer_list.pop_at(from_index)
+	layer_list.insert(to_index, id)
 
 	changed.emit()
 
 
-func set_layer_setting(layer:int, setting:String, value:Variant) -> void:
-	if not has_layer(layer):
+## Changes the scene property of the DialogicStyleLayer resource at [param layer_id].
+func set_layer_scene(layer_id:String, scene:String) -> void:
+	if not has_layer(layer_id):
 		return
 
-	if layer == -1:
-		base_overrides[setting] = value
-	else:
-		layers[layer].overrides[setting] = value
-
+	layer_info[layer_id].scene = load(scene)
 	changed.emit()
 
 
-func remove_layer_setting(layer:int, setting:String) -> void:
-	if not has_layer(layer):
+## Changes an override of the DialogicStyleLayer resource at [param layer_id].
+func set_layer_setting(layer_id:String, setting:String, value:Variant) -> void:
+	if not has_layer(layer_id):
 		return
 
-	if layer == -1:
-		base_overrides.erase(setting)
-	else:
-		layers[layer].overrides.erase(setting)
-
+	layer_info[layer_id].overrides[setting] = value
 	changed.emit()
 
 
-## This merges two layers (mainly their overrides). Layer a has priority!
-func merge_layer_infos(layer_a:Dictionary, layer_b:Dictionary) -> Dictionary:
-	var combined := layer_a.duplicate(true)
+## Resets (removes) an override of the DialogicStyleLayer resource at [param layer_id].
+func remove_layer_setting(layer_id:String, setting:String) -> void:
+	if not has_layer(layer_id):
+		return
 
-	combined.path = layer_b.path
-	combined.overrides.merge(layer_b.overrides)
+	layer_info[layer_id].overrides.erase(setting)
+	changed.emit()
 
-	return combined
-
-
-func has_layer(index:int) -> bool:
-	return index < layers.size()
+#
+#endregion
 
 
+#region INHERITANCE METHODS
+# These methods are what you should usually use to get info about this style.
+
+
+## Returns `true` if this style is inheriting from another style.
 func inherits_anything() -> bool:
 	return inherits != null
 
 
+## Returns the base style of this style.
 func get_inheritance_root() -> DialogicStyle:
-	if inherits == null:
+	if not inherits_anything():
 		return self
 
 	var style: DialogicStyle = self
-	while style.inherits != null:
+	while style.inherits_anything():
 		style = style.inherits
 
 	return style
 
 
+## This merges some [param layer_info] with it's param ancestors layer info.
+func merge_layer_infos(layer_info:Dictionary, ancestor_info:Dictionary) -> Dictionary:
+	var combined := layer_info.duplicate(true)
+
+	combined.path = ancestor_info.path
+	combined.overrides.merge(ancestor_info.overrides)
+
+	return combined
+
+
+## Returns the layer info of the layer at [param id] taking into account inherited info.
+## If [param inherited_only] is `true`, the local info is not included.
+func get_layer_inherited_info(id:String, inherited_only := false) -> Dictionary:
+	var style := self
+	var info := {"id": id, "path": "", "overrides": {}}
+
+	if not inherited_only:
+		info = get_layer_info(id)
+
+	while style.inherits_anything():
+		style = style.inherits
+		info = merge_layer_infos(info, style.get_layer_info(id))
+
+	return info
+
+
+func get_layer_inherited_list() -> Array:
+	var style := self
+	var list := layer_list
+
+	while style.inherits_anything():
+		style = style.inherits
+		list = style.layer_list
+
+	return list
+
+
 func realize_inheritance() -> void:
-	base_scene = get_base_scene()
-	base_overrides = get_layer_inherited_info(-1)
+	layer_list = get_layer_inherited_list()
 
-	var _layers: Array[DialogicStyleLayer] = []
-	for i in range(get_layer_count()):
-		var info := get_layer_inherited_info(i)
-		_layers.append(DialogicStyleLayer.new(info.get("path", ""), info.get("overrides", {})))
+	var new_layer_info := {}
+	for id in layer_info:
+		var info := get_layer_inherited_info(id)
+		new_layer_info[id] = DialogicStyleLayer.new(info.get("path", ""), info.get("overrides", {}))
 
-	layers = _layers
+	layer_info = new_layer_info
 	inherits = null
 	changed.emit()
 
 
+##endregion
+
 func clone() -> DialogicStyle:
 	var style := DialogicStyle.new()
 	style.name = name
-	if base_scene != null:
-		style.base_scene = base_scene
 	style.inherits = inherits
-	style.base_overrides = base_overrides
-	for layer_idx in range(get_layer_count()):
-		var info := get_layer_info(layer_idx)
-		style.add_layer(info.path, info.overrides)
+	style.layer_list = layer_list.duplicate(true)
+
+	for id in layer_info:
+		var info := get_layer_info(id)
+		style.add_layer(info.path, info.overrides, id)
 
 	return style
 
 
 func prepare() -> void:
-	if base_scene:
-		ResourceLoader.load_threaded_request(base_scene.resource_path)
-
-	for layer in layers:
-		if layer.scene:
-			ResourceLoader.load_threaded_request(layer.scene.resource_path)
+	for id in layer_info:
+		if layer_info[id].scene:
+			ResourceLoader.load_threaded_request(layer_info[id].scene.resource_path)

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -96,7 +96,7 @@ func get_new_layer_id() -> String:
 
 ## Adds a layer with the given scene and overrides.
 ## Returns the new layers id.
-func add_layer(scene:String, overrides:Dictionary = {}, id:="##") -> String:
+func add_layer(scene:String, overrides:Dictionary = {}, id:= "##") -> String:
 	if id == "##":
 		id = get_new_layer_id()
 	layer_info[id] = DialogicStyleLayer.new(scene, overrides)
@@ -245,9 +245,12 @@ func clone() -> DialogicStyle:
 	var style := DialogicStyle.new()
 	style.name = name
 	style.inherits = inherits
-	style.layer_list = layer_list.duplicate(true)
 
-	for id in layer_info:
+	var base_info := get_layer_info("")
+	set_layer_scene("", base_info.path)
+	set_layer_overrides("", base_info.overrides)
+
+	for id in layer_list:
 		var info := get_layer_info(id)
 		style.add_layer(info.path, info.overrides, id)
 
@@ -291,5 +294,6 @@ func update_from_pre_alpha16() -> void:
 	if not base_overrides.is_empty():
 		set_layer_overrides("", base_overrides)
 		base_overrides.clear()
+
 
 #endregion

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -110,6 +110,7 @@ func add_layer(scene:String, overrides:Dictionary = {}, id:="##") -> String:
 	if id == "##":
 		id = get_new_layer_id()
 	layer_info[id] = DialogicStyleLayer.new(scene, overrides)
+	layer_list.append(id)
 	changed.emit()
 	return id
 

--- a/addons/dialogic/Resources/dialogic_style_layer.gd
+++ b/addons/dialogic/Resources/dialogic_style_layer.gd
@@ -12,4 +12,3 @@ func _init(scene_path:Variant=null, scene_overrides:Dictionary={}):
 	elif scene_path is String and ResourceLoader.exists(scene_path):
 		scene = load(scene_path)
 	overrides = scene_overrides
-


### PR DESCRIPTION
This is a big rewrite of how styles are stored in layers with the main goal of identifying styles not by their index but by an identifier. This solves a big issue that inherited styles previously had, where moving the layers of the base style was allowed but would break sub-styles. 

This also includes some code which auto-updates existing styles, but I'd like to remove this code again before we enter the beta phase (or at least for stable).

- fixes #2085