### PR TITLE
Implement audio previews

### DIFF
--- a/addons/dialogic/Modules/Audio/event_music.gd
+++ b/addons/dialogic/Modules/Audio/event_music.gd
@@ -110,7 +110,6 @@ func get_channel_list() -> Array:
 	return channel_name_list
 
 
-
 func _on_play_preview_audio() -> void:
 	if _preview_node:
 		_preview_node.stream = load(file_path)
@@ -126,4 +125,3 @@ func _on_stop_preview_audio() -> void:
 
 func _on_preview_finished() -> void:
 	ui_update_needed.emit()
-

--- a/addons/dialogic/Modules/Audio/event_sound.gd
+++ b/addons/dialogic/Modules/Audio/event_sound.gd
@@ -73,8 +73,8 @@ func get_shortcode_parameters() -> Dictionary:
 ################################################################################
 
 func build_event_editor() -> void:
-	add_header_edit('file_path', ValueType.FILE,
-			{'left_text'	: 'Play',
+	add_header_edit('file_path', ValueType.FILE, {
+			'left_text'	: 'Play',
 			'file_filter' 	: '*.mp3, *.ogg, *.wav; Supported Audio Files',
 			'placeholder' 	: "Select file",
 			'editor_icon' 	: ["AudioStreamPlayer", "EditorIcons"]})

--- a/addons/dialogic/Modules/Voice/event_voice.gd
+++ b/addons/dialogic/Modules/Voice/event_voice.gd
@@ -15,6 +15,8 @@ var volume: float = 0
 var audio_bus := "Master"
 
 
+var _preview_node: AudioStreamPlayer
+
 ################################################################################
 ## 						EXECUTE
 ################################################################################
@@ -45,6 +47,11 @@ func _init() -> void:
 	event_sorting_index = 5
 
 
+func _enter_visual_editor(_timeline_editor:DialogicEditor) -> void:
+	_preview_node = AudioStreamPlayer.new()
+	editor_node.add_child(_preview_node)
+	_preview_node.finished.connect(_on_preview_finished)
+
 ################################################################################
 ## 						SAVING/LOADING
 ################################################################################
@@ -73,5 +80,24 @@ func build_event_editor() -> void:
 			'file_filter'	: "*.mp3, *.ogg, *.wav",
 			'placeholder' 	: "Select file",
 			'editor_icon' 	: ["AudioStreamPlayer", "EditorIcons"]})
+	add_header_button('', _on_play_preview_audio, '', ["Play", "EditorIcons"], '!file_path.is_empty() && !_preview_node.is_playing()')
+	add_header_button('', _on_stop_preview_audio, '', ["Stop", "EditorIcons"], '_preview_node.is_playing()')
 	add_body_edit('volume', ValueType.NUMBER, {'left_text':'Volume:', 'mode':2}, '!file_path.is_empty()')
 	add_body_edit('audio_bus', ValueType.SINGLELINE_TEXT, {'left_text':'Audio Bus:'}, '!file_path.is_empty()')
+
+
+func _on_play_preview_audio() -> void:
+	if _preview_node:
+		_preview_node.stream = load(file_path)
+		_preview_node.play()
+		ui_update_needed.emit()
+
+
+func _on_stop_preview_audio() -> void:
+	_preview_node.stop()
+	_preview_node.stream = null
+	ui_update_needed.emit()
+
+
+func _on_preview_finished() -> void:
+	ui_update_needed.emit()


### PR DESCRIPTION
Closes: #1072 

Behaves essentially the same as Dialogic 1. An `AudioStreamPlayer` gets added as a child to the `editor_node` in the `_enter_visual_editor` function.