### PR TITLE
chore: fix small spelling mistake in event documentation.

### DIFF
--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -483,7 +483,7 @@ func build_event_editor() -> void:
 ## @left_text: 		Text that will be shown to the left of the field
 ## @right_text: 	Text that will be shown to the right of the field
 ## @extra_info: 	Allows passing a lot more info to the field.
-## 					What info can be passed is differnet for every field
+## 					What info can be passed is different for every field
 
 func add_header_label(text:String, condition:= "") -> void:
 	editor_list.append({


### PR DESCRIPTION
Small thing :) A fixed spelling mistake. Thank you for the addon!