### PR TITLE
Ignore directories ignored by godot (.gdignore file)

### DIFF
--- a/addons/dialogic/Core/DialogicResourceUtil.gd
+++ b/addons/dialogic/Core/DialogicResourceUtil.gd
@@ -275,7 +275,7 @@ static func list_resources_of_type(extension:String) -> Array:
 
 static func scan_folder(path:String, extension:String) -> Array:
 	var list: Array = []
-	if DirAccess.dir_exists_absolute(path):
+	if DirAccess.dir_exists_absolute(path) and not FileAccess.file_exists(path + "/" + ".gdignore"):
 		var dir := DirAccess.open(path)
 		dir.list_dir_begin()
 		var file_name := dir.get_next()


### PR DESCRIPTION
Godot ignores directories with a `.gdignore` file, but Dialogic still scans them.

In case of the android build template, Godot copies all files into `./android/build/assets` and the gradle build copies them again. In my case Dialogic had 3 copies of every timeline and every character. The name of those duplicates can change inside `project.godot` which is annoying for version control.