### PR TITLE
Adds mouse filter to bubble

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
@@ -200,3 +200,11 @@ func get_speaker_canvas_position() -> Vector2:
 		if node_to_point_at is CanvasItem:
 			base_position = (node_to_point_at as CanvasItem).get_global_transform_with_canvas().origin
 	return base_position
+
+
+## Changes the property of mouse filter of the bubble and its children (text and label).
+func change_mouse_filter(mouse_filter: Control.MouseFilter) -> void:
+	mouse_filter = mouse_filter
+	text.mouse_filter = mouse_filter
+	name_label_box.mouse_filter = mouse_filter
+	name_label_holder.mouse_filter = mouse_filter

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble_layer.gd
@@ -25,6 +25,7 @@ extends DialogicLayoutLayer
 @export_subgroup('Behaviour')
 @export var behaviour_distance: int = 50
 @export var behaviour_direction: Vector2 = Vector2(1, -1)
+@export var behaviour_mouse_filter: Control.MouseFilter
 
 @export_group('Name Label')
 @export_subgroup("Name Label")
@@ -118,6 +119,7 @@ func bubble_apply_overrides(bubble:TextBubble) -> void:
 	## BEHAVIOUR
 	bubble.safe_zone = behaviour_distance
 	bubble.base_direction = behaviour_direction
+	bubble.change_mouse_filter(behaviour_mouse_filter)
 
 
 	## NAME LABEL SETTINGS


### PR DESCRIPTION
By allowing the user to change the mouse filter, the bubble can now be set to ignore to prevent it from capturing events. The original use case for this modification was preventing bubbles of blocking the mouse movement when the mouse was captured on a 3D game.

Original issue: https://discord.com/channels/628713677239091231/1357374714263376035