### PR TITLE
fix: portrait overlapping #2458 

### DIFF
--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -64,7 +64,7 @@ func _execute() -> void:
 
 	var character_name_text := dialogic.Text.get_character_name_parsed(character)
 	if character:
-        dialogic.current_state_info['speaker'] = character.resource_path
+		dialogic.current_state_info['speaker'] = character.resource_path
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.change_style(character.custom_info.style, false)
 			await dialogic.get_tree().process_frame

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -64,6 +64,7 @@ func _execute() -> void:
 
 	var character_name_text := dialogic.Text.get_character_name_parsed(character)
 	if character:
+                dialogic.current_state_info['speaker'] = character.resource_path
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.change_style(character.custom_info.style, false)
 			await dialogic.get_tree().process_frame

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -64,7 +64,7 @@ func _execute() -> void:
 
 	var character_name_text := dialogic.Text.get_character_name_parsed(character)
 	if character:
-                dialogic.current_state_info['speaker'] = character.resource_path
+        dialogic.current_state_info['speaker'] = character.resource_path
 		if dialogic.has_subsystem('Styles') and character.custom_info.get('style', null):
 			dialogic.Styles.change_style(character.custom_info.style, false)
 			await dialogic.get_tree().process_frame


### PR DESCRIPTION
By switching to a new speaker before changing the style, I solved the issue of overlapping portraits. This way, when changing the style, the object calling change_speaker is already the next speaker.