### PR TITLE
Styles: Fix persistent info getting lost

### DIFF
--- a/addons/dialogic/Resources/dialogic_layout_base.gd
+++ b/addons/dialogic/Resources/dialogic_layout_base.gd
@@ -63,7 +63,9 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
-	Engine.set_meta("dialogic_persistent_style_info", _get_persistent_info())
+	var info: Dictionary = Engine.get_meta("dialogic_persistent_style_info", {})
+	info.merge(_get_persistent_info(), true)
+	Engine.set_meta("dialogic_persistent_style_info", info)
 
 
 ## To be overwritten. Return any info that a later used style might want to know.


### PR DESCRIPTION
Now persistent info is always merged with the previously stored info. This means switching to a non-textbubble style doesn't clear all registers.