### PR TITLE
Apply new overrides when switching styles if there's a common ancestor

### DIFF
--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -51,7 +51,7 @@ func load_style(style_name := "", parent: Node = null, is_base_style := true, st
 			return previous_layout
 
 		# If this has the same scene setup, just apply the new overrides
-		elif previous_layout.get_meta('style') == style.get_inheritance_root():
+		elif previous_layout.get_meta('style') == style.get_inheritance_root() or previous_layout.get_meta('style').get_inheritance_root() == style.get_inheritance_root():
 			DialogicUtil.apply_scene_export_overrides(previous_layout, style.get_layer_inherited_info("").overrides)
 			var index := 0
 			for layer in previous_layout.get_layers():


### PR DESCRIPTION
A very simple change. When switching between styles if the new applied style inherits the old one then the exports of the old style get transferred to the new one, this PR makes this also happen when both old and new styles inherit from the same style.

The use-case, at least in our case, was that we had a different style for each character in our game, so every time the characters switched in the dialogue the whole layer was destroyed and rebuilt, causing problems with the textbox animations. So we made all the styles inherit from one base style that way when we switch between styles the exports simply change, but we had the problem that when changing from a character style to a different character style since the second style technically didn't inherit from the first one it didn't work, this PR fixes that.