### PR TITLE
Make visual timeline deselect other items when selecting an already selected one

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -312,8 +312,8 @@ func _on_event_block_gui_input(event: InputEvent, item: Node) -> void:
 
 			drag_allowed = true
 
-		if event.is_released() and !%TimelineArea.dragging and !Input.is_key_pressed(KEY_SHIFT):
-			if len(selected_items) > 1 and item in selected_items and !Input.is_key_pressed(KEY_CTRL):
+		if event.is_released() and not %TimelineArea.dragging and not Input.is_key_pressed(KEY_SHIFT):
+			if len(selected_items) > 1 and item in selected_items and not Input.is_key_pressed(KEY_CTRL):
 				deselect_all_items()
 				select_item(item)
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -312,6 +312,11 @@ func _on_event_block_gui_input(event: InputEvent, item: Node) -> void:
 
 			drag_allowed = true
 
+		if event.is_released() and !%TimelineArea.dragging and !Input.is_key_pressed(KEY_SHIFT):
+			if len(selected_items) > 1 and item in selected_items and !Input.is_key_pressed(KEY_CTRL):
+				deselect_all_items()
+				select_item(item)
+
 	if len(selected_items) > 0 and event is InputEventMouseMotion:
 		if Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
 			if !%TimelineArea.dragging and !get_viewport().gui_is_dragging() and drag_allowed:


### PR DESCRIPTION
This change is for when you have multiple event blocks selected, and you want to just select one of them.

Previously, if you had multiple items selected and click on one of the already selected ones (without CTRL/SHIFT), nothing would happen. With this change, it will deselect the other items and only select the one you clicked on. This will only happen when you *release* the mouse button, and if you haven't started dragging. This makes the selection behave similarly to how filesystem selections usually work.