### PR TITLE
Remove stray print statment, fix extension creator mode

### DIFF
--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -242,7 +242,6 @@ func update_resource_list(resources_list: PackedStringArray = []) -> void:
 
 			# Sort the folder names by their folder name (not by the full path)
 			var sorted_dir_keys := unique_folder_names.keys()
-			print(sorted_dir_keys)
 			sorted_dir_keys.sort_custom(
 				func(x, y):
 					return x.get_slice("/", x.get_slice_count("/")-1) < y.get_slice("/", y.get_slice_count("/")-1)

--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -148,7 +148,7 @@ func _on_submit_extension_button_pressed() -> void:
 
 	var file: FileAccess
 	var indexer_content := "@tool\nextends DialogicIndexer\n\n"
-	if mode != 1: # don't add event in Subsystem Only mode
+	if mode != 2: # don't add event in Subsystem Only mode
 		indexer_content += """func _get_events() -> Array:
 	return [this_folder.path_join('event_"""+%NameEdit.text.to_snake_case()+""".gd')]\n\n"""
 		file = FileAccess.open(extensions_folder.path_join('event_'+%NameEdit.text.to_snake_case()+'.gd'), FileAccess.WRITE)


### PR DESCRIPTION
A stray print statement was leftover from a recent merge, so I removed it.
The Extension Creator's setup mode had two options reversed. Selecting `Event+Subsystem` would only create an event and `Subsystem only` would create both an event and subsystem.