### PR TITLE
Allows jump to be a variable, making the jump event dynamic

### DIFF
--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -134,6 +134,9 @@ func get_label_suggestions(_filter:String="") -> Dictionary:
 	if timeline_identifier in DialogicResourceUtil.get_label_cache().keys():
 		for label in DialogicResourceUtil.get_label_cache()[timeline_identifier]:
 			suggestions[label] = {'value': label, 'tooltip':label, 'editor_icon': ["ArrowRight", "EditorIcons"]}
+	if _filter.begins_with("{"):
+		for var_path in DialogicUtil.list_variables(DialogicUtil.get_default_variables()):
+			suggestions["{"+var_path+"}"] = {'value':"{"+var_path+"}", 'icon':load("res://addons/dialogic/Editor/Images/Pieces/variable.svg")}
 	return suggestions
 
 
@@ -144,6 +147,8 @@ func _get_code_completion(CodeCompletionHelper:Node, TextNode:TextEdit, line:Str
 	if symbol == ' ' and line.count(' ') == 1:
 		CodeCompletionHelper.suggest_labels(TextNode, '', '\n', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
 		CodeCompletionHelper.suggest_timelines(TextNode, CodeEdit.KIND_MEMBER, event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
+	if symbol == "{":
+		CodeCompletionHelper.suggest_variables(TextNode)
 	if symbol == '/':
 		CodeCompletionHelper.suggest_labels(TextNode, line.strip_edges().trim_prefix('jump ').trim_suffix('/'+String.chr(0xFFFF)).strip_edges(), '\n', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
 

--- a/addons/dialogic/Modules/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Modules/Jump/subsystem_jump.gd
@@ -31,6 +31,8 @@ func jump_to_label(label:String) -> void:
 		dialogic.current_event_idx = 0
 		jumped_to_label.emit({'timeline':dialogic.current_timeline, 'label':"TOP"})
 		return
+	## Allows label to be a variable, making the jump event dynamic
+	label = str(dialogic.VAR.parse_variables(label))
 
 	var idx: int = -1
 	while true:


### PR DESCRIPTION
I noticed that the jump event could not be set to a variable. This pull request is to add that feature.

How to test:
1. create a dialogic variable in the default VAR folder.
![image](https://github.com/user-attachments/assets/04a400e8-c112-482b-b1e9-c2cd58e52dbc)
2. create a timeline with a jump event with the name of the variable and have it jump pass an end time line event to a label with the name of what the variable is set too.
`jump {jump_demo}`
`Failed`
`[end_timeline]`
`label variable`
`Success`

3. Run the timeline. You should see the dialog that it jumped too.

