### PR TITLE
Fix crash when creating DialogicLabelEvent in gdscript

### DIFF
--- a/addons/dialogic/Core/DialogicResourceUtil.gd
+++ b/addons/dialogic/Core/DialogicResourceUtil.gd
@@ -62,6 +62,7 @@ static func add_resource_to_directory(file_path:String, directory:Dictionary) ->
 ## Returns the unique identifier for the given resource path.
 ## Returns an empty string if no identifier was found.
 static func get_unique_identifier(file_path:String) -> String:
+	if not file_path: return ""
 	var identifier: String = get_directory(file_path.get_extension()).find_key(file_path)
 	if typeof(identifier) == TYPE_STRING:
 		return identifier


### PR DESCRIPTION
Adding a label via gdscript will cause Dialogic to crash in `get_unique_identifier()` when attempting to `get_extension()` on a null `file_path`. This PR checks if it's null and returns `""`.