### PR TITLE
handle some null/freed item cases to avoid bugs

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -112,9 +112,11 @@ func batch_events(array: Array, size: int, batch_number: int) -> Array:
 var opener_events_stack := []
 
 func load_batch(data:Array) -> void:
-	var current_batch: Array = _batches.pop_front()
+	# Don't try to cast it to Array immedietly, as the item may have become null and will throw a useless error
+	var current_batch = _batches.pop_front()
 	if current_batch:
-		for i in current_batch:
+		var current_batch_items: Array = current_batch
+		for i in current_batch_items:
 			if i is DialogicEndBranchEvent:
 				create_end_branch_event(%Timeline.get_child_count(), opener_events_stack.pop_back())
 			else:
@@ -134,9 +136,9 @@ func _on_batch_loaded() -> void:
 		return
 
 	if opener_events_stack:
-
 		for ev in opener_events_stack:
-			create_end_branch_event(%Timeline.get_child_count(), ev)
+			if is_instance_valid(ev):
+				create_end_branch_event(%Timeline.get_child_count(), ev)
 
 	opener_events_stack = []
 	indent_events()


### PR DESCRIPTION
May fix #2381  but don't know for sure yet.

Regardless, this gets rid of some potential error spam that isn't useful to the end-user.

Sometimes the `opener_events_stack` items can be in the process of being freed, or have become Null by the time the code got there and causes an error trying to feed them into the `create_and_branch_event()` function.
Same with the `_batches` content.