### PR TITLE
Make variable editor right click menu hidden by default

### DIFF
--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
@@ -147,7 +147,6 @@ icon_alignment = 1
 [node name="RightClickMenu" type="PopupMenu" parent="Editor/Tree"]
 unique_name_in_owner = true
 size = Vector2i(67, 35)
-visible = true
 item_count = 1
 item_0/text = "Copy"
 item_0/id = 0


### PR DESCRIPTION
The RightClick menu showed up in the top left of the editor each time the editor was started because `visible` was set to `true`. This fixes that so the menu doesn't show up by default.