### PR TITLE
Fix portrait scaling

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_containers.gd
+++ b/addons/dialogic/Modules/Character/subsystem_containers.gd
@@ -257,8 +257,8 @@ func str_to_vector(input: String, base_vector:=Vector2()) -> Vector2:
 				pass # Keep values as they are
 			'%', _:
 				match i.get_string(&'part'):
-					'x': value *= get_viewport().get_window().size.x
-					'y': value *= get_viewport().get_window().size.y
+					'x': value *= get_viewport().get_visible_rect().size.x
+					'y': value *= get_viewport().get_visible_rect().size.y
 
 		match i.get_string(&'part'):
 			'x': vec.x = value


### PR DESCRIPTION
Closes: #2443 

Based on conversation with @zaknafean, I checked how this was done in Dialogic 1, and it uses `get_viewport().get_visible_rect()`, which according to my testing does respect the window stretch mode in Project Settings.

More detailed testing may be required, I only tested that the size matches expectations based on the stretch mode settings of `disabled` and `canvas_items`. When set to `disabled` the size reflects the actual window size, but on `canvas_items` the viewport size is returned instead, regardless of the window size. If I have time for further testing I will post any results as well.