### PR TITLE
Fix test timeline scene error with Dictionary signal event

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
+++ b/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 	DialogicUtil.autoload().signal_event.connect(receive_event_signal)
 	DialogicUtil.autoload().text_signal.connect(receive_text_signal)
 
-func receive_event_signal(argument:String) -> void:
+func receive_event_signal(argument:Variant) -> void:
 	print("[Dialogic] Encountered a signal event: ", argument)
 
 func receive_text_signal(argument:String) -> void:


### PR DESCRIPTION
Fixes an error when using the Play Timeline button when you have a signal event that uses a `Dictionary` instead of a `String`.