### PR TITLE
Fixes for 4.2, textbubble, missing audio files and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## Version
 
-Dialogic 2 **requires at least Godot 4.2**.
+Dialogic 2 **requires at least Godot 4.2.2**.
 
 [If you are looking for the Godot 3.x version (Dialogic 1.x) you can find it here.](https://github.com/dialogic-godot/dialogic-1)
 

--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -110,7 +110,6 @@ var Choices := preload("res://addons/dialogic/Modules/Choice/subsystem_choices.g
 var Expressions := preload("res://addons/dialogic/Modules/Core/subsystem_expression.gd").new():
 	get: return get_subsystem("Expressions")
 
-
 var Glossary := preload("res://addons/dialogic/Modules/Glossary/subsystem_glossary.gd").new():
 	get: return get_subsystem("Glossary")
 

--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -9,7 +9,9 @@ class_name DialogicUtil
 ## This method should be used instead of EditorInterface.get_editor_scale(), because if you use that
 ## it will run perfectly fine from the editor, but crash when the game is exported.
 static func get_editor_scale() -> float:
-	return get_dialogic_plugin().get_editor_interface().get_editor_scale()
+	if Engine.is_editor_hint():
+		return get_dialogic_plugin().get_editor_interface().get_editor_scale()
+	return 1.0
 
 
 ## Although this does in fact always return a EditorPlugin node,

--- a/addons/dialogic/Editor/Common/toolbar.gd
+++ b/addons/dialogic/Editor/Common/toolbar.gd
@@ -4,7 +4,7 @@ extends HBoxContainer
 # Dialogic Editor toolbar. Works together with editors_mangager.
 
 ################################################################################
-## 					EDITOR BUTTONS/LABELS 
+## 					EDITOR BUTTONS/LABELS
 ################################################################################
 func _ready() -> void:
 	if owner.get_parent() is SubViewport:
@@ -44,6 +44,3 @@ func add_custom_button(label:String, icon:Texture) -> Button:
 func hide_all_custom_buttons() -> void:
 	for button in %CustomButtons.get_children():
 		button.hide()
-
-
-

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
@@ -32,10 +32,6 @@ script = ExtResource("3_dbfvv")
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="ResaveTool" type="Button" parent="ToolButtons"]
-layout_mode = 2
-text = "Resave all timelines"
-
 [node name="ToolProgress" type="ProgressBar" parent="."]
 unique_name_in_owner = true
 visible = false
@@ -232,7 +228,6 @@ text = "Process timers in physics_process"
 unique_name_in_owner = true
 layout_mode = 2
 
-[connection signal="pressed" from="ToolButtons/ResaveTool" to="." method="_on_resave_tool_pressed"]
 [connection signal="item_selected" from="HBoxContainer3/LayoutNodeEndBehaviour" to="." method="_on_layout_node_end_behaviour_item_selected"]
 [connection signal="pressed" from="HBoxContainer6/HBoxContainer4/HBoxContainer5/Reload" to="." method="_on_reload_pressed"]
 [connection signal="pressed" from="HBoxContainer6/ExtensionsPanel/VBox/CreateExtensionButton" to="." method="_on_create_extension_button_pressed"]

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -79,15 +79,21 @@ func _gui_input(event):
 	match event.as_text():
 		"Ctrl+K":
 			toggle_comment()
+
+		# TODO clean this up when dropping 4.2 support
 		"Alt+Up":
-			move_lines_up()
+			if has_method("move_lines_up"):
+				call("move_lines_up")
 		"Alt+Down":
-			move_lines_down()
+			if has_method("move_lines_down"):
+				call("move_lines_down")
+
 		"Ctrl+Shift+D", "Ctrl+D":
 			duplicate_lines()
 		_:
 			return
 	get_viewport().set_input_as_handled()
+
 
 # Toggle the selected lines as comments
 func toggle_comment() -> void:
@@ -128,14 +134,14 @@ func toggle_comment() -> void:
 	text_changed.emit()
 
 
-# Allows dragging files into the editor
+## Allows dragging files into the editor
 func _can_drop_data(at_position:Vector2, data:Variant) -> bool:
 	if typeof(data) == TYPE_DICTIONARY and 'files' in data.keys() and len(data.files) == 1:
 		return true
 	return false
 
 
-# Allows dragging files into the editor
+## Allows dragging files into the editor
 func _drop_data(at_position:Vector2, data:Variant) -> void:
 	if typeof(data) == TYPE_DICTIONARY and 'files' in data.keys() and len(data.files) == 1:
 		set_caret_column(get_line_column_at_pos(at_position).x)
@@ -232,19 +238,19 @@ func search_navigate(navigate_up := false) -> void:
 ## 					AUTO COMPLETION
 ################################################################################
 
-# Called if something was typed
+## Called if something was typed
 func _request_code_completion(force:bool):
 	code_completion_helper.request_code_completion(force, self)
 
 
-# Filters the list of all possible options, depending on what was typed
-# Purpose of the different Kinds is explained in [_request_code_completion]
+## Filters the list of all possible options, depending on what was typed
+## Purpose of the different Kinds is explained in [_request_code_completion]
 func _filter_code_completion_candidates(candidates:Array) -> Array:
 	return code_completion_helper.filter_code_completion_candidates(candidates, self)
 
 
-# Called when code completion was activated
-# Inserts the selected item
+## Called when code completion was activated
+## Inserts the selected item
 func _confirm_code_completion(replace:bool) -> void:
 	code_completion_helper.confirm_code_completion(replace, self)
 
@@ -253,11 +259,11 @@ func _confirm_code_completion(replace:bool) -> void:
 ##					SYMBOL CLICKING
 ################################################################################
 
-# Performs an action (like opening a link) when a valid symbol was clicked
+## Performs an action (like opening a link) when a valid symbol was clicked
 func _on_symbol_lookup(symbol, line, column):
 	code_completion_helper.symbol_lookup(symbol, line, column)
 
 
-# Called to test if a symbol can be clicked
+## Called to test if a symbol can be clicked
 func _on_symbol_validate(symbol:String) -> void:
 	code_completion_helper.symbol_validate(symbol, self)

--- a/addons/dialogic/Modules/Audio/event_audio.gd
+++ b/addons/dialogic/Modules/Audio/event_audio.gd
@@ -346,8 +346,9 @@ func get_audio_channel_suggestions(filter:String) -> Dictionary:
 		"tooltip": "Used for one shot sounds effects. Plays each sound in its own AudioStreamPlayer.",
 		"editor_icon": ["GuiRadioUnchecked", "EditorIcons"]
 		}
