### PR TITLE
Multiple fixes

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -269,6 +269,7 @@ func handle_event(event_index:int) -> void:
 		end_timeline()
 		return
 
+	# TODO: Check if necessary. This should be impossible.
 	#actually process the event now, since we didnt earlier at runtime
 	#this needs to happen before we create the copy DialogicEvent variable, so it doesn't throw an error if not ready
 	if current_timeline_events[event_index].event_node_ready == false:

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -119,6 +119,9 @@ func _save() -> void:
 
 ## Saves a new empty character to the given path
 func new_character(path: String) -> void:
+	if not path.ends_with(".dch"):
+		path = path.trim_suffix(".")
+		path += ".dch"
 	var resource := DialogicCharacter.new()
 	resource.resource_path = path
 	resource.display_name = path.get_file().trim_suffix("."+path.get_extension())

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://b873ho41sklv8"]
+[gd_scene load_steps=6 format=3 uid="uid://b873ho41sklv8"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd" id="2"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/settings_tools.gd" id="2_3xeuv"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_kqhx5"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/tool_resave.gd" id="3_dbfvv"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/field_file.tscn" id="3_i7rug"]
 
 [node name="General" type="VBoxContainer"]
@@ -15,12 +17,44 @@ script = ExtResource("2")
 [node name="HBoxContainer2" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="SectionBehaviourTitle" type="Label" parent="HBoxContainer2"]
+[node name="SectionToolsTitle" type="Label" parent="HBoxContainer2"]
+layout_mode = 2
+theme_type_variation = &"DialogicSettingsSection"
+text = "Tools"
+
+[node name="Tools" type="Node" parent="."]
+script = ExtResource("2_3xeuv")
+
+[node name="ResaveTool" type="Node" parent="Tools"]
+script = ExtResource("3_dbfvv")
+
+[node name="ToolButtons" type="VBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="ResaveTool" type="Button" parent="ToolButtons"]
+layout_mode = 2
+text = "Resave all timelines"
+
+[node name="ToolProgress" type="ProgressBar" parent="."]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+max_value = 1.0
+value = 1.0
+
+[node name="HSeparator5" type="HSeparator" parent="."]
+layout_mode = 2
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="SectionBehaviourTitle" type="Label" parent="HBoxContainer5"]
 layout_mode = 2
 theme_type_variation = &"DialogicSettingsSection"
 text = "Layout Node Behaviour"
 
-[node name="HintTooltip" parent="HBoxContainer2" instance=ExtResource("2_kqhx5")]
+[node name="HintTooltip" parent="HBoxContainer5" instance=ExtResource("2_kqhx5")]
 layout_mode = 2
 tooltip_text = "The layout scene configured in the Layout editor is automatically 
 instanced when calling Dialogic.start(). Depending on your game, 
@@ -198,6 +232,7 @@ text = "Process timers in physics_process"
 unique_name_in_owner = true
 layout_mode = 2
 
+[connection signal="pressed" from="ToolButtons/ResaveTool" to="." method="_on_resave_tool_pressed"]
 [connection signal="item_selected" from="HBoxContainer3/LayoutNodeEndBehaviour" to="." method="_on_layout_node_end_behaviour_item_selected"]
 [connection signal="pressed" from="HBoxContainer6/HBoxContainer4/HBoxContainer5/Reload" to="." method="_on_reload_pressed"]
 [connection signal="pressed" from="HBoxContainer6/ExtensionsPanel/VBox/CreateExtensionButton" to="." method="_on_create_extension_button_pressed"]

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_tools.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_tools.gd
@@ -1,0 +1,81 @@
+@tool
+extends Node
+
+var tool_thread : Thread
+var tool_progress := 1.0
+var tool_progress_mutex : Mutex
+signal tool_finished_signal
+
+
+func _ready() -> void:
+	for button in %ToolButtons.get_children():
+		button.queue_free()
+
+	for i in get_children():
+		var button := Button.new()
+		button.text = i.button_text
+		button.tooltip_text = i.tooltip
+		button.pressed.connect(execute_tool.bind(i.method))
+		%ToolButtons.add_child(button)
+
+
+func execute_tool(method:Callable) -> void:
+	for button in %ToolButtons.get_children():
+		button.disabled = true
+
+	var prev_timeline := close_active_timeline()
+	await get_tree().process_frame
+	if tool_thread and tool_thread.is_alive():
+		tool_thread.wait_to_finish()
+
+	tool_thread = Thread.new()
+	tool_progress_mutex = Mutex.new()
+	print(method)
+	tool_thread.start(method)
+
+	await tool_finished_signal
+	silently_open_timeline(prev_timeline)
+	for button in %ToolButtons.get_children():
+		button.disabled = false
+
+
+func _process(delta: float) -> void:
+	if (tool_thread and tool_thread.is_alive()) or %ToolProgress.value < 1:
+		if tool_progress_mutex: tool_progress_mutex.lock()
+		%ToolProgress.value = tool_progress
+		if tool_progress_mutex: tool_progress_mutex.unlock()
+		%ToolProgress.show()
+		if %ToolProgress.value == 1:
+			tool_finished_signal.emit()
+			%ToolProgress.hide()
+
+
+func _exit_tree() -> void:
+	if tool_thread:
+		tool_thread.wait_to_finish()
+
+
+
+#region HELPERS
+
+## Closes the current timeline in the Dialogic Editor and returns the timeline
+## as a resource.
+## If no timeline has been opened, returns null.
+func close_active_timeline() -> Resource:
+	var timeline_node: DialogicEditor = get_parent().settings_editor.editors_manager.editors['Timeline']['node']
+	# We will close this timeline to ensure it will properly update.
+	# By saving this reference, we can open it again.
+	var current_timeline := timeline_node.current_resource
+	# Clean the current editor, this will also close the timeline.
+	get_parent().settings_editor.editors_manager.clear_editor(timeline_node, true)
+
+	return current_timeline
+
+
+## Opens the timeline resource into the Dialogic Editor.
+## If the timeline is null, does nothing.
+func silently_open_timeline(timeline_to_open: Resource) -> void:
+	if timeline_to_open != null:
+		get_parent().settings_editor.editors_manager.edit_resource(timeline_to_open, true, true)
+
+#endregion

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/tool_resave.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/tool_resave.gd
@@ -1,0 +1,32 @@
+@tool
+extends Node
+
+@onready var ToolUtil := get_parent()
+
+var button_text := "Resave all timelines"
+var tooltip := "Opens and resaves all timelines. This can be useful if an update introduced a syntax change."
+var method := resave_tool
+
+
+func resave_tool() -> void:
+	ToolUtil.tool_progress_mutex.lock()
+	ToolUtil.tool_progress = 0
+	ToolUtil.tool_progress_mutex.unlock()
+
+	var index := 0
+	var timelines := DialogicResourceUtil.get_timeline_directory()
+	for timeline_identifier in timelines:
+		var timeline := DialogicResourceUtil.get_timeline_resource(timeline_identifier)
+		await timeline.process()
+		timeline.set_meta("timeline_not_saved", true)
+		ResourceSaver.save(timeline)
+
+		ToolUtil.tool_progress_mutex.lock()
+		ToolUtil.tool_progress = 1.0/len(timelines)*index
+		ToolUtil.tool_progress_mutex.unlock()
+
+		index += 1
+
+	ToolUtil.tool_progress_mutex.lock()
+	ToolUtil.tool_progress = 1
+	ToolUtil.tool_progress_mutex.unlock()

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -496,7 +496,7 @@ func add_events_indexed(indexed_events:Dictionary) -> void:
 	var events := []
 	for event_idx in indexes:
 		# first get a new resource from the text version
-		var event_resource :DialogicEvent
+		var event_resource: DialogicEvent
 		for i in DialogicResourceUtil.get_event_cache():
 			if i._test_event_string(indexed_events[event_idx]):
 				event_resource = i.duplicate()
@@ -571,6 +571,7 @@ func copy_selected_events() -> void:
 	if len(selected_items) == 0:
 		return
 
+	sort_selection()
 	var event_copy_array := []
 	for item in selected_items:
 		event_copy_array.append(item.resource._store_as_string())
@@ -579,6 +580,7 @@ func copy_selected_events() -> void:
 				event_copy_array[-1] += str(selected_items.find(item.parent_node))
 			else: # add global index
 				event_copy_array[-1] += '#'+str(item.parent_node.get_index())
+
 	DisplayServer.clipboard_set(var_to_str({
 			"events":event_copy_array,
 			"project_name": ProjectSettings.get_setting("application/config/name")

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -152,6 +152,9 @@ func _on_resource_saved() -> void:
 func new_timeline(path:String) -> void:
 	_save()
 	var new_timeline := DialogicTimeline.new()
+	if not path.ends_with(".dtl"):
+		path = path.trim_suffix(".")
+		path += ".dtl"
 	new_timeline.resource_path = path
 	new_timeline.set_meta('timeline_not_saved', true)
 	var err := ResourceSaver.save(new_timeline)

--- a/addons/dialogic/Editor/editor_main.gd
+++ b/addons/dialogic/Editor/editor_main.gd
@@ -53,61 +53,45 @@ func _on_sidebar_toggled(sidebar_shown: bool) -> void:
 
 
 func update_theme_additions() -> void:
-	add_theme_stylebox_override(
-		"panel",
-		(
-			DCSS
-			. inline(
-				{
-					"background": get_theme_color("base_color", "Editor"),
-					"padding":
-					[5 * DialogicUtil.get_editor_scale(), 5 * DialogicUtil.get_editor_scale()],
-				}
-			)
-		)
-	)
-	var holder_panel := (
-		DCSS
-		. inline(
-			{
-				"border-radius": 5,
-				#'border': 2,
-				#'border-color': get_theme_color("base_color", "Editor"),
-				"background": get_theme_color("dark_color_2", "Editor"),
-				"padding":
-				[5 * DialogicUtil.get_editor_scale(), 5 * DialogicUtil.get_editor_scale()],
-			}
-		)
-	)
+	add_theme_stylebox_override("panel", DCSS.inline({
+		"background": get_theme_color("base_color", "Editor"),
+		"padding":
+		[5 * DialogicUtil.get_editor_scale(), 5 * DialogicUtil.get_editor_scale()],
+		}))
+	var holder_panel := (DCSS.inline({
+		"border-radius": 5,
+		"background": get_theme_color("dark_color_2", "Editor"),
+		"padding":
+		[5 * DialogicUtil.get_editor_scale(), 5 * DialogicUtil.get_editor_scale()],
+		}))
+
 	holder_panel.border_width_top = 0
 	holder_panel.corner_radius_top_left = 0
 	editors_manager.editors_holder.add_theme_stylebox_override("panel", holder_panel)
 
-	if theme == null:
-		theme = Theme.new()
-	theme.clear()
+	var new_theme := Theme.new()
 
-	theme.set_type_variation("DialogicTitle", "Label")
-	theme.set_font("font", "DialogicTitle", get_theme_font("title", "EditorFonts"))
-	theme.set_color("font_color", "DialogicTitle", get_theme_color("warning_color", "Editor"))
-	theme.set_color(
+	new_theme.set_type_variation("DialogicTitle", "Label")
+	new_theme.set_font("font", "DialogicTitle", get_theme_font("title", "EditorFonts"))
+	new_theme.set_color("font_color", "DialogicTitle", get_theme_color("warning_color", "Editor"))
+	new_theme.set_color(
 		"font_uneditable_color", "DialogicTitle", get_theme_color("warning_color", "Editor")
 	)
-	theme.set_color(
+	new_theme.set_color(
 		"font_selected_color", "DialogicTitle", get_theme_color("warning_color", "Editor")
 	)
-	theme.set_font_size(
+	new_theme.set_font_size(
 		"font_size", "DialogicTitle", get_theme_font_size("doc_size", "EditorFonts")
 	)
 
-	theme.set_type_variation("DialogicSubTitle", "Label")
-	theme.set_font("font", "DialogicSubTitle", get_theme_font("title", "EditorFonts"))
-	theme.set_font_size(
+	new_theme.set_type_variation("DialogicSubTitle", "Label")
+	new_theme.set_font("font", "DialogicSubTitle", get_theme_font("title", "EditorFonts"))
+	new_theme.set_font_size(
 		"font_size", "DialogicSubTitle", get_theme_font_size("doc_size", "EditorFonts")
 	)
-	theme.set_color("font_color", "DialogicSubTitle", get_theme_color("accent_color", "Editor"))
+	new_theme.set_color("font_color", "DialogicSubTitle", get_theme_color("accent_color", "Editor"))
 
-	theme.set_type_variation("DialogicPanelA", "PanelContainer")
+	new_theme.set_type_variation("DialogicPanelA", "PanelContainer")
 	var panel_style := (
 		DCSS
 		. inline(
@@ -118,19 +102,19 @@ func update_theme_additions() -> void:
 			}
 		)
 	)
-	theme.set_stylebox("panel", "DialogicPanelA", panel_style)
-	theme.set_stylebox("normal", "DialogicPanelA", panel_style)
+	new_theme.set_stylebox("panel", "DialogicPanelA", panel_style)
+	new_theme.set_stylebox("normal", "DialogicPanelA", panel_style)
 
 	var dark_panel := panel_style.duplicate()
 	dark_panel.bg_color = get_theme_color("dark_color_3", "Editor")
-	theme.set_stylebox("panel", "DialogicPanelDarkA", dark_panel)
+	new_theme.set_stylebox("panel", "DialogicPanelDarkA", dark_panel)
 
 	var cornerless_panel := panel_style.duplicate()
 	cornerless_panel.corner_radius_top_left = 0
-	theme.set_stylebox("panel", "DialogicPanelA_cornerless", cornerless_panel)
+	new_theme.set_stylebox("panel", "DialogicPanelA_cornerless", cornerless_panel)
 
 	# panel used for example for portrait previews in character editor
-	theme.set_type_variation("DialogicPanelB", "PanelContainer")
+	new_theme.set_type_variation("DialogicPanelB", "PanelContainer")
 	var side_panel: StyleBoxFlat = panel_style.duplicate()
 	side_panel.corner_radius_top_left = 0
 	side_panel.corner_radius_bottom_left = 0
@@ -139,9 +123,9 @@ func update_theme_additions() -> void:
 	side_panel.set_border_width_all(1)
 	side_panel.border_width_left = 0
 	side_panel.border_color = get_theme_color("contrast_color_2", "Editor")
-	theme.set_stylebox("panel", "DialogicPanelB", side_panel)
+	new_theme.set_stylebox("panel", "DialogicPanelB", side_panel)
 
-	theme.set_type_variation("DialogicEventEdit", "Control")
+	new_theme.set_type_variation("DialogicEventEdit", "Control")
 	var edit_panel := StyleBoxFlat.new()
 	edit_panel.draw_center = true
 	edit_panel.bg_color = get_theme_color("accent_color", "Editor")
@@ -153,60 +137,60 @@ func update_theme_additions() -> void:
 	edit_panel.content_margin_left = 5
 	edit_panel.content_margin_right = 5
 	edit_panel.set_corner_radius_all(1)
-	theme.set_stylebox("panel", "DialogicEventEdit", edit_panel)
-	theme.set_stylebox("normal", "DialogicEventEdit", edit_panel)
+	new_theme.set_stylebox("panel", "DialogicEventEdit", edit_panel)
+	new_theme.set_stylebox("normal", "DialogicEventEdit", edit_panel)
 
 	var focus_edit := edit_panel.duplicate()
 	focus_edit.border_color = get_theme_color("property_color_z", "Editor")
 	focus_edit.draw_center = false
-	theme.set_stylebox("focus", "DialogicEventEdit", focus_edit)
+	new_theme.set_stylebox("focus", "DialogicEventEdit", focus_edit)
 
 	var hover_edit := edit_panel.duplicate()
 	hover_edit.border_color = get_theme_color("warning_color", "Editor")
 
-	theme.set_stylebox("hover", "DialogicEventEdit", hover_edit)
+	new_theme.set_stylebox("hover", "DialogicEventEdit", hover_edit)
 	var disabled_edit := edit_panel.duplicate()
 	disabled_edit.border_color = get_theme_color("property_color", "Editor")
-	theme.set_stylebox("disabled", "DialogicEventEdit", disabled_edit)
+	new_theme.set_stylebox("disabled", "DialogicEventEdit", disabled_edit)
 
-	theme.set_type_variation("DialogicHintText", "Label")
-	theme.set_color("font_color", "DialogicHintText", get_theme_color("readonly_color", "Editor"))
-	theme.set_font("font", "DialogicHintText", get_theme_font("doc_italic", "EditorFonts"))
+	new_theme.set_type_variation("DialogicHintText", "Label")
+	new_theme.set_color("font_color", "DialogicHintText", get_theme_color("readonly_color", "Editor"))
+	new_theme.set_font("font", "DialogicHintText", get_theme_font("doc_italic", "EditorFonts"))
 
-	theme.set_type_variation("DialogicHintText2", "Label")
-	theme.set_color(
+	new_theme.set_type_variation("DialogicHintText2", "Label")
+	new_theme.set_color(
 		"font_color", "DialogicHintText2", get_theme_color("property_color_w", "Editor")
 	)
-	theme.set_font("font", "DialogicHintText2", get_theme_font("doc_italic", "EditorFonts"))
+	new_theme.set_font("font", "DialogicHintText2", get_theme_font("doc_italic", "EditorFonts"))
 
-	theme.set_type_variation("DialogicSection", "Label")
-	theme.set_font("font", "DialogicSection", get_theme_font("main_msdf", "EditorFonts"))
-	theme.set_color("font_color", "DialogicSection", get_theme_color("property_color_z", "Editor"))
-	theme.set_font_size(
+	new_theme.set_type_variation("DialogicSection", "Label")
+	new_theme.set_font("font", "DialogicSection", get_theme_font("main_msdf", "EditorFonts"))
+	new_theme.set_color("font_color", "DialogicSection", get_theme_color("property_color_z", "Editor"))
+	new_theme.set_font_size(
 		"font_size", "DialogicSection", get_theme_font_size("doc_size", "EditorFonts")
 	)
 
-	theme.set_type_variation("DialogicSettingsSection", "DialogicSection")
-	theme.set_font("font", "DialogicSettingsSection", get_theme_font("main_msdf", "EditorFonts"))
-	theme.set_color(
+	new_theme.set_type_variation("DialogicSettingsSection", "DialogicSection")
+	new_theme.set_font("font", "DialogicSettingsSection", get_theme_font("main_msdf", "EditorFonts"))
+	new_theme.set_color(
 		"font_color", "DialogicSettingsSection", get_theme_color("property_color_z", "Editor")
 	)
-	theme.set_font_size(
+	new_theme.set_font_size(
 		"font_size", "DialogicSettingsSection", get_theme_font_size("doc_size", "EditorFonts")
 	)
 
-	theme.set_type_variation("DialogicSectionBig", "DialogicSection")
-	theme.set_color("font_color", "DialogicSectionBig", get_theme_color("accent_color", "Editor"))
-	theme.set_font_size(
+	new_theme.set_type_variation("DialogicSectionBig", "DialogicSection")
+	new_theme.set_color("font_color", "DialogicSectionBig", get_theme_color("accent_color", "Editor"))
+	new_theme.set_font_size(
 		"font_size", "DialogicSectionBig", get_theme_font_size("doc_title_size", "EditorFonts")
 	)
 
-	theme.set_type_variation("DialogicLink", "LinkButton")
-	theme.set_color("font_hover_color", "DialogicLink", get_theme_color("warning_color", "Editor"))
+	new_theme.set_type_variation("DialogicLink", "LinkButton")
+	new_theme.set_color("font_hover_color", "DialogicLink", get_theme_color("warning_color", "Editor"))
 
-	theme.set_type_variation("DialogicMegaSeparator", "HSeparator")
+	new_theme.set_type_variation("DialogicMegaSeparator", "HSeparator")
 	(
-		theme
+		new_theme
 		. set_stylebox(
 			"separator",
 			"DialogicMegaSeparator",
@@ -223,9 +207,9 @@ func update_theme_additions() -> void:
 			)
 		)
 	)
-	theme.set_constant("separation", "DialogicMegaSeparator", 50)
+	new_theme.set_constant("separation", "DialogicMegaSeparator", 50)
 
-	theme.set_type_variation("DialogicTextEventTextEdit", "CodeEdit")
+	new_theme.set_type_variation("DialogicTextEventTextEdit", "CodeEdit")
 	var editor_settings := plugin_reference.get_editor_interface().get_editor_settings()
 	var text_panel := (
 		DCSS
@@ -242,7 +226,7 @@ func update_theme_additions() -> void:
 	)
 	text_panel.content_margin_bottom = 5
 	text_panel.content_margin_left = 13
-	theme.set_stylebox("normal", "DialogicTextEventTextEdit", text_panel)
+	new_theme.set_stylebox("normal", "DialogicTextEventTextEdit", text_panel)
 
 	var event_field_group_panel := DCSS.inline({
 		'border-radius': 8,
@@ -250,10 +234,12 @@ func update_theme_additions() -> void:
 		"padding":2,
 		"boder-color": get_theme_color("property_color", "Editor"),
 		"background":"none"})
-	theme.set_type_variation("DialogicEventEditGroup", "PanelContainer")
-	theme.set_stylebox("panel", "DialogicEventEditGroup", event_field_group_panel)
+	new_theme.set_type_variation("DialogicEventEditGroup", "PanelContainer")
+	new_theme.set_stylebox("panel", "DialogicEventEditGroup", event_field_group_panel)
 
-	theme.set_icon('Plugin', 'Dialogic', load("res://addons/dialogic/Editor/Images/plugin-icon.svg"))
+	new_theme.set_icon('Plugin', 'Dialogic', load("res://addons/dialogic/Editor/Images/plugin-icon.svg"))
+
+	theme = new_theme
 
 
 ## Switches from floating window mode to embedded mode based on current mode

--- a/addons/dialogic/Editor/editor_main.gd
+++ b/addons/dialogic/Editor/editor_main.gd
@@ -287,18 +287,26 @@ func swap_to_embedded_editor() -> void:
 
 
 func godot_file_dialog(
-	callable: Callable,
-	filter: String,
-	mode := EditorFileDialog.FILE_MODE_OPEN_FILE,
-	window_title := "Save",
-	current_file_name := "New_File",
-	saving_something := false,
-	extra_message: String = ""
-) -> EditorFileDialog:
+		callable: Callable, filter: String, mode := EditorFileDialog.FILE_MODE_OPEN_FILE,
+		window_title := "Save",
+		current_file_name := "New_File",
+		saving_something := false,
+		extra_message: String = ""
+		) -> EditorFileDialog:
+
 	for connection in editor_file_dialog.file_selected.get_connections():
 		editor_file_dialog.file_selected.disconnect(connection.callable)
 	for connection in editor_file_dialog.dir_selected.get_connections():
 		editor_file_dialog.dir_selected.disconnect(connection.callable)
+
+	if mode == EditorFileDialog.FILE_MODE_OPEN_FILE or mode == EditorFileDialog.FILE_MODE_SAVE_FILE:
+		editor_file_dialog.file_selected.connect(callable)
+	elif mode == EditorFileDialog.FILE_MODE_OPEN_DIR:
+		editor_file_dialog.dir_selected.connect(callable)
+	elif mode == EditorFileDialog.FILE_MODE_OPEN_ANY:
+		editor_file_dialog.dir_selected.connect(callable)
+		editor_file_dialog.file_selected.connect(callable)
+
 	editor_file_dialog.file_mode = mode
 	editor_file_dialog.clear_filters()
 	editor_file_dialog.popup_centered_ratio(0.6)
@@ -312,11 +320,5 @@ func godot_file_dialog(
 	else:
 		editor_file_dialog.get_meta("info_message_label").hide()
 
-	if mode == EditorFileDialog.FILE_MODE_OPEN_FILE or mode == EditorFileDialog.FILE_MODE_SAVE_FILE:
-		editor_file_dialog.file_selected.connect(callable)
-	elif mode == EditorFileDialog.FILE_MODE_OPEN_DIR:
-		editor_file_dialog.dir_selected.connect(callable)
-	elif mode == EditorFileDialog.FILE_MODE_OPEN_ANY:
-		editor_file_dialog.dir_selected.connect(callable)
-		editor_file_dialog.file_selected.connect(callable)
+
 	return editor_file_dialog

--- a/addons/dialogic/Modules/Audio/event_audio.gd
+++ b/addons/dialogic/Modules/Audio/event_audio.gd
@@ -220,6 +220,7 @@ func _music_from_text(string:String) -> void:
 	if data.has('loop'):
 		set_loop = true
 		loop = str_to_var(data['loop'])
+	update_text_version()
 
 
 func _sound_from_text(string:String) -> void:
@@ -250,6 +251,8 @@ func _sound_from_text(string:String) -> void:
 	if data.has('loop'):
 		set_loop = true
 		loop = str_to_var(data['loop'])
+	update_text_version()
+
 
 #endregion
 

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -19,40 +19,12 @@ func _recognize(resource: Resource) -> bool:
 
 
 ## Save the resource
-## TODO: This should use timeline.as_text(), why is this still here?
 func _save(resource: Resource, path: String = '', _flags: int = 0) -> Error:
 	if resource.get_meta("timeline_not_saved", false):
+		var timeline_as_text: String = resource.as_text()
 
-		var timeline_as_text := ""
-		# if events are resources, create text
-		if resource.events_processed:
-
-			var indent := 0
-			for idx in range(0, len(resource.events)):
-				if resource.events[idx]:
-					var event: DialogicEvent = resource.events[idx]
-					if event.event_name == 'End Branch':
-						indent -=1
-						continue
-
-					for i in event.empty_lines_above:
-						timeline_as_text += '\t'.repeat(indent) + '\n'
-
-					if event != null:
-						timeline_as_text += "\t".repeat(indent)+ event.event_node_as_text + "\n"
-					if event.can_contain_events:
-						indent += 1
-					if indent < 0:
-						indent = 0
-
-		# if events are string lines, just save them
-		else:
-			for event in resource.events:
-				timeline_as_text += event + "\n"
-
-		# Now do the actual saving
 		var file := FileAccess.open(path, FileAccess.WRITE)
-		if !file:
+		if not file:
 			print("[Dialogic] Error opening file:", FileAccess.get_open_error())
 			return ERR_CANT_OPEN
 		file.store_string(timeline_as_text)

--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -132,8 +132,8 @@ func process() -> void:
 
 			event_content += "\n"+following_line_stripped
 
-		event._load_from_string(event_content)
 		event.event_node_as_text = event_content
+		await event._load_from_string(event_content)
 
 		processed_events.append(event)
 		prev_was_opener = event.can_contain_events


### PR DESCRIPTION
- Implement a Tool system and a Resave all Timelines Tool in the general settings tab (very useful to update to the new audio event syntax)
- Improve startup time by avoiding unnecessary theme changes
- Fix for native file dialogs #2518 
- Small fix for copying events in visual timelines