### PR TITLE
Implement proper timeline ending logic

### DIFF
--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -194,7 +194,7 @@ func update_audio(channel_name:= "", path := "", settings_overrides := {}) -> vo
 		current_audio_channels[channel_name] = new_player
 
 
-## Returns true if any audio is playing on the given [param channel_name].
+## Returns `true` if any audio is playing on the given [param channel_name].
 func is_channel_playing(channel_name: String) -> bool:
 	return (current_audio_channels.has(channel_name)
 		and is_instance_valid(current_audio_channels[channel_name])
@@ -224,6 +224,14 @@ func interpolate_volume_linearly(value: float, node: Node) -> void:
 func is_channel_playing_file(file_path: String, channel_name: String) -> bool:
 	return (is_channel_playing(channel_name)
 		and current_audio_channels[channel_name].stream.resource_path == file_path)
+
+
+## Returns `true` if any channel is playing.
+func is_any_channel_playing() -> bool:
+	for channel in current_audio_channels:
+		if is_channel_playing(channel):
+			return true
+	return false
 
 
 func _on_audio_finished(player: AudioStreamPlayer, channel_name: String, path: String) -> void:

--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -28,7 +28,7 @@ func _execute() -> void:
 
 	if clear_textbox and dialogic.has_subsystem("Text") and dialogic.Text.is_textbox_visible():
 		dialogic.Text.update_dialog_text('')
-		dialogic.Text.hide_textbox()
+		dialogic.Text.hide_textbox(final_time == 0)
 		dialogic.current_state = dialogic.States.IDLE
 		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 

--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -26,7 +26,7 @@ func _execute() -> void:
 		var time_per_event: float = dialogic.Inputs.auto_skip.time_per_event
 		final_time = min(time, time_per_event)
 
-	if clear_textbox and dialogic.has_subsystem("Text"):
+	if clear_textbox and dialogic.has_subsystem("Text") and dialogic.Text.is_textbox_visible():
 		dialogic.Text.update_dialog_text('')
 		dialogic.Text.hide_textbox()
 		dialogic.current_state = dialogic.States.IDLE
@@ -44,9 +44,10 @@ func _execute() -> void:
 		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
 	if clear_music and dialogic.has_subsystem('Audio'):
-		dialogic.Audio.stop_all_channels(final_time)
 		dialogic.Audio.stop_all_one_shot_sounds()
-		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
+		if dialogic.Audio.is_any_channel_playing():
+			dialogic.Audio.stop_all_channels(final_time)
+			if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
 	if clear_style and dialogic.has_subsystem('Styles'):
 		dialogic.Styles.change_style()

--- a/addons/dialogic/Modules/Jump/event_return.gd
+++ b/addons/dialogic/Modules/Jump/event_return.gd
@@ -11,7 +11,7 @@ extends DialogicEvent
 ################################################################################
 
 func _execute() -> void:
-	if !dialogic.Jump.is_jump_stack_empty():
+	if not dialogic.Jump.is_jump_stack_empty():
 		dialogic.Jump.resume_from_last_jump()
 	else:
 		dialogic.end_timeline()


### PR DESCRIPTION
Dialogic now uses a timeline to perform the end of dialog. By default this timeline simply contains a default clear event, but it can easily be swapped out. 
This should fix #2509 and #572 because `end_timeline()` now does an actual nice closing by default.