### PR TITLE
Changed Glossary_popup font resource from FontFile to Font, fix #2599 

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Glossary/glossary_popup_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Glossary/glossary_popup_layer.gd
@@ -122,7 +122,7 @@ func _on_dialogic_display_dialog_text_meta_hover_ended(_meta:String) -> void:
 
 func _apply_export_overrides() -> void:
 	# Apply fonts
-	var font: FontFile
+	var font: Font
 	var global_font_setting: String = get_global_setting(&"font", '')
 	if font_use_global and ResourceLoader.exists(global_font_setting):
 		font = load(global_font_setting)


### PR DESCRIPTION
Quick fix to #2599 . Changing FontFile to Font correctly fixes all the problems exposed in the issue, without any setbacks, as Font is the super class of FontFile and FontVariation 