### PR TITLE
Fix visual editor event copy/paste issues

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1108,8 +1108,8 @@ func _input(event:InputEvent) -> void:
 			var paste_position := 0
 			if selected_items:
 				paste_position = selected_items[-1].get_index()+1
-			elif %Timeline.get_child_count() > 0:
-				paste_position = %Timeline.get_child_count()-1
+			else:
+				paste_position = %Timeline.get_child_count()
 			if events_list:
 				TimelineUndoRedo.create_action("[D] Pasting "+str(len(events_list))+" event(s).")
 				TimelineUndoRedo.add_do_method(add_events_at_index.bind(events_list, paste_position))

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1099,6 +1099,7 @@ func _input(event:InputEvent) -> void:
 			get_viewport().set_input_as_handled()
 
 		"Ctrl+C":
+			select_events_indexed(get_events_indexed(selected_items))
 			copy_selected_events()
 			get_viewport().set_input_as_handled()
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -425,12 +425,12 @@ func get_events_indexed(events:Array) -> Dictionary:
 		if event.resource is DialogicEndBranchEvent:
 			continue
 
-		indexed_dict[event.get_index()] = event.resource.to_text()
+		indexed_dict[event.get_index()] = event.resource._store_as_string()
 
 		# store an end branch if it is selected or connected to a selected event
 		if 'end_node' in event and event.end_node:
 			event = event.end_node
-			indexed_dict[event.get_index()] = event.resource.to_text()
+			indexed_dict[event.get_index()] = event.resource._store_as_string()
 		elif event.resource is DialogicEndBranchEvent:
 			if event.parent_node in events: # add local index
 				indexed_dict[event.get_index()] += str(events.find(event.parent_node))
@@ -542,7 +542,7 @@ func copy_selected_events() -> void:
 
 	var event_copy_array := []
 	for item in selected_items:
-		event_copy_array.append(item.resource.to_text())
+		event_copy_array.append(item.resource._store_as_string())
 		if item.resource is DialogicEndBranchEvent:
 			if item.parent_node in selected_items: # add local index
 				event_copy_array[-1] += str(selected_items.find(item.parent_node))

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -471,7 +471,7 @@ func add_events_indexed(indexed_events:Dictionary) -> void:
 				event_resource = i.duplicate()
 				break
 
-		event_resource.from_text(indexed_events[event_idx])
+		event_resource._load_from_string(indexed_events[event_idx])
 
 		# now create the visual block.
 		deselect_all_items()

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1104,10 +1104,10 @@ func _input(event:InputEvent) -> void:
 
 		"Ctrl+V":
 			var events_list := get_clipboard_data()
-			var paste_position := -1
+			var paste_position := 0
 			if selected_items:
 				paste_position = selected_items[-1].get_index()+1
-			else:
+			elif %Timeline.get_child_count() > 0:
 				paste_position = %Timeline.get_child_count()-1
 			if events_list:
 				TimelineUndoRedo.create_action("[D] Pasting "+str(len(events_list))+" event(s).")


### PR DESCRIPTION
Closes: #2455
Closes: #2407

When pasting into an empty timeline, the paste position would be set to -1, making the first item pop down to the end of the list.