### PR TITLE
Fixed errors of repeatedly connecting events.

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -194,8 +194,10 @@ func start(timeline:Variant, label_or_idx:Variant="") -> Node:
 		scene.show()
 
 	if not scene.is_node_ready():
-		scene.ready.connect(clear.bind(ClearFlags.KEEP_VARIABLES))
-		scene.ready.connect(start_timeline.bind(timeline, label_or_idx))
+		if not scene.ready.is_connected(clear.bind(ClearFlags.KEEP_VARIABLES)):
+			scene.ready.connect(clear.bind(ClearFlags.KEEP_VARIABLES))
+		if not scene.ready.is_connected(start_timeline.bind(timeline, label_or_idx)):
+			scene.ready.connect(start_timeline.bind(timeline, label_or_idx))
 	else:
 		start_timeline(timeline, label_or_idx)
 


### PR DESCRIPTION
When I end and start a new timeline, there is an error below.

I check signal connections before connecting new events as a precaution.

<img width="1042" alt="Screenshot 2025-04-17 at 02 41 40" src="https://github.com/user-attachments/assets/ef9f3516-c05d-4eb6-84e4-06ef37dea6db" />
