### PR TITLE
Fix Publish Test Report failures

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: "Checkout your Repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: "Upload Unit Test Reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "godot-version"
           path: |

--- a/.github/workflows/unit_test_report.yml
+++ b/.github/workflows/unit_test_report.yml
@@ -17,8 +17,9 @@ jobs:
 
     - name: "Publish Test Report"
       if: ${{ always() }}
-      uses: dorny/test-reporter@v1.6.0
+      uses: dorny/test-reporter@v1.9.1
       with:
+        artifact: "godot-version"
         name: "test_report"
-        path: "reports/**/results.xml"
+        path: "**/reports/**/results.xml"
         reporter: java-junit


### PR DESCRIPTION
Tested these changes on my main branch and it seems to fix the publish test report Github Action failing.

Also updated to the latest versions of the three actions (checkout, upload-artifact, and dorny/test-reporter) to fix warnings about outdated node.js versions.

Adds the artifact name to the test report, and changes the path so it can find the files to generate the report.

Link to passing publish test report -> [salianifo/dialogic/runs/31923968779](https://github.com/salianifo/dialogic/runs/31923968779)