### PR TITLE
Improving/fixing issues with Speaker signal and Highlight methods

### DIFF
--- a/Tests/Unit/subsystem_text_test.gd
+++ b/Tests/Unit/subsystem_text_test.gd
@@ -2,6 +2,11 @@ extends GdUnitTestSuite
 
 const VALID_SPEAKER_PATH := "unit_test_character"
 
+
+func test_build_character_directory() -> void:
+	DialogicResourceUtil.update()
+
+
 ## We ensure that missing a speaker will return null.
 func test_missing_current_speaker() -> void:
 	var null_speaker := DialogicUtil.autoload().Text.get_current_speaker()

--- a/Tests/Unit/subsystem_text_test.gd
+++ b/Tests/Unit/subsystem_text_test.gd
@@ -24,4 +24,4 @@ func test_set_valid_current_speaker() -> void:
 	var current_speaker := DialogicUtil.autoload().Text.get_current_speaker()
 
 	assert(not current_speaker == null, "Valid speaker must be valid, but is invalid.")
-	assert(current_speaker.get_path() == VALID_SPEAKER_PATH, "Valid speaker path is not set correctly.")
+	assert(current_speaker.get_identifier() == VALID_SPEAKER_PATH, "Valid speaker path is not set correctly.")

--- a/Tests/Unit/subsystem_text_test.gd
+++ b/Tests/Unit/subsystem_text_test.gd
@@ -1,6 +1,6 @@
 extends GdUnitTestSuite
 
-const VALID_SPEAKER_PATH := "res://Tests/Resources/unit_test_character.dch"
+const VALID_SPEAKER_PATH := "unit_test_character"
 
 ## We ensure that missing a speaker will return null.
 func test_missing_current_speaker() -> void:

--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -80,12 +80,12 @@ signal dialogic_paused
 signal dialogic_resumed
 
 
-## Emitted when the timeline ends.
-## This can be a timeline ending or [method end_timeline] being called.
-signal timeline_ended
 ## Emitted when a timeline starts by calling either [method start]
 ## or [method start_timeline].
 signal timeline_started
+## Emitted when the timeline ends.
+## This can be a timeline ending or [method end_timeline] being called.
+signal timeline_ended
 ## Emitted when an event starts being executed.
 ## The event may not have finished executing yet.
 signal event_handled(resource: DialogicEvent)

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -53,11 +53,11 @@ func load_game_state(_load_flag:=LoadFlags.FULL_LOAD) -> void:
 			push_error('[Dialogic] Failed to load character "' + str(character_path) + '".')
 
 	# Load Speaker Portrait
-	var speaker: Variant = dialogic.current_state_info.get('speaker', "")
+	var speaker: Variant = dialogic.current_state_info.get("speaker", "")
 	if speaker:
-		dialogic.current_state_info['speaker'] = ""
-		change_speaker(load(speaker))
-	dialogic.current_state_info['speaker'] = speaker
+		dialogic.current_state_info["speaker"] = ""
+		change_speaker(DialogicResourceUtil.get_character_resource(speaker))
+	dialogic.current_state_info["speaker"] = speaker
 
 
 func pause() -> void:
@@ -613,13 +613,6 @@ func remove_character(character: DialogicCharacter) -> void:
 	dialogic.current_state_info['portraits'].erase(character.resource_path)
 
 
-func get_current_character() -> DialogicCharacter:
-	if dialogic.current_state_info.get('speaker', null):
-		return load(dialogic.current_state_info.speaker)
-	return null
-
-
-
 ## Returns true if the given character is currently joined.
 func is_character_joined(character: DialogicCharacter) -> bool:
 	if character == null or not character.resource_path in dialogic.current_state_info['portraits']:
@@ -733,16 +726,13 @@ func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 
 		_change_portrait_mirror(character_node)
 
-	if speaker:
-		if speaker.resource_path != dialogic.current_state_info['speaker']:
-			if dialogic.current_state_info['speaker'] and is_character_joined(load(dialogic.current_state_info['speaker'])):
-				dialogic.current_state_info['portraits'][dialogic.current_state_info['speaker']].node.get_child(-1)._unhighlight()
-
-			if speaker and is_character_joined(speaker):
-				dialogic.current_state_info['portraits'][speaker.resource_path].node.get_child(-1)._highlight()
-
-	elif dialogic.current_state_info['speaker'] and is_character_joined(load(dialogic.current_state_info['speaker'])):
-		dialogic.current_state_info['portraits'][dialogic.current_state_info['speaker']].node.get_child(-1)._unhighlight()
+	var prev_speaker: DialogicCharacter = dialogic.Text.get_current_speaker()
+	if speaker != prev_speaker:
+		if is_character_joined(prev_speaker):
+			dialogic.current_state_info["portraits"][prev_speaker.resource_path].node.get_child(-1)._unhighlight()
+		
+		if is_character_joined(speaker):
+			dialogic.current_state_info["portraits"][speaker.resource_path].node.get_child(-1)._highlight()
 
 #endregion
 
@@ -753,14 +743,15 @@ func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 ## Called from the [portrait=something] text effect.
 func text_effect_portrait(_text_node:Control, _skipped:bool, argument:String) -> void:
 	if argument:
-		if dialogic.current_state_info.get('speaker', null):
-			change_character_portrait(load(dialogic.current_state_info.speaker), argument)
-			change_speaker(load(dialogic.current_state_info.speaker), argument)
+		var current_speaker := dialogic.Text.get_current_speaker()
+		if current_speaker:
+			change_character_portrait(current_speaker, argument)
+			change_speaker(current_speaker, argument)
 
 
 ## Called from the [extra_data=something] text effect.
 func text_effect_extradata(_text_node:Control, _skipped:bool, argument:String) -> void:
 	if argument:
-		if dialogic.current_state_info.get('speaker', null):
-			change_character_extradata(load(dialogic.current_state_info.speaker), argument)
+		if dialogic.Text.get_current_speaker():
+			change_character_extradata(dialogic.Text.get_current_speaker(), argument)
 #endregion

--- a/addons/dialogic/Resources/dialogic_identifiable_resource.gd
+++ b/addons/dialogic/Resources/dialogic_identifiable_resource.gd
@@ -18,7 +18,7 @@ func _to_string() -> String:
 func get_identifier() -> String:
 	if resource_path:
 		return DialogicResourceUtil.get_unique_identifier_by_path(resource_path)
-	if Engine.is_editor_hint():
+	if not Engine.is_editor_hint():
 		return DialogicResourceUtil.get_runtime_unique_identifier(self, _get_extension())
 	return ""
 


### PR DESCRIPTION
- fixes several issues reported on the discord server

This code is defenitely breaking some compatibilty, because the speaker is now stored as an identifier and not as a resource_path in the current_state (breaks compat with old saves and maybe with some custom code of people). This is necessary to allow the speaker_update method to work with runtime-characters.

Could also break stuff because the order of operations in the text event has slightly been changed.

Also removed the unnecessary get_current_character method from the Portraits subsystem, as it just did the same as the Text systems method, and speaker is mostly a text concept anyways.

Fixed a dumb mistake in the dialogic_identifiable_resource