### PR TITLE
Improve runtime resources (timelines and characters created through code)

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -439,6 +439,6 @@ func print_debug_moment() -> void:
 	if not current_timeline:
 		return
 
-	printerr("\tAt event ", current_event_idx+1, " (",current_timeline_events[current_event_idx].event_name, ' Event) in timeline "', DialogicResourceUtil.get_unique_identifier(current_timeline.resource_path), '" (',current_timeline.resource_path,').')
+	printerr("\tAt event ", current_event_idx+1, " (",current_timeline_events[current_event_idx].event_name, ' Event) in timeline "', current_timeline.get_identifier(), '" (',current_timeline.resource_path,').')
 	print("\n")
 #endregion

--- a/addons/dialogic/Core/DialogicResourceUtil.gd
+++ b/addons/dialogic/Core/DialogicResourceUtil.gd
@@ -63,7 +63,7 @@ static func add_resource_to_directory(file_path:String, directory:Dictionary) ->
 
 ## Returns the unique identifier for the given resource path.
 ## Returns an empty string if no identifier was found.
-static func get_unique_identifier(file_path:String) -> String:
+static func get_unique_identifier_by_path(file_path:String) -> String:
 	if not file_path: return ""
 	var identifier: Variant = get_directory(file_path.get_extension()).find_key(file_path)
 	if typeof(identifier) == TYPE_STRING:
@@ -74,12 +74,15 @@ static func get_unique_identifier(file_path:String) -> String:
 ## Returns the resource associated with the given unique identifier.
 ## The expected extension is needed to use the right directory.
 static func get_resource_from_identifier(identifier:String, extension:String) -> Resource:
-	var path: String = get_directory(extension).get(identifier, '')
-	if ResourceLoader.exists(path):
-		return load(path)
+	var value: Variant = get_directory(extension).get(identifier, '')
+	if typeof(value) == TYPE_STRING and ResourceLoader.exists(value):
+		return load(value)
+	elif value is Resource:
+		return value
 	return null
 
 
+## Editor Only
 static func change_unique_identifier(file_path:String, new_identifier:String) -> void:
 	var directory := get_directory(file_path.get_extension())
 	var key: String = directory.find_key(file_path)
@@ -112,6 +115,21 @@ static func remove_resource(file_path:String) -> void:
 
 static func is_identifier_unused(extension:String, identifier:String) -> bool:
 	return not identifier in get_directory(extension)
+
+
+## While usually the directory maps identifiers to paths, this method (only supposed to be used at runtime)
+## allows mapping resources that are not saved to an identifier.
+static func register_runtime_resource(resource:Resource, identifier:String, extension:String) -> void:
+	var directory := get_directory(extension)
+	directory[identifier] = resource
+	set_directory(extension, directory)
+
+
+static func get_runtime_unique_identifier(resource:Resource, extension:String) -> String:
+	var identifier: Variant = get_directory(extension).find_key(resource)
+	if typeof(identifier) == TYPE_STRING:
+		return identifier
+	return ""
 
 #endregion
 

--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -528,6 +528,7 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 		TYPE_DICTIONARY:
 			input = load("res://addons/dialogic/Editor/Events/Fields/field_dictionary.tscn").instantiate()
 			input.property_name = property_info["name"]
+			input.set_value(value)
 			input.value_changed.connect(_on_export_dict_submitted.bind(property_changed))
 		TYPE_OBJECT:
 			input = load("res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn").instantiate()

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -71,9 +71,9 @@ func _open_resource(resource:Resource) -> void:
 	load_portrait_tree()
 
 	loading = false
-	character_loaded.emit(resource.resource_path)
+	character_loaded.emit(current_resource.resource_path)
 
-	%CharacterName.text = DialogicResourceUtil.get_unique_identifier(resource.resource_path)
+	%CharacterName.text = current_resource.get_identifier()
 
 	$NoCharacterScreen.hide()
 	%PortraitChangeInfo.hide()
