### PR TITLE
Check for UIDs in strings as well on `start_timeline`

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -198,7 +198,7 @@ func start_timeline(timeline:Variant, label_or_idx:Variant = "") -> void:
 	# load the resource if only the path is given
 	if typeof(timeline) == TYPE_STRING:
 		#check the lookup table if it's not a full file name
-		if (timeline as String).contains("res://"):
+		if (timeline as String).contains("res://") or (timeline as String).contains("uid://"):
 			timeline = load((timeline as String))
 		else:
 			timeline = DialogicResourceUtil.get_timeline_resource((timeline as String))


### PR DESCRIPTION
If you use an exported variable with a path to a file (let's say a timeline):

`@export_file var timeline = ""`

Godot will automatically use a UID path (something like `uid://d0kqf1bb2ev0` instead of `res://timeline.dtl`) file to avoid having issues when moving that file in the future. This check in Dialogic is only expecting for the string `res://` in the argument, so if you do something like `Dialogic.start(timeline)` it will fail to run.

The fix just adds a check for UID as well. 

I suspect there are many other places where this is happening, so it would be good to replace all those instances of checking for "res://" to also check for "uid://"