### PR TITLE
Add Signal text_started that aligns with the text appearing

### DIFF
--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -127,7 +127,9 @@ func _execute() -> void:
 			_try_play_current_line_voice()
 			final_text = dialogic.Text.update_dialog_text(final_text, false, is_append)
 
-			#this is after the await for the textbox so the text starts rendering here
+			# This is after the await for the textbox so it's after any text box 
+			# opening animations that may make animations reliant on knowing when
+			# the text starts 
 			dialogic.Text.text_started.emit({'text':final_text, 'character':character, 'portrait':portrait, 'append': is_append})
 
 			_mark_as_read(character_name_text, final_text)

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -127,6 +127,9 @@ func _execute() -> void:
 			_try_play_current_line_voice()
 			final_text = dialogic.Text.update_dialog_text(final_text, false, is_append)
 
+			#this is after the await for the textbox so the text starts rendering here
+			dialogic.Text.text_started.emit({'text':final_text, 'character':character, 'portrait':portrait, 'append': is_append})
+
 			_mark_as_read(character_name_text, final_text)
 
 			# We must skip text animation before we potentially return when there

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -127,9 +127,6 @@ func _execute() -> void:
 			_try_play_current_line_voice()
 			final_text = dialogic.Text.update_dialog_text(final_text, false, is_append)
 
-			# This is after the await for the textbox so it's after any text box 
-			# opening animations that may make animations reliant on knowing when
-			# the text starts 
 			dialogic.Text.text_started.emit({'text':final_text, 'character':character, 'portrait':portrait, 'append': is_append})
 
 			_mark_as_read(character_name_text, final_text)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -5,6 +5,7 @@ extends DialogicSubsystem
 #region SIGNALS
 
 signal about_to_show_text(info:Dictionary)
+signal text_started(info:Dictionary)
 signal text_finished(info:Dictionary)
 signal speaker_updated(character:DialogicCharacter)
 signal textbox_visibility_changed(visible:bool)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -4,19 +4,43 @@ extends DialogicSubsystem
 
 #region SIGNALS
 
+## Emitted when a text event is reached or a new text section is about to be shown.
+## Gives a dictionary with the following keys: [br]
+## [br]
+## Key         |   Value Type  | Value [br]
+## ----------- | ------------- | ----- [br]
+## `text`      | [type String] | The text that is being displayed. [br]
+## `character` | [type DialogicCharacter]  | The character that says this text. [br]
+## `portrait`  | [type String] | The name of the portrait the character will use. [br]
+## `append`    | [type bool]   | Whether the text will be appended to the previous text. [br]
 signal about_to_show_text(info:Dictionary)
+## Emitted when a text event (or a new text section) starts displaying.
+## This will be AFTER the textox animation, while [signal about_to_show_text] is before.
+## Gives a dictionary with the same values as [signal about_to_show_text]
 signal text_started(info:Dictionary)
+## When the text has finished revealing.
+## Gives a dictionary with the keys text and character.
 signal text_finished(info:Dictionary)
+## Emitted when the speaker changes.
 signal speaker_updated(character:DialogicCharacter)
+## Emitted when the textbox is shown or hidden.
 signal textbox_visibility_changed(visible:bool)
 
-signal animation_textbox_new_text
+## Emitted when the textbox appears.
+## Use this together with the Animations subsystem to implement animations.
+## If you start an animation and want dialogic to wait for it to finish before showing text,
+## call Dialogic.Animations.start_animating() and then Dialogic.animation_finished() once it's done.
 signal animation_textbox_show
+## Emitted when the textbox is hiding. Use like [signal animation_textbox_show].
 signal animation_textbox_hide
+## Emitted when a new text starts. Use like [signal animation_textbox_show].
+signal animation_textbox_new_text
 
-# forwards of the dialog_text signals of all present dialog_text nodes
-signal meta_hover_ended(meta:Variant)
+## Emitted when a meta text on any DialogText node is hovered.
 signal meta_hover_started(meta:Variant)
+## Emitted when a meta text on any DialogText node is not hovered anymore.
+signal meta_hover_ended(meta:Variant)
+## Emitted when a meta text on any DialogText node is clicked.
 signal meta_clicked(meta:Variant)
 
 #endregion


### PR DESCRIPTION
The `await` on line 124 can take some time depending on if the textbox fades in or has an animation when opening, and because of that the `about_to_show_text` signal has a delay before the text begins to render.

Delay from before the await to after the await measured by `Time.get_ticks_msec()`
![image](https://github.com/user-attachments/assets/38d6a09b-c9ab-4acd-90ca-4159d242d15e)
```gdscript
dialogic.Text.about_to_show_text.emit({'text':final_text, 'character':character, 'portrait':portrait, 'append': is_append})

print("About to await dialogic.Text.update_textbox %s" % Time.get_ticks_msec())
await dialogic.Text.update_textbox(final_text, false)
print("Done Awaiting dialogic.Text.update_textbox %s" % Time.get_ticks_msec())
```

If you use `about_to_show_text` to enable an animation, as an example for lip flaps, the delay makes it look awkward because mouth begins moving before the text begins rendering. This PR adds a signal after the await so that it's closer to when the text starts rendering. 

Here's an example where I swap between a normal mouth to an `AnimatedSprite2D` for the character to talk:
```gdscript
extends Node2D

#this goes on the group in a custom layered character scene that has the mouth

@export var normal_sprite : Sprite2D
@export var talking_sprite : AnimatedSprite2D

func _ready():
	Dialogic.Text.about_to_show_text.connect(start_talking)
	# The text_started signal is a drop in replacement that feels much better for things
	# That need to respond to the text being drawn
	# Dialogic.Text.text_started.connect(start_talking)
	Dialogic.Text.text_finished.connect(stop_talking)
	
func start_talking(info:Dictionary):
	normal_sprite.visible = false
	talking_sprite.visible = true
	
func stop_talking(info:Dictionary):
	normal_sprite.visible = true
	talking_sprite.visible = false
```
I saw while I was researching there was similar methods to this that may have been in previous versions like `started_revealing_text` but those seem to have been removed or something. 