### PR TITLE
Set Extra Data after updating portrait in Character Update Event

### DIFF
--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -154,10 +154,10 @@ func _execute() -> void:
 			finish()
 			return
 
-		dialogic.Portraits.change_character_extradata(character, extra_data)
-
 		if set_portrait:
 			dialogic.Portraits.change_character_portrait(character, portrait, fade_animation, fade_length)
+
+		dialogic.Portraits.change_character_extradata(character, extra_data)
 
 		if set_mirrored:
 			dialogic.Portraits.change_character_mirror(character, mirrored)


### PR DESCRIPTION
Using a Character Update Event to change both the portrait and extra data at the same time doesn't pass the extra data to the new portrait. This changes it so that the extra data gets set AFTER loading the new portrait (if there is one).