### PR TITLE
Assorted Bug Fixes

### DIFF
--- a/addons/dialogic/Editor/Events/EventBlock/event_block.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_block.gd
@@ -425,6 +425,6 @@ func _on_EventNode_gui_input(event:InputEvent) -> void:
 			popup.current_event = self
 			popup.popup_on_parent(Rect2(get_global_mouse_position(),Vector2()))
 			if resource.help_page_path == "":
-				popup.set_item_disabled(2, true)
+				popup.set_item_disabled(4, true)
 			else:
-				popup.set_item_disabled(2, false)
+				popup.set_item_disabled(4, false)

--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -99,7 +99,7 @@ func update_audio(channel_name:= "", path := "", settings_overrides := {}) -> vo
 	## TODO use .merged after dropping 4.2 support
 	var audio_settings: Dictionary = DialogicUtil.get_audio_channel_defaults().get(channel_name, {})
 	audio_settings.merge(
-		{"volume":0, "audio_bus":"", "fade_length":0.0, "loop":false, "sync_channel":""}
+		{"volume":0, "audio_bus":"", "fade_length":0.0, "loop":true, "sync_channel":""}
 	)
 	audio_settings.merge(settings_overrides, true)
 

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -155,7 +155,7 @@ func _execute() -> void:
 			return
 
 		if set_portrait:
-			dialogic.Portraits.change_character_portrait(character, portrait, fade_animation, fade_length)
+			await dialogic.Portraits.change_character_portrait(character, portrait, fade_animation, fade_length)
 
 		dialogic.Portraits.change_character_extradata(character, extra_data)
 


### PR DESCRIPTION
Fixes the following bugs:

- Audio loop default had incorrect value in the `update_audio` function causing looping to not work at all
- Portrait changing during Character Update event was not `await`ing `Portraits.change_character_portrait` which is now an asynchronous function due to threaded loading
- Play from here was incorrectly disabled in the visual editor on events with the `help_page_path == ""`