### PR TITLE
Fix instancing new Character Nodes on Simple Highlight Portrait

### DIFF
--- a/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.gd
+++ b/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.gd
@@ -19,6 +19,10 @@ func _ready() -> void:
 		self.modulate = unhighlighted_color
 
 
+func _should_do_portrait_update(_character: DialogicCharacter, _portrait: String) -> bool:
+    return true
+
+
 func _highlight() -> void:
 	create_tween().tween_property(self, 'modulate', Color.WHITE, 0.15)
 	_prev_z_index = DialogicUtil.autoload().Portraits.get_character_info(character).get('z_index', 0)


### PR DESCRIPTION
This portrait is simple and allows for only one image, there is no underlying node hierarchy that may need to change. Therefore, we need to ensure to not recreate a new character node.

We should look at handling this behaviour, to keep highlights working for other portrait scenes, that create a new character instance, too.