### PR TITLE
fix: potential infinite loop on DialogicResourceUtil.gd

### DIFF
--- a/addons/dialogic/Core/DialogicResourceUtil.gd
+++ b/addons/dialogic/Core/DialogicResourceUtil.gd
@@ -53,8 +53,12 @@ static func update_directory(extension:String) -> void:
 
 static func add_resource_to_directory(file_path:String, directory:Dictionary) -> Dictionary:
 	var suggested_name := file_path.get_file().trim_suffix("."+file_path.get_extension())
+	var temp := suggested_name
 	while suggested_name in directory:
 		suggested_name = file_path.trim_suffix("/"+suggested_name+"."+file_path.get_extension()).get_file().path_join(suggested_name)
+		if suggested_name == temp:
+			break
+		temp = suggested_name
 	directory[suggested_name] = file_path
 	return directory
 


### PR DESCRIPTION
My game was strangely freezing when trying to trigger a timeline. I looked into the codebase and I found out this while loop on DialogicResourceUtil caused the issue.

```gdscript
static func add_resource_to_directory(file_path:String, directory:Dictionary) -> Dictionary:
    var suggested_name := file_path.get_file().trim_suffix("."+file_path.get_extension())
    while suggested_name in directory:
        suggested_name = file_path.trim_suffix("/"+suggested_name+"."+file_path.get_extension()).get_file().path_join(suggested_name)
    directory[suggested_name] = file_path
    return directory
```
If file_path is `user://laura olsdal.dch` and directory is `{ ..., "laura_olsdal": "res://assets/characters/laura_olsdal/laura_olsdal.dch", ... }` the code enters an infinite loop. So I just made a little check to break the loop if `suggested_name` stops changing.
