### PR TITLE
Feat: background file can now be loaded from user:// scope too

### DIFF
--- a/addons/dialogic/Modules/Background/DefaultBackgroundScene/default_background.gd
+++ b/addons/dialogic/Modules/Background/DefaultBackgroundScene/default_background.gd
@@ -19,6 +19,10 @@ func _update_background(argument:String, _time:float) -> void:
 	if argument.begins_with('res://'):
 		image_node.texture = load(argument)
 		color_node.color = Color.TRANSPARENT
+	elif argument.begins_with('user://'):
+		var ext_image = Image.load_from_file(argument)
+		image_node.texture = ImageTexture.create_from_image(ext_image)
+		color_node.color = Color.TRANSPARENT
 	elif argument.is_valid_html_color():
 		image_node.texture = null
 		color_node.color = Color(argument, 1)


### PR DESCRIPTION
Godot resource load works only for imported Resources and background changer accepted only res:// paths before. This change allows for an image from user:// path to also be used. 