### PR TITLE
Improve slide animations

### DIFF
--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_down_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_down_in_out.gd
@@ -4,16 +4,17 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var target_position := base_position.y
-	var start_position: float = -node.get_viewport().size.y
+	var end_position_y: float = base_position.y + node.get_parent().global_position.y
+	var start_position: float = -get_node_size().y + get_node_origin().y
 
 	if is_reversed:
-		target_position = -node.get_viewport().size.y
+		tween.set_ease(Tween.EASE_IN)
+		end_position_y = -get_node_size().y + get_node_origin().y
 		start_position = base_position.y
 
 	node.position.y = start_position
 
-	tween.tween_property(node, 'position:y', target_position, time)
+	tween.tween_property(node, 'global_position:y', end_position_y, time)
 
 	await tween.finished
 	finished_once.emit()

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_left_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_left_in_out.gd
@@ -5,15 +5,16 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var end_position_x: float = base_position.x
+	var end_position_x: float = base_position.x + node.get_parent().global_position.x
 
 	if is_reversed:
-		end_position_x = -node.get_viewport().size.x / 2
+		end_position_x = - get_node_size().x + get_node_origin().x
+		tween.set_ease(Tween.EASE_IN)
 
 	else:
-		node.position.x = -node.get_viewport().size.x / 5
+		node.global_position.x = -get_node_size().x + get_node_origin().x
 
-	tween.tween_property(node, 'position:x', end_position_x, time)
+	tween.tween_property(node, 'global_position:x', end_position_x, time)
 
 	await tween.finished
 	finished_once.emit()
@@ -21,6 +22,6 @@ func animate() -> void:
 
 func _get_named_variations() -> Dictionary:
 	return {
-		"slide in left": {"reversed": false, "type": AnimationType.IN},
-		"slide out right": {"reversed": true, "type": AnimationType.OUT},
+		"slide from left": {"reversed": false, "type": AnimationType.IN},
+		"slide to left": {"reversed": true, "type": AnimationType.OUT},
 	}

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_right_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_right_in_out.gd
@@ -4,24 +4,21 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var viewport_x: float = node.get_viewport().size.x
-
-	var start_position_x: float = viewport_x + viewport_x / 5
-	var end_position_x := base_position.x
+	var viewport_x: float = get_viewport_size().x
+	var end_position_x : float = base_position.x + node.get_parent().global_position.x
 
 	if is_reversed:
-		start_position_x = base_position.x
-		end_position_x = viewport_x + node.get_viewport().size.x / 5
+		end_position_x = viewport_x + get_node_origin().x
+		tween.set_ease(Tween.EASE_IN)
+	else:
+		node.global_position.x = viewport_x + get_node_origin().x
 
-
-	node.position.x = start_position_x
-	tween.tween_property(node, 'position:x', end_position_x, time)
-
+	tween.tween_property(node, 'global_position:x', end_position_x, time)
 	tween.finished.connect(emit_signal.bind('finished_once'))
 
 
 func _get_named_variations() -> Dictionary:
 	return {
-		"slide in right": {"reversed": false, "type": AnimationType.IN},
-		"slide out left": {"reversed": true, "type": AnimationType.OUT},
+		"slide from right": {"reversed": false, "type": AnimationType.IN},
+		"slide to right": {"reversed": true, "type": AnimationType.OUT},
 	}

--- a/addons/dialogic/Modules/Character/DefaultAnimations/slide_up_in.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/slide_up_in.gd
@@ -4,15 +4,16 @@ func animate() -> void:
 	var tween := (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_BACK)
 
-	var start_position_y: float = node.get_viewport().size.y * 2
-	var end_position_y := base_position.y
+	var start_position_y: float = get_viewport_size().y + get_node_origin().y
+	var end_position_y: float = base_position.y + node.get_parent().global_position.y
 
 	if is_reversed:
-		start_position_y = base_position.y
-		end_position_y = node.get_viewport().size.y * 2
+		tween.set_ease(Tween.EASE_IN)
+		start_position_y = end_position_y
+		end_position_y = get_viewport_size().y + get_node_origin().y
 
-	node.position.y = start_position_y
-	tween.tween_property(node, 'position:y', end_position_y, time)
+	node.global_position.y = start_position_y
+	tween.tween_property(node, 'global_position:y', end_position_y, time)
 
 	await tween.finished
 	finished_once.emit()

--- a/addons/dialogic/Modules/Character/class_dialogic_animation.gd
+++ b/addons/dialogic/Modules/Character/class_dialogic_animation.gd
@@ -75,3 +75,28 @@ func get_modulation_property() -> String:
 		return "self_modulate"
 	else:
 		return "modulate"
+
+
+## Tries to return the size of the node to be animated.
+## For portraits this uses the portrait containers size.
+## This is useful if your animation depends on the size of the node.
+func get_node_size() -> Vector2:
+	if not node:
+		return Vector2()
+	if node.get_parent() is DialogicNode_PortraitContainer:
+		return node.get_parent().size
+	if "size" in node:
+		return node.size * node.scale
+	return node.get_viewport().size
+
+
+func get_node_origin() -> Vector2:
+	if not node:
+		return Vector2()
+	if node.get_parent() is DialogicNode_PortraitContainer:
+		return node.get_parent()._get_origin_position()
+	return Vector2()
+
+
+func get_viewport_size() -> Vector2:
+	return node.get_viewport().get_visible_rect().size


### PR DESCRIPTION
This changes the slide animations. Slide In/Out Left and Slide In/Out Right are now renamed to Slide From Left, Slide To Left, Slide From Right and Slide To Right. All the slide animations have been adjusted to slide exactly the needed amount so that the portrait fully leaves the screen, not just sliding a fixed amount. To do this, the animation class has gotten two new methods that help determening the animated nodes (e.g. Portraits) size and position.

This breaks compatibility because those animation names have changed.