### PR TITLE
Immediately load persistent info to prevent overwritting

### DIFF
--- a/addons/dialogic/Resources/dialogic_layout_base.gd
+++ b/addons/dialogic/Resources/dialogic_layout_base.gd
@@ -58,7 +58,7 @@ func _apply_export_overrides() -> void:
 #region HANDLE PERSISTENT DATA
 ################################################################################
 
-func _enter_tree() -> void:
+func _init() -> void:
 	_load_persistent_info(Engine.get_meta("dialogic_persistent_style_info", {}))
 
 


### PR DESCRIPTION
Fixes #2526 by calling `_load_persistent_info()` in `_init()` instead of `_enter_tree()`. Previously, `_enter_tree()` was called the frame after `Dialogic.start()`, causing new changes (e.g., `register_character` to be overwritten with the old persistent info.

The fix here is more general than the one proposed in #2526 (which only addressed text bubbles). During testing `_init()` was called after `_exit_tree()`, so there should be **_no_** race conditions with saving and loading persistent info on the same frame.