-	return suggestions.merged(DialogicUtil.get_audio_channel_suggestions(filter))
-
+	# TODO use .merged after dropping 4.2 support
+	suggestions.merge(DialogicUtil.get_audio_channel_suggestions(filter))
+	return suggestions
 
 func get_sync_audio_channel_suggestions(filter:="") -> Dictionary:
 	return DialogicUtil.get_audio_channel_suggestions(filter)

--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -98,7 +98,9 @@ func update_audio(channel_name:= "", path := "", settings_overrides := {}) -> vo
 		return
 
 	## Determine audio settings
-	var audio_settings: Dictionary = DialogicUtil.get_audio_channel_defaults().get(channel_name, {}).merged(
+	## TODO use .merged after dropping 4.2 support
+	var audio_settings: Dictionary = DialogicUtil.get_audio_channel_defaults().get(channel_name, {})
+	audio_settings.merge(
 		{"volume":0, "audio_bus":"", "fade_length":0.0, "loop":false, "sync_channel":""}
 	)
 	audio_settings.merge(settings_overrides, true)

--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -138,6 +138,11 @@ func update_audio(channel_name:= "", path := "", settings_overrides := {}) -> vo
 		new_player.name = "OneShotSFX"
 		one_shot_audio_node.add_child(new_player)
 
+	var file := load(path)
+	if file == null:
+		printerr("[Dialogic] Audio file \"%s\" failed to load." % path)
+		return
+
 	new_player.stream = load(path)
 
 	## Apply audio settings

--- a/addons/dialogic/Modules/DefaultLayoutParts/Base_TextBubble/text_bubble_base.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Base_TextBubble/text_bubble_base.gd
@@ -82,7 +82,8 @@ func _on_dialogic_text_event(info:Dictionary):
 
 	bubble_to_use.current_character = info.character
 	bubble_to_use.node_to_point_at = node_to_point_at
-	bubble_to_use.reset()
+	if not bubble_to_use.visible:
+		bubble_to_use.reset()
 	if has_node('TextBubbleLayer'):
 		get_node("TextBubbleLayer").bubble_apply_overrides(bubble_to_use)
 	bubble_to_use.open()

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
@@ -42,7 +42,7 @@ func reset() -> void:
 	tail.points = []
 	bubble_rect = Rect2(0,0,2,2)
 
-	base_position = get_speaker_canvas_position()
+	base_position = get_speaker_canvas_position() + base_direction * safe_zone
 	position = base_position
 
 


### PR DESCRIPTION
- Makes sure a missing/invalid audio file path doesn't result in a crash, just an error
- Small code cleanup
- Change textbubble layout slightly to reduce the movement on each new text.
- Remove some usage of dict.merged and disguise move CodeEdit.move_line_up/down() usage to keep 4.2 compatibility
- Bump minimum required version to 4.2.2