### PR TITLE
Fix file field clobbering path on unfocus without changes

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/field_file.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_file.gd
@@ -134,6 +134,8 @@ func _on_field_focus_entered() -> void:
 func _on_field_focus_exited() -> void:
 	$FocusStyle.hide()
 	var field_text: String = %Field.text
+	if current_value == field_text or (file_mode != EditorFileDialog.FILE_MODE_OPEN_DIR and current_value.get_file() == field_text):
+		return
 	_on_file_dialog_selected(field_text)
 
 #endregion


### PR DESCRIPTION
The file event field would cause the path to get changed to just the file name without the directory when you accidentally click on the field and click off the field without changing anything. This changes adds a check to make sure the current value and field text value aren't the same before calling `_on_file_dialog_selected`, or, if `file_mode` isn't directory open mode, that the current value as just the filename isn't the same as the field's value.