### PR TITLE
Variable Editor: Add Name Validation and Undo/Redo functionality

### DIFF
--- a/addons/dialogic/Editor/Common/reference_manager_window.gd
+++ b/addons/dialogic/Editor/Common/reference_manager_window.gd
@@ -172,6 +172,10 @@ func _on_close_requested() -> void:
 	broken_manager.close()
 
 
+func get_change_count() -> int:
+	return len(broken_manager.reference_changes)
+
+
 func update_indicator() -> void:
 	icon_button.get_child(0).visible = !broken_manager.reference_changes.is_empty()
 

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://defdeav8rli6o" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn" id="3_up2bn"]
 [ext_resource type="Script" uid="uid://bb2umikh806og" path="res://addons/dialogic/Editor/TimelineEditor/shortcut_popup.gd" id="6_rfuk0"]
 
-[sub_resource type="Image" id="Image_u2118"]
+[sub_resource type="Image" id="Image_6bv6r"]
 data = {
 "data": PackedByteArray(255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 42, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 93, 93, 41, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 92, 92, 0, 255, 92, 92, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 93, 93, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0),
 "format": "RGBA8",
@@ -15,10 +15,10 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_boacm"]
-image = SubResource("Image_u2118")
+[sub_resource type="ImageTexture" id="ImageTexture_u2118"]
+image = SubResource("Image_6bv6r")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_r3ew6"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_boacm"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -116,7 +116,7 @@ size_flags_horizontal = 10
 size_flags_vertical = 4
 tooltip_text = "Switch between Text Editor and Visual Editor"
 text = "Text editor"
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 
 [node name="Shortcuts" type="Button" parent="VBox/HBox"]
 unique_name_in_owner = true
@@ -124,7 +124,7 @@ layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 4
 tooltip_text = "Shortcuts"
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 
 [node name="VisualEditor" parent="VBox" instance=ExtResource("2_qs7vc")]
 unique_name_in_owner = true
@@ -144,7 +144,7 @@ size_flags_vertical = 3
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_r3ew6")
+theme_override_styles/panel = SubResource("StyleBoxFlat_boacm")
 
 [node name="VBox" type="VBoxContainer" parent="VBox/SearchReplaceSection"]
 layout_mode = 2
@@ -167,13 +167,13 @@ layout_mode = 2
 [node name="SearchUp" type="Button" parent="VBox/SearchReplaceSection/VBox/SearchSection"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 flat = true
 
 [node name="SearchDown" type="Button" parent="VBox/SearchReplaceSection/VBox/SearchSection"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 flat = true
 
 [node name="MatchCase" type="CheckBox" parent="VBox/SearchReplaceSection/VBox/SearchSection"]
@@ -189,7 +189,7 @@ text = "Whole Words"
 [node name="SearchClose" type="Button" parent="VBox/SearchReplaceSection/VBox/SearchSection"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 flat = true
 
 [node name="ReplaceSection" type="HBoxContainer" parent="VBox/SearchReplaceSection/VBox"]
@@ -216,7 +216,7 @@ text = "Replace All"
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Replace in all timelines"
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 
 [node name="ProgressSection" type="HBoxContainer" parent="VBox"]
 unique_name_in_owner = true
@@ -242,7 +242,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_r3ew6")
+theme_override_styles/panel = SubResource("StyleBoxFlat_boacm")
 
 [node name="CenterContainer" type="CenterContainer" parent="NoTimelineScreen"]
 layout_mode = 2
@@ -289,7 +289,7 @@ text = "Shortcuts "
 [node name="CloseShortcutPanel" type="Button" parent="ShortcutsPanel/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_boacm")
+icon = SubResource("ImageTexture_u2118")
 flat = true
 
 [node name="ScrollContainer" type="ScrollContainer" parent="ShortcutsPanel/VBoxContainer"]

--- a/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
@@ -7,6 +7,8 @@ enum TreeButtons {ADD_FOLDER, ADD_VARIABLE, DUPLICATE_FOLDER, DELETE, CHANGE_TYP
 
 var validation_regex := RegEx.create_from_string(r"[^\w]")
 
+var undo := UndoRedo.new()
+
 #region INITIAL SETUP
 
 func _ready() -> void:
@@ -52,20 +54,21 @@ func load_info(dict:Dictionary, parent:TreeItem = null, is_new:=false) -> void:
 			load_info(dict[key], folder, is_new)
 
 
-
-func add_variable_item(name:String, value:Variant, parent:TreeItem) -> TreeItem:
+func add_variable_item(item_name:String, value:Variant, parent:TreeItem) -> TreeItem:
 	var item := create_item(parent)
 	item.set_meta("type", "VARIABLE")
 
-	item.set_text(0, name)
+	item.set_text(0, item_name)
 	item.set_editable(0, true)
-	item.set_metadata(0, name)
+	item.set_metadata(0, item_name)
 	item.set_icon(0, load(DialogicUtil.get_module_path('Variable').path_join("variable.svg")))
-	var folder_color: Color = parent.get_meta('color', Color.DARK_GOLDENROD)
-	item.set_custom_bg_color(0, folder_color.lerp(get_theme_color("background", "Editor"), 0.8))
+
+	var folder_color: Color = parent.get_meta('color', Color.TRANSPARENT)
+	folder_color.a *= 0.5
+	item.set_custom_bg_color(0, folder_color.lerp(get_theme_color("background", "Editor"), 0.5))
 
 	item.add_button(1, get_theme_icon("String", "EditorIcons"), TreeButtons.CHANGE_TYPE)
-	adjust_variable_type(item, DialogicUtil.get_variable_value_type(value), value)
+	set_variable_value(item, DialogicUtil.get_variable_value_type(value), value)
 	item.set_editable(2, true)
 	item.add_button(2, get_theme_icon("Remove", "EditorIcons"), TreeButtons.DELETE)
 
@@ -73,27 +76,51 @@ func add_variable_item(name:String, value:Variant, parent:TreeItem) -> TreeItem:
 	return item
 
 
-func add_folder_item(name:String, parent:TreeItem) -> TreeItem:
+func add_folder_item(item_name:String, parent:TreeItem) -> TreeItem:
 	var item := create_item(parent)
 	item.set_icon(0, get_theme_icon("Folder", "EditorIcons"))
-	item.set_text(0, name)
+	item.set_meta("type", "FOLDER")
+	item.set_text(0, item_name)
+	item.set_metadata(0, item_name)
 	item.set_editable(0, item != get_root())
 
-	var folder_color: Color
+	var folder_color := Color.TRANSPARENT
 	if parent == null:
+		#folder_color = Color.TRANSPARENT#
 		folder_color = Color(0.33000001311302, 0.15179999172688, 0.15179999172688)
 	else:
-		folder_color = parent.get_meta('color')
-	folder_color.h = wrap(folder_color.h+0.15*(item.get_index()+1), 0, 1)
+		var parent_color: Color = parent.get_meta('color', Color(0.33000001311302, 0.15179999172688, 0.15179999172688))
+		folder_color = parent_color
+
+	var level := 1
+	var i := item
+	while i.get_parent():
+		i = i.get_parent()
+		level += 1
+
+	var parent_vars_count := 0
+	if parent:
+		parent_vars_count = parent.get_children().reduce(func(x, y): return x + 1 if y.get_meta("type") == "VARIABLE" else x, 0)
+
+	if level == 2:
+		folder_color.h = wrap(folder_color.h+0.15*(item.get_index()-parent_vars_count+1), 0, 1)
+		#folder_color = folder_color.lerp(get_theme_color("background", "Editor"), 0.1*level)
+	elif level == 3:
+		folder_color.h = wrap(folder_color.h-0.1*(item.get_index()-parent_vars_count+1), 0, 1)
+	elif level == 4:
+		folder_color.h = wrap(folder_color.h+0.1*(item.get_index()-parent_vars_count+1), 0, 1)
+
+	folder_color = folder_color.lerp(get_theme_color("background", "Editor"), 0.25)
 	item.set_custom_bg_color(0, folder_color)
 	item.set_custom_bg_color(1, folder_color)
 	item.set_custom_bg_color(2, folder_color)
 	item.set_meta('color', folder_color)
+
 	item.add_button(2, load(self.get_script().get_path().get_base_dir().get_base_dir() + "/add-variable.svg"), TreeButtons.ADD_VARIABLE)
 	item.add_button(2, load("res://addons/dialogic/Editor/Images/Pieces/add-folder.svg"), TreeButtons.ADD_FOLDER)
 	item.add_button(2, get_theme_icon("Duplicate", "EditorIcons"), TreeButtons.DUPLICATE_FOLDER, item == get_root())
 	item.add_button(2, get_theme_icon("Remove", "EditorIcons"), TreeButtons.DELETE, item == get_root())
-	item.set_meta("type", "FOLDER")
+
 	return item
 
 
@@ -120,32 +147,27 @@ func get_variable_item_default(item:TreeItem) -> Variant:
 	return ""
 
 
-func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
+func _on_button_clicked(item: TreeItem, _column: int, id: int, _mouse_button_index: int) -> void:
 	match id:
-		TreeButtons.ADD_FOLDER:
-			var new_item := add_folder_item("Folder", item)
-			new_item.set_text(0, "NewFolder")
-			validate_name(new_item)
+		TreeButtons.ADD_FOLDER, TreeButtons.ADD_VARIABLE:
+			var new_item_name := ""
+			if id == TreeButtons.ADD_FOLDER:
+				new_item_name = validate_name(item, "NewFolder")
+				item_add_undoable(item, new_item_name, "FOLDER", {})
+			else:
+				new_item_name = validate_name(item, "NewVar")
+				item_add_undoable(item, new_item_name, "VARIABLE", "")
+			await get_tree().process_frame
+			var new_item := get_path_item(get_item_path(item, new_item_name))
 			new_item.select(0)
 			new_item.set_meta("new", true)
-			await get_tree().process_frame
-			await get_tree().process_frame
-			edit_selected()
-		TreeButtons.ADD_VARIABLE:
-			var new_item := add_variable_item("Var", "", item)
-			new_item.set_text(0, "NewVariable")
-			validate_name(new_item)
-			new_item.set_meta("new", true)
-			if item.get_child_count() > 1:
-				new_item.move_before(item.get_child(0))
-			new_item.select(0)
-			await get_tree().process_frame
 			await get_tree().process_frame
 			edit_selected()
 		TreeButtons.DELETE:
-			item.free()
+			item_remove_undoable(item)
 		TreeButtons.DUPLICATE_FOLDER:
-			load_info({item.get_text(0)+"(copy)":get_info(item)}, item.get_parent(), true)
+			var new_folder_name := validate_name(item.get_parent(), item.get_text(0))
+			item_add_undoable(item.get_parent(), new_folder_name, "FOLDER", get_info(item))
 		TreeButtons.CHANGE_TYPE:
 			%ChangeTypePopup.show()
 			%ChangeTypePopup.set_meta('item', item)
@@ -155,10 +177,23 @@ func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index
 			%ChangeTypePopup/HBox.get_child(int(item.get_meta('value_type', DialogicUtil.VarTypes.STRING)-1)).set_pressed_no_signal(true)
 
 
-func _on_type_pressed(pressed:bool, type:int) -> void:
+func _on_type_pressed(_pressed:bool, type:int) -> void:
 	%ChangeTypePopup.hide()
-	var item: Variant = %ChangeTypePopup.get_meta('item')
-	adjust_variable_type(item, type, item.get_metadata(2))
+	# This is a MESS.
+	# Basically there are two ways a variable value can change:
+	# - by being set edited the tree
+	# - by the type being changed
+	# The problem is that to make the first undoable, we always store the value in the metadata as well.
+	# When we detect an edit (in _on_item_edited) we commit the do/undo actions which edit the value AGAIN.
+	# But here, where we change the type we now have to edit the type two times as well.
+	# There might be a better way but who cares...
+	var item: TreeItem = %ChangeTypePopup.get_meta('item')
+	var old_value: Variant = item.get_metadata(2)
+	set_variable_value(item, type, item.get_metadata(2))
+	var new_value: Variant = get_variable_item_default(item)
+	if typeof(new_value) != typeof(old_value) or new_value != old_value:
+		item.set_metadata(2, old_value)
+		item_change_value_undoable(item)
 
 
 func _on_item_edited() -> void:
@@ -172,18 +207,98 @@ func _on_item_edited() -> void:
 					else:
 						validate_name(item)
 						if item.get_text(0) != item.get_metadata(0):
-							item.set_metadata(0, item.get_text(0))
-							report_name_changes(item)
-
+							item_rename_undoable(item)
 				2:
-					item.set_metadata(2, get_variable_item_default(item))
+					if get_variable_item_default(item) != item.get_metadata(2):
+						item_change_value_undoable(item)
 		"FOLDER":
-			validate_name(item)
-			report_name_changes(item)
+			if item.get_text(0) != item.get_metadata(0):
+				validate_name(item)
+				item_rename_undoable(item)
 
 
-func validate_name(item:TreeItem) -> void:
+func item_add_undoable(parent_item:TreeItem, item_name:String, type:String, value:Variant) -> void:
+	undo.create_action("Add Item")
+	undo.add_do_method(
+		add_item.bind(
+			get_item_path(parent_item),
+			item_name,
+			type,
+			value)
+			)
+	undo.add_undo_method(remove_item.bind(get_item_path(parent_item, item_name)))
+	undo.commit_action()
+
+
+func add_item(parent_path:String, text:String, type:String, value:Variant) -> void:
+	var parent_item := get_path_item(parent_path)
+	match type:
+		"VARIABLE":
+			add_variable_item(text, value, parent_item)
+		"FOLDER":
+			load_info({text:value}, parent_item, true)
+
+
+func item_remove_undoable(item:TreeItem) -> void:
+	undo.create_action("Remove Item")
+	undo.add_do_method(remove_item.bind(get_item_path(item)))
+	undo.add_undo_method(
+		add_item.bind(
+			get_item_path(item.get_parent()),
+			item.get_text(0),
+			item.get_meta("type"),
+			get_variable_item_default(item) if item.get_meta("type") == "VARIABLE" else get_info(item))
+			)
+	undo.commit_action()
+
+func remove_item(item_path:String) -> void:
+	get_path_item(item_path).free()
+
+
+func item_rename_undoable(item:TreeItem) -> void:
+	var new_item_path := get_item_path(item)
+	var new_name := item.get_text(0)
+	var old_name: String = item.get_metadata(0)
+	item.set_text(0, item.get_metadata(0))
+	var old_item_path := get_item_path(item)
+	undo.create_action("Renamed Item")
+	undo.add_do_method(item_rename.bind(old_item_path, new_name, old_name))
+	undo.add_undo_method(item_rename.bind(new_item_path, old_name, new_name))
+	undo.commit_action()
+
+
+func item_rename(item_path:String, new_name:String, old_name:String) -> void:
+	var item := get_path_item(item_path)
+	if item.get_text(0) == old_name:
+		item.set_text(0, new_name)
+	report_name_changes(item)
+	item.set_metadata(0, item.get_text(0))
+
+
+func item_change_value_undoable(item:TreeItem) -> void:
+	var item_path := get_item_path(item)
+	var old_value: Variant = item.get_metadata(2)
+	var new_value: Variant = get_variable_item_default(item)
+
+	undo.create_action("Change Variable")
+	undo.add_do_method(item_change_value.bind(item_path, new_value))
+	undo.add_undo_method(item_change_value.bind(item_path, old_value))
+	undo.commit_action()
+
+
+func item_change_value(item_path:String, value:Variant) -> void:
+	#print("SET VARIABLE VALUE ", value)
+	var item := get_path_item(item_path)
+	set_variable_value(item, DialogicUtil.get_variable_value_type(value), value)
+	item.set_metadata(2, value)
+
+
+func validate_name(item:TreeItem, check_for_imaginary_child := "") -> String:
 	var item_name := item.get_text(0)
+	var item_parent := item.get_parent()
+	if check_for_imaginary_child:
+		item_name = check_for_imaginary_child
+		item_parent = item
 	if not item_name.is_valid_identifier():
 		item_name = validation_regex.sub(item_name, "_", true)
 	if not item_name.is_valid_identifier():
@@ -191,7 +306,7 @@ func validate_name(item:TreeItem) -> void:
 
 	var sibling_names := []
 
-	for i in item.get_parent().get_children():
+	for i in item_parent.get_children():
 		if i == item:
 			continue
 		sibling_names.append(i.get_text(0))
@@ -210,10 +325,13 @@ func validate_name(item:TreeItem) -> void:
 
 		item_name = item_name + str(x)
 
-	item.set_text(0, item_name)
+	if not check_for_imaginary_child:
+		item.set_text(0, item_name)
+
+	return item_name
 
 
-func adjust_variable_type(item:TreeItem, type:int, prev_value:Variant) -> void:
+func set_variable_value(item:TreeItem, type:int, prev_value:Variant) -> void:
 	set_variable_item_type(item, type)
 	match type:
 		DialogicUtil.VarTypes.STRING:
@@ -236,12 +354,21 @@ func adjust_variable_type(item:TreeItem, type:int, prev_value:Variant) -> void:
 			item.set_checked(2, prev_value and true)
 
 
-func _input(event):
+func _input(event:InputEvent) -> void:
+	if get_window().has_focus() and is_visible_in_tree() and event is InputEventKey and event.is_pressed():
+		match event.as_text():
+			"Ctrl+Z":
+				undo.undo()
+				accept_event()
+			"Ctrl+Y", "Ctrl+Shift+Z":
+				undo.redo()
+				accept_event()
 	if !%ChangeTypePopup.visible:
 		return
 	if event is InputEventMouseButton and event.pressed:
 		if not %ChangeTypePopup.get_global_rect().has_point(get_global_mouse_position()):
 			%ChangeTypePopup.hide()
+
 
 #endregion
 
@@ -285,7 +412,7 @@ func get_info(item:TreeItem = null) -> Dictionary:
 #region DRAG AND DROP
 ################################################################################
 
-func _get_drag_data(position:Vector2) -> Variant:
+func _get_drag_data(_position:Vector2) -> Variant:
 	drop_mode_flags = DROP_MODE_INBETWEEN
 	var preview := Label.new()
 	preview.text = "     "+get_selected().get_text(0)
@@ -295,11 +422,11 @@ func _get_drag_data(position:Vector2) -> Variant:
 	return get_selected()
 
 
-func _can_drop_data(position:Vector2, data:Variant) -> bool:
+func _can_drop_data(_position:Vector2, data:Variant) -> bool:
 	return data is TreeItem
 
 
-func _drop_data(position:Vector2, item:Variant) -> void:
+func _drop_data(_position:Vector2, item:Variant) -> void:
 	var to_item := get_item_at_position(position)
 
 	if !to_item:
@@ -364,12 +491,38 @@ func report_name_changes(item:TreeItem) -> void:
 				report_name_changes(child)
 
 
-func get_item_path(item:TreeItem) -> String:
-	var path := item.get_text(0)
-	while item.get_parent() != get_root():
+func get_item_path(item:TreeItem, imaginary_child:String = "") -> String:
+	var path := ""
+	if item != get_root():
+		path = item.get_text(0)
+	while item != get_root() and item.get_parent() != get_root():
 		item = item.get_parent()
 		path = item.get_text(0)+"."+path
+	if imaginary_child:
+		if path:
+			path += "."+imaginary_child
+		else:
+			path = imaginary_child
 	return path
+
+
+func get_path_item(path:String) -> TreeItem:
+	var paths := Array(path.split(".", false))
+	var item := get_root()
+	while paths:
+		var found := false
+		for i in item.get_children():
+			if i.get_text(0) == paths[0]:
+				item = i
+				paths.pop_front()
+				found = true
+				break
+		if not found:
+			break
+
+	if get_item_path(item) != path:
+		return null
+	return item
 
 #endregion
 

--- a/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
@@ -426,13 +426,13 @@ func _can_drop_data(_position:Vector2, data:Variant) -> bool:
 	return data is TreeItem
 
 
-func _drop_data(_position:Vector2, item:Variant) -> void:
-	var to_item := get_item_at_position(position)
+func _drop_data(drop_position:Vector2, item:Variant) -> void:
+	var to_item := get_item_at_position(drop_position)
 
 	if !to_item:
 		return
 
-	var drop_section := get_drop_section_at_position(position)
+	var drop_section := get_drop_section_at_position(drop_position)
 	var parent: TreeItem = null
 	if (drop_section == 1 and to_item.get_meta('type') == "FOLDER") or to_item == get_root():
 		parent = to_item

--- a/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd
@@ -124,14 +124,22 @@ func _on_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index
 	match id:
 		TreeButtons.ADD_FOLDER:
 			var new_item := add_folder_item("Folder", item)
+			new_item.set_text(0, "NewFolder")
+			validate_name(new_item)
 			new_item.select(0)
 			new_item.set_meta("new", true)
+			await get_tree().process_frame
 			await get_tree().process_frame
 			edit_selected()
 		TreeButtons.ADD_VARIABLE:
 			var new_item := add_variable_item("Var", "", item)
-			new_item.select(0)
+			new_item.set_text(0, "NewVariable")
+			validate_name(new_item)
 			new_item.set_meta("new", true)
+			if item.get_child_count() > 1:
+				new_item.move_before(item.get_child(0))
+			new_item.select(0)
+			await get_tree().process_frame
 			await get_tree().process_frame
 			edit_selected()
 		TreeButtons.DELETE:
@@ -344,7 +352,6 @@ func _drop_data(position:Vector2, item:Variant) -> void:
 ################################################################################
 
 func report_name_changes(item:TreeItem) -> void:
-
 	match item.get_meta('type'):
 		"VARIABLE":
 			if item.get_meta("new", false):

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
@@ -18,7 +18,7 @@ func _register() -> void:
 	alternative_text = "Create and edit dialogic variables and their default values"
 
 
-func _open(argument:Variant = null):
+func _open(_argument:Variant = null) -> void:
 	%ReferenceInfo.hide()
 	%Tree.load_info(ProjectSettings.get_setting('dialogic/variables', {}))
 
@@ -50,7 +50,6 @@ func variable_renamed(old_name:String, new_name:String):
 		%ReferenceInfo.hide()
 	elif count < new_count:
 		%ReferenceInfo.show()
-
 
 func _on_reference_manager_pressed() -> void:
 	editors_manager.reference_manager.open()

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
@@ -43,8 +43,13 @@ func _ready() -> void:
 func variable_renamed(old_name:String, new_name:String):
 	if old_name == new_name:
 		return
+	var count: int = editors_manager.reference_manager.get_change_count()
 	editors_manager.reference_manager.add_variable_ref_change(old_name, new_name)
-	%ReferenceInfo.show()
+	var new_count: int = editors_manager.reference_manager.get_change_count()
+	if count > new_count:
+		%ReferenceInfo.hide()
+	elif count < new_count:
+		%ReferenceInfo.show()
 
 
 func _on_reference_manager_pressed() -> void:


### PR DESCRIPTION
This adds two very useful QOL features to the variable editor:
- Name Validation makes sure variable and folder names only use valid symbols (no spaces, - / " etc.) and are unique (so no data get's lost, fixing #2408 
- UndoRedo is just super useful when editing variables, as it's pretty easy to accidentally delete something wrong.