@@ -549,7 +549,7 @@ func report_name_change(item: TreeItem) -> void:
 		editors_manager.reference_manager.add_portrait_ref_change(
 			item.get_meta('previous_name'),
 			%PortraitTree.get_full_item_name(item),
-			[DialogicResourceUtil.get_unique_identifier(current_resource.resource_path)])
+			[current_resource.get_identifier()])
 	item.set_meta('previous_name', %PortraitTree.get_full_item_name(item))
 	%PortraitChangeInfo.show()
 

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -433,7 +433,7 @@ func _on_right_click_menu_id_pressed(id: int) -> void:
 			)
 		4:  # COPY IDENTIFIER
 			DisplayServer.clipboard_set(
-				DialogicResourceUtil.get_unique_identifier(
+				DialogicResourceUtil.get_unique_identifier_by_path(
 					%RightClickMenu.get_meta("item_clicked").get_metadata(0)
 				)
 			)

--- a/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
@@ -50,7 +50,7 @@ func _set_value(value:Variant) -> void:
 			Modes.PRETTY_PATH:
 				%Search.text = DialogicUtil.pretty_name(value)
 			Modes.IDENTIFIER when value.begins_with("res://"):
-				%Search.text = DialogicResourceUtil.get_unique_identifier(value)
+				%Search.text = DialogicResourceUtil.get_unique_identifier_by_path(value)
 			Modes.ANY_VALID_STRING when validation_func:
 				%Search.text = validation_func.call(value).get('valid_text', value)
 			_:
@@ -361,7 +361,7 @@ func _can_drop_data(position:Vector2, data:Variant) -> bool:
 func _drop_data(position:Vector2, data:Variant) -> void:
 	var path := str(data.files[0])
 	if mode == Modes.IDENTIFIER:
-		path = DialogicResourceUtil.get_unique_identifier(path)
+		path = DialogicResourceUtil.get_unique_identifier_by_path(path)
 	_set_value(path)
 	value_changed.emit(property_name, path)
 	current_value_updated = false

--- a/addons/dialogic/Editor/Events/Fields/field_options_fixed.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_options_fixed.gd
@@ -3,7 +3,11 @@ extends DialogicVisualEditorField
 
 ## Event block field for constant options. For varying options use ComplexPicker.
 
-var options: Array = []
+var options: Array = []:
+	set(o):
+		options = o
+		if current_value != -1:
+			set_value(current_value)
 
 ## if true, only the symbol will be displayed. In the dropdown text will be visible.
 ## Useful for making UI simpler
@@ -21,6 +25,7 @@ func _ready() -> void:
 	call("get_popup").index_pressed.connect(index_pressed)
 
 
+
 func _load_display_info(info:Dictionary) -> void:
 	options = info.get('options', [])
 	self.disabled = info.get('disabled', false)
@@ -35,7 +40,7 @@ func _set_value(value:Variant) -> void:
 			if !symbol_only:
 				self.text = option['label']
 			self.icon = option.get('icon', null)
-			current_value = value
+	current_value = value
 
 
 func get_value() -> Variant:

--- a/addons/dialogic/Editor/Inspector/timeline_inspector_field.gd
+++ b/addons/dialogic/Editor/Inspector/timeline_inspector_field.gd
@@ -61,7 +61,7 @@ func _update_property() -> void:
 	updating = true
 	current_value = new_value
 	if current_value:
-		field.set_value(DialogicResourceUtil.get_unique_identifier(current_value.resource_path))
+		field.set_value(current_value.get_identifier())
 		button.show()
 	else:
 		button.hide()

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -73,7 +73,7 @@ func _open_resource(resource:Resource) -> void:
 		EditorMode.TEXT:
 			%TextEditor.load_timeline(current_resource)
 	$NoTimelineScreen.hide()
-	%TimelineName.text = DialogicResourceUtil.get_unique_identifier(current_resource.resource_path)
+	%TimelineName.text = current_resource.get_identifier()
 	play_timeline_button.disabled = false
 
 

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -82,7 +82,7 @@ var character_identifier: String:
 		if character_identifier == '--All--':
 			return '--All--'
 		if character:
-			var identifier := DialogicResourceUtil.get_unique_identifier(character.resource_path)
+			var identifier := character.get_identifier()
 			if not identifier.is_empty():
 				return identifier
 		return character_identifier
@@ -225,7 +225,7 @@ func to_text() -> String:
 	if action == Actions.LEAVE and character_identifier == '--All--':
 		result_string += "--All--"
 	elif character:
-		var name := DialogicResourceUtil.get_unique_identifier(character.resource_path)
+		var name := character.get_character_name()
 
 		if name.count(" ") > 0:
 			name = '"' + name + '"'

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -35,7 +35,7 @@ func load_game_state(_load_flag:=LoadFlags.FULL_LOAD) -> void:
 		var character_info: Dictionary = portraits_info[character_path]
 		var character: DialogicCharacter = load(character_path)
 		var container := dialogic.PortraitContainers.load_position_container(character.get_character_name())
-		
+
 		ResourceLoader.load_threaded_request(character_path)
 
 		var load_status = ResourceLoader.load_threaded_get_status(character_path)
@@ -138,7 +138,7 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 
 		if ResourceLoader.exists(scene_path):
 			ResourceLoader.load_threaded_request(scene_path)
-			
+
 			var load_status = ResourceLoader.load_threaded_get_status(scene_path)
 			while load_status == ResourceLoader.THREAD_LOAD_IN_PROGRESS:
 				await get_tree().process_frame
@@ -371,7 +371,7 @@ func get_valid_portrait(character:DialogicCharacter, portrait:String) -> String:
 
 	if not portrait in character.portraits:
 		if not portrait.is_empty():
-			printerr('[Dialogic] Tried to use invalid portrait "', portrait, '" on character "', DialogicResourceUtil.get_unique_identifier(character.resource_path), '". Using default portrait instead.')
+			printerr('[Dialogic] Tried to use invalid portrait "', portrait, '" on character "', character.get_character_name(), '". Using default portrait instead.')
 			dialogic.print_debug_moment()
 		portrait = character.default_portrait
 
@@ -452,9 +452,9 @@ func add_character(character: DialogicCharacter, container: DialogicNode_Portrai
 	if not character:
 		printerr('[DialogicError] Cannot call add_portrait() with null character.')
 		return null
-	
+
 	ResourceLoader.load_threaded_request(character.resource_path)
-	
+
 	var load_status = ResourceLoader.load_threaded_get_status(character.resource_path)
 	while load_status == ResourceLoader.THREAD_LOAD_IN_PROGRESS:
 		await get_tree().process_frame

--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -19,7 +19,7 @@ var label_name := ""
 var timeline_identifier := "":
 	get:
 		if timeline:
-			var identifier := DialogicResourceUtil.get_unique_identifier(timeline.resource_path)
+			var identifier := timeline.get_identifier()
 			if not identifier.is_empty():
 				return identifier
 		return timeline_identifier

--- a/addons/dialogic/Modules/Jump/event_label.gd
+++ b/addons/dialogic/Modules/Jump/event_label.gd
@@ -24,7 +24,7 @@ func _execute() -> void:
 			"identifier": name,
 			"display_name": get_property_translated("display_name"),
 			"display_name_orig": display_name,
-			"timeline": DialogicResourceUtil.get_unique_identifier(dialogic.current_timeline.resource_path)
+			"timeline": dialogic.current_timeline.get_identifier()
 		})
 	finish()
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -507,8 +507,8 @@ func collect_character_names() -> void:
 
 	character_colors = {}
 
