### PR TITLE
Add: Typing Sound Audio Bus in Character Settings

### DIFF
--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
@@ -234,6 +234,6 @@ func preview() -> void:
 
 func _load_audio_bus_options() -> void:
 	%AudioBus.clear()
-	for i in AudioServer.bus_count:
+	for i: int in AudioServer.bus_count:
 		var bus = AudioServer.get_bus_name(i)
 		%AudioBus.add_item(bus)

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
@@ -60,8 +60,8 @@ func _ready() -> void:
 	%Duplicate.icon = get_theme_icon("Duplicate", "EditorIcons")
 	%Play.icon = get_theme_icon("Play", "EditorIcons")
 	%Default.icon = get_theme_icon("NonFavorite", "EditorIcons")
-
 	%NameWarning.texture = get_theme_icon("StatusWarning", "EditorIcons")
+	_load_audio_bus_options()
 
 
 func update_mood_list(selected_name := "") -> void:
@@ -127,6 +127,7 @@ func load_mood_info(dict:Dictionary) -> void:
 	%VolumeBase.set_value(dict.get('volume_base', 0))
 	%VolumeVariance.set_value(dict.get('volume_variance', 0))
 	%Skip.set_value(dict.get('skip_characters', 0))
+	%AudioBus.select(dict.get('audio_bus', 0))
 
 
 func get_mood_info() -> Dictionary:
@@ -139,6 +140,7 @@ func get_mood_info() -> Dictionary:
 	dict['volume_base'] = %VolumeBase.value
 	dict['volume_variance'] = %VolumeVariance.value
 	dict['skip_characters'] = %Skip.value
+	dict['audio_bus'] = %AudioBus.selected
 	return dict
 
 
@@ -228,3 +230,10 @@ func preview() -> void:
 		await preview_timer.timeout
 
 	preview_timer.queue_free()
+
+
+func _load_audio_bus_options() -> void:
+	%AudioBus.clear()
+	for i in AudioServer.bus_count:
+		var bus = AudioServer.get_bus_name(i)
+		%AudioBus.add_item(bus)

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
@@ -170,7 +170,7 @@ text = "Audio Bus:"
 [node name="AudioBus" type="OptionButton" parent="VBox/Settings/Grid"]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "Audio bus in which the type sounds will be sent"
+tooltip_text = "Audio bus on which the typing sounds will be played."
 selected = 0
 item_count = 1
 popup/item_0/text = "Master"

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
@@ -163,6 +163,18 @@ size_flags_horizontal = 3
 file_filter = "*.ogg, *.mp3, *.wav"
 file_mode = 3
 
+[node name="AudioBusLabel" type="Label" parent="VBox/Settings/Grid"]
+layout_mode = 2
+text = "Audio Bus:"
+
+[node name="AudioBus" type="OptionButton" parent="VBox/Settings/Grid"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Audio bus in which the type sounds will be sent"
+selected = 0
+item_count = 1
+popup/item_0/text = "Master"
+
 [node name="Label2" type="Label" parent="VBox/Settings/Grid"]
 layout_mode = 2
 text = "Pitch:"

--- a/addons/dialogic/Modules/Text/node_type_sound.gd
+++ b/addons/dialogic/Modules/Text/node_type_sound.gd
@@ -44,6 +44,7 @@ func _on_started_revealing_text() -> void:
 	var default_bus_index: int = AudioServer.get_bus_index(bus)
 	var bus_index: int = current_overwrite_data.get('audio_bus', default_bus_index)
 	bus = AudioServer.get_bus_name(bus_index)
+	
 	if !enabled or (get_parent() is DialogicNode_DialogText and !get_parent().enabled):
 		return
 	characters_since_last_sound = current_overwrite_data.get('skip_characters', play_every_character-1)+1

--- a/addons/dialogic/Modules/Text/node_type_sound.gd
+++ b/addons/dialogic/Modules/Text/node_type_sound.gd
@@ -41,6 +41,9 @@ func _ready() -> void:
 
 
 func _on_started_revealing_text() -> void:
+	var default_bus_index: int = AudioServer.get_bus_index(bus)
+	var bus_index: int = current_overwrite_data.get('audio_bus', default_bus_index)
+	bus = AudioServer.get_bus_name(bus_index)
 	if !enabled or (get_parent() is DialogicNode_DialogText and !get_parent().enabled):
 		return
 	characters_since_last_sound = current_overwrite_data.get('skip_characters', play_every_character-1)+1


### PR DESCRIPTION
Add a new field "Audio Bus" into the character settings typing sounds section:
![image](https://github.com/user-attachments/assets/f0627b98-1684-4782-8dae-1e66838fb512)
The Audio Bus is an OptionButton field which values are populated from AudioServer buses.
I decided to make the change after opening the issue:
#2420 