### PR TITLE
Fix portrait tree drag drop bugs

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -80,7 +80,10 @@ func _on_item_mouse_selected(pos: Vector2, mouse_button_index: int) -> void:
 ##					DRAG AND DROP
 ################################################################################
 
-func _get_drag_data(position: Vector2) -> Variant:
+func _get_drag_data(_at_position: Vector2) -> Variant:
+	if not get_selected():
+		return null
+	
 	drop_mode_flags = DROP_MODE_INBETWEEN
 	var preview := Label.new()
 	preview.text = "     "+get_selected().get_text(0)
@@ -90,12 +93,12 @@ func _get_drag_data(position: Vector2) -> Variant:
 	return get_selected()
 
 
-func _can_drop_data(position: Vector2, data: Variant) -> bool:
+func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
 	return data is TreeItem
 
 
-func _drop_data(position: Vector2, item: Variant) -> void:
-	var to_item := get_item_at_position(position)
+func _drop_data(at_position: Vector2, item: Variant) -> void:
+	var to_item := get_item_at_position(at_position)
 	if to_item:
 		var test_item := to_item
 		while true:
@@ -105,7 +108,7 @@ func _drop_data(position: Vector2, item: Variant) -> void:
 			if test_item == get_root():
 				break
 
-	var drop_section := get_drop_section_at_position(position)
+	var drop_section := get_drop_section_at_position(at_position)
 	var parent := get_root()
 	if to_item:
 		parent = to_item.get_parent()

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -80,17 +80,18 @@ func _on_item_mouse_selected(pos: Vector2, mouse_button_index: int) -> void:
 ##					DRAG AND DROP
 ################################################################################
 
-func _get_drag_data(_at_position: Vector2) -> Variant:
-	if not get_selected():
+func _get_drag_data(at_position: Vector2) -> Variant:
+	var drag_item := get_item_at_position(at_position)
+	if not drag_item:
 		return null
 	
 	drop_mode_flags = DROP_MODE_INBETWEEN
 	var preview := Label.new()
-	preview.text = "     "+get_selected().get_text(0)
+	preview.text = "     "+drag_item.get_text(0)
 	preview.add_theme_stylebox_override('normal', get_theme_stylebox("Background", "EditorStyles"))
 	set_drag_preview(preview)
 
-	return get_selected()
+	return drag_item
 
 
 func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:


### PR DESCRIPTION
Maybe Fixes: #2372 

Added check to make sure something is selected when trying to create drag preview in the Character editor's Portrait tree. Also renamed some function arguments to avoid shadowing builtin `position` variable.