### PR TITLE
fix one-off name getting lost in visual editor

### DIFF
--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -325,12 +325,15 @@ func from_text(string:String) -> void:
 		else:
 			character = DialogicResourceUtil.get_character_resource(name)
 
-			if character == null and Engine.is_editor_hint() == false:
-				character = DialogicCharacter.new()
-				character.display_name = name
-				character.set_identifier(name)
-				if portrait:
-					character.color = Color(portrait)
+			if character == null:
+				if Engine.is_editor_hint() == false:
+					character = DialogicCharacter.new()
+					character.display_name = name
+					character.set_identifier(name)
+					if portrait:
+						character.color = Color(portrait)
+				else:
+					character_identifier = name
 
 	if not result:
 		return


### PR DESCRIPTION
fixes: #2570 

This does not fix the bug where characters aren't set if you don't click them in the drop down. that it's own can of works