-	for dch_path in DialogicResourceUtil.get_character_directory().values():
-		var character := (load(dch_path) as DialogicCharacter)
+	for dch_identifier in DialogicResourceUtil.get_character_directory():
+		var character := (DialogicResourceUtil.get_character_resource(dch_identifier) as DialogicCharacter)
 
 		if character.display_name:
 			if "{" in character.display_name and "}" in character.display_name:

--- a/addons/dialogic/Resources/character.gd
+++ b/addons/dialogic/Resources/character.gd
@@ -1,5 +1,5 @@
 @tool
-extends Resource
+extends "res://addons/dialogic/Resources/dialogic_identifiable_resource.gd"
 class_name DialogicCharacter
 
 
@@ -30,8 +30,12 @@ enum TranslatedProperties {
 var _translation_id := ""
 
 
-func _to_string() -> String:
-	return "[{name}:{id}]".format({"name":get_character_name(), "id":get_instance_id()})
+func _get_extension() -> String:
+	return "dch"
+
+
+func _get_resource_name() -> String:
+	return "DialogicCharacter"
 
 
 ## Adds a translation ID to the character.
@@ -125,7 +129,7 @@ func get_display_name_translated() -> String:
 
 ## Returns the best name for this character.
 func get_character_name() -> String:
-	var unique_identifier := DialogicResourceUtil.get_unique_identifier(resource_path)
+	var unique_identifier := get_identifier()
 	if not unique_identifier.is_empty():
 		return unique_identifier
 	if not resource_path.is_empty():
@@ -134,6 +138,19 @@ func get_character_name() -> String:
 		return display_name.validate_node_name()
 	else:
 		return "UnnamedCharacter"
+
+#
+### Sets the unique identifier-string of this resource.
+### In editor (if the resource is already saved) the identifier will be stored.
+### In game (if the resource is not stored) the resource will be temporarily registered.
+#func set_identifier(new_identifier:String) -> bool:
+	#if resource_path and Engine.is_editor_hint():
+		#DialogicResourceUtil.change_unique_identifier(resource_path, new_identifier)
+		#return true
+	#if not resource_path and not Engine.is_editor_hint():
+		#DialogicResourceUtil.register_runtime_resource(self, new_identifier, "dch")
+		#return true
+	#return false
 
 
 ## Returns the info of the given portrait.

--- a/addons/dialogic/Resources/dialogic_identifiable_resource.gd
+++ b/addons/dialogic/Resources/dialogic_identifiable_resource.gd
@@ -1,0 +1,36 @@
+@tool
+extends Resource
+
+
+func _get_extension() -> String:
+	return ""
+
+
+func _get_resource_name() -> String:
+	return "DialogicIdentifiableResource"
+
+
+func _to_string() -> String:
+	return "[{name}:{id}]".format({"name":_get_resource_name(), "id":get_identifier()})
+
+
+## Returns the best name for this character.
+func get_identifier() -> String:
+	if resource_path:
+		return DialogicResourceUtil.get_unique_identifier_by_path(resource_path)
+	if Engine.is_editor_hint():
+		return DialogicResourceUtil.get_runtime_unique_identifier(self, _get_extension())
+	return ""
+
+
+## Sets the unique identifier-string of this resource.
+## In editor (if the resource is already saved) the identifier will be stored.
+## In game (if the resource is not stored) the resource will be temporarily registered.
+func set_identifier(new_identifier:String) -> bool:
+	if resource_path and Engine.is_editor_hint():
+		DialogicResourceUtil.change_unique_identifier(resource_path, new_identifier)
+		return true
+	if not resource_path and not Engine.is_editor_hint():
+		DialogicResourceUtil.register_runtime_resource(self, new_identifier, _get_extension())
+		return true
+	return false

--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -1,17 +1,23 @@
 @tool
-extends Resource
+extends "res://addons/dialogic/Resources/dialogic_identifiable_resource.gd"
 class_name DialogicTimeline
 
 ## Resource that defines a list of events.
 ## It can store them as text and load them from text too.
 
+
+
 var events: Array = []
 var events_processed := false
 var text_lines_indexed := {}
 
-## Method used for printing timeline resources identifiably
-func _to_string() -> String:
-	return "[DialogicTimeline:{file}]".format({"file":resource_path})
+
+func _get_extension() -> String:
+	return "dtl"
+
+
+func _get_resource_name() -> String:
+	return "DialogicTimeline"
 
 
 ## Helper method
@@ -56,7 +62,6 @@ func as_text() -> String:
 		result.trim_suffix('\n')
 
 	return result.strip_edges()
-
 
 
 ## Returns the index of the event that corresponds to a specific line


### PR DESCRIPTION
This makes both `DialogicTimeline` and `DialogicCharacter` extend `DialogicIdentifiableResource` which basically adds a get_identifier and set_identifier method. If an identifier is set at runtime for a non-saved resource, the resource is registered to the directories directly (without a path) allowing for the use of those resources in timelines from then on.

```gdscript
        var characterA := DialogicCharacter.new()
	characterA.display_name = "Code Character"
	characterA.color = Color.WEB_PURPLE
	characterA.set_identifier("CodeCharacter")

	var timelineA := DialogicTimeline.new()
	timelineA.from_text(
	"""
		CodeCharacter: Timeline A!!!
		jump CodeTimelineB/
		label Section2
		CodeCharacter: About to end timeline A.
	""")
	timelineA.set_identifier("CodeTimelineA")

	var timelineB := DialogicTimeline.new()
	timelineB.from_text(
	"""
		Timeline B!!!
		jump CodeTimelineA/Section2
	"""
	)
	timelineB.set_identifier("CodeTimelineB")

	Dialogic.start(timelineA)
```
- fixes #2492 
- fixes #2491

This also once again allows using "invalid" character names in timelines (a new character resource will be created on the spot) and will now even interpret the portrait as a color for those, which allows to have one-off characters say something. However the portrait picker is not shown in the visual editor for those characters for now so this is kinda a text-editor exclusive rn.
```
"Random person" (webpurple): Wait who's that?
"Other person" (darkblue): I think that's the new guy.
```

Also fixes a bug with dictionaries as export overrides for custom portraits.