### PR TITLE
Add support for custom RichTextEffects & example fade effects

### DIFF
--- a/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd
+++ b/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd
@@ -23,8 +23,18 @@ var cache := []
 @export_group("Test", "test")
 @export_range(-0.1, 1.0, 0.1) var test_value := -0.1
 
+var was_skipped := false
+var was_reset := false
+
+
 func reset() -> void:
+	was_reset = true
+	was_skipped = false
 	cache.clear()
+
+
+func skip() -> void:
+	was_skipped = true
 
 
 func _process_custom_fx(char_fx: CharFXTransform) -> bool:
@@ -36,10 +46,19 @@ func _process_custom_fx(char_fx: CharFXTransform) -> bool:
 		if visible_characters == 0:
 			cache.clear()
 			return false
+		if was_reset:
+			if visible_characters != -1:
+				was_reset = false
+			else:
+				return false
 
-		if len(cache) < visible_characters:
+		if len(cache) < visible_characters or visible_characters == -1 or was_skipped:
 			if char_fx.range.x >= len(cache):
 				cache.append(char_fx.elapsed_time)
+
+		if was_skipped:
+			for i in range(len(cache)):
+				cache[i] = char_fx.elapsed_time-time
 
 		if len(cache) > char_fx.range.x:
 			char_age = char_fx.elapsed_time - cache[char_fx.range.x]

--- a/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd
+++ b/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd
@@ -1,0 +1,64 @@
+@tool
+class_name DialogicRichTextTransitionEffect
+extends RichTextEffect
+
+var visible_characters := -1
+
+@export var bbcode := "animate_in"
+var cache := []
+
+@export_range(0.0, 5.0, 0.01) var time := 0.2
+@export_group("Color", "color")
+@export var color_modulate: Gradient = null
+@export var color_replace: Gradient = null
+@export_group("Scale", "scale")
+@export var scale_enabled := false
+@export var scale_curve := Curve.new()
+@export var scale_pivot := Vector2()
+@export_group("Position", "position")
+@export var position_enabled := false
+@export var position_x_curve := Curve.new()
+@export var position_y_curve := Curve.new()
+
+@export_group("Test", "test")
+@export_range(-0.1, 1.0, 0.1) var test_value := -0.1
+
+func reset() -> void:
+	cache.clear()
+
+
+func _process_custom_fx(char_fx: CharFXTransform) -> bool:
+	var char_age :float = 0.0
+	if test_value >= 0:
+		char_age = test_value
+
+	else:
+		if visible_characters == 0:
+			cache.clear()
+			return false
+
+		if len(cache) < visible_characters:
+			if char_fx.range.x >= len(cache):
+				cache.append(char_fx.elapsed_time)
+
+		if len(cache) > char_fx.range.x:
+			char_age = char_fx.elapsed_time - cache[char_fx.range.x]
+
+	var text_server := TextServerManager.get_primary_interface()
+	var trans: float = clamp(char_age, 0.0, time)/time
+
+	if color_replace:
+		var c := color_replace.sample(trans)
+		c.a = 1
+		char_fx.color = char_fx.color.lerp(c, color_replace.sample(trans).a)
+	if color_modulate:
+		char_fx.color *= color_modulate.sample(trans)
+	var glyph_size := text_server.font_get_glyph_size(char_fx.font, Vector2i(16,1), char_fx.glyph_index)
+	if scale_enabled:
+		char_fx.transform = char_fx.transform.translated_local(scale_pivot*glyph_size*Vector2(1, -1)*(1-scale_curve.sample(trans)))
+		char_fx.transform = char_fx.transform.scaled_local(Vector2.ONE*scale_curve.sample(trans))
+
+	if position_enabled:
+		char_fx.transform = char_fx.transform.translated_local(Vector2(position_x_curve.sample(trans), position_y_curve.sample(trans))*glyph_size)
+
+	return true

--- a/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd.uid
+++ b/addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd.uid
@@ -1,0 +1,1 @@
+uid://wf7hpguw17ex

--- a/addons/dialogic/Example Assets/bbcode_transitions/fade_in.tres
+++ b/addons/dialogic/Example Assets/bbcode_transitions/fade_in.tres
@@ -1,0 +1,17 @@
+[gd_resource type="RichTextEffect" script_class="DialogicRichTextTransitionEffect" load_steps=3 format=3 uid="uid://qegqrr4g2riu"]
+
+[ext_resource type="Script" uid="uid://wf7hpguw17ex" path="res://addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd" id="1_5w3vn"]
+
+[sub_resource type="Gradient" id="Gradient_5w3vn"]
+colors = PackedColorArray(1, 1, 1, 0, 1, 1, 1, 1)
+
+[resource]
+script = ExtResource("1_5w3vn")
+bbcode = "fade_in"
+time = 0.2
+color_modulate = SubResource("Gradient_5w3vn")
+scale_enabled = false
+scale_pivot = Vector2(0, 0)
+position_enabled = false
+test_value = null
+metadata/_custom_type_script = "uid://wf7hpguw17ex"

--- a/addons/dialogic/Example Assets/bbcode_transitions/fade_in.tres
+++ b/addons/dialogic/Example Assets/bbcode_transitions/fade_in.tres
@@ -13,5 +13,5 @@ color_modulate = SubResource("Gradient_5w3vn")
 scale_enabled = false
 scale_pivot = Vector2(0, 0)
 position_enabled = false
-test_value = null
+test_value = -0.1
 metadata/_custom_type_script = "uid://wf7hpguw17ex"

--- a/addons/dialogic/Example Assets/bbcode_transitions/fade_scale_in.tres
+++ b/addons/dialogic/Example Assets/bbcode_transitions/fade_scale_in.tres
@@ -1,0 +1,24 @@
+[gd_resource type="RichTextEffect" script_class="DialogicRichTextTransitionEffect" load_steps=4 format=3 uid="uid://hx8qyt5ry3h0"]
+
+[ext_resource type="Script" uid="uid://wf7hpguw17ex" path="res://addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd" id="1_rsak6"]
+
+[sub_resource type="Gradient" id="Gradient_rsak6"]
+offsets = PackedFloat32Array(0, 0.6351706)
+colors = PackedColorArray(1, 1, 1, 0, 1, 1, 1, 1)
+
+[sub_resource type="Curve" id="Curve_oitc5"]
+_limits = [0.0, 2.0, 0.0, 1.0]
+_data = [Vector2(0, 2), 0.0, 0.0, 0, 0, Vector2(0.40294844, 1.0066038), -0.13865282, 0.0, 0, 0]
+point_count = 2
+
+[resource]
+script = ExtResource("1_rsak6")
+bbcode = "fade_scale_in"
+time = 0.30000000000000004
+color_modulate = SubResource("Gradient_rsak6")
+scale_enabled = true
+scale_curve = SubResource("Curve_oitc5")
+scale_pivot = Vector2(0.5, 0.5)
+position_enabled = false
+test_value = -0.1
+metadata/_custom_type_script = "uid://wf7hpguw17ex"

--- a/addons/dialogic/Example Assets/bbcode_transitions/fancy_in.tres
+++ b/addons/dialogic/Example Assets/bbcode_transitions/fancy_in.tres
@@ -1,0 +1,35 @@
+[gd_resource type="RichTextEffect" script_class="DialogicRichTextTransitionEffect" load_steps=6 format=3 uid="uid://c8b884puc720d"]
+
+[ext_resource type="Script" uid="uid://wf7hpguw17ex" path="res://addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd" id="1_n3lqs"]
+
+[sub_resource type="Gradient" id="Gradient_n3lqs"]
+offsets = PackedFloat32Array(0, 0.45292622)
+colors = PackedColorArray(1, 1, 1, 0, 1, 1, 1, 1)
+
+[sub_resource type="Gradient" id="Gradient_lhhwu"]
+interpolation_mode = 1
+offsets = PackedFloat32Array(0, 0.6666667, 0.86513996)
+colors = PackedColorArray(0.5208, 0.76631993, 0.93, 0, 0.5242275, 0.76595265, 0.93170327, 1, 0.5208, 0.76631993, 0.93, 0)
+
+[sub_resource type="Curve" id="Curve_lhhwu"]
+_data = [Vector2(0.002457004, 1), 0.0, -1.993977, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 2
+
+[sub_resource type="Curve" id="Curve_4i73d"]
+_limits = [0.0, 1.5, 0.0, 1.0]
+_data = [Vector2(0, 0.6627359), 0.0, 1.7969435, 0, 0, Vector2(0.4987715, 1.0308962), -1.6188686, -1.6188686, 0, 0, Vector2(0.66093373, 1), -0.34929827, 0.0, 0, 0]
+point_count = 3
+
+[resource]
+script = ExtResource("1_n3lqs")
+bbcode = "fancy_in"
+time = 0.4
+color_modulate = SubResource("Gradient_n3lqs")
+color_replace = SubResource("Gradient_lhhwu")
+scale_enabled = true
+scale_curve = SubResource("Curve_4i73d")
+scale_pivot = Vector2(0.5, 0)
+position_enabled = true
+position_x_curve = SubResource("Curve_lhhwu")
+test_value = -0.1
+metadata/_custom_type_script = "uid://wf7hpguw17ex"

--- a/addons/dialogic/Example Assets/bbcode_transitions/shaky_in.tres
+++ b/addons/dialogic/Example Assets/bbcode_transitions/shaky_in.tres
@@ -1,0 +1,35 @@
+[gd_resource type="RichTextEffect" script_class="DialogicRichTextTransitionEffect" load_steps=6 format=3 uid="uid://dnxkgwncm1pt5"]
+
+[ext_resource type="Script" uid="uid://wf7hpguw17ex" path="res://addons/dialogic/Example Assets/bbcode_transitions/bbcode_transition_effect.gd" id="1_ur6c5"]
+
+[sub_resource type="Gradient" id="Gradient_ur6c5"]
+offsets = PackedFloat32Array(0, 0.5089058)
+colors = PackedColorArray(1, 1, 1, 0, 1, 1, 1, 1)
+
+[sub_resource type="Curve" id="Curve_5qe3f"]
+_limits = [-0.5, 0.51556605, 0.0, 1.0]
+_data = [Vector2(0, 0.0235914), 0.0, 0.0, 0, 0, Vector2(0.019656021, -0.2441923), 0.0, 0.0, 0, 0, Vector2(0.046683047, 0.17305207), 0.0, 0.0, 0, 0, Vector2(0.1081081, -0.23173726), 0.0, 0.0, 0, 0, Vector2(0.16216215, 0.12323183), 0.0, 0.0, 0, 0, Vector2(0.2997543, -0.16946197), 0.0, 0.0, 0, 0, Vector2(0.38329238, 0.042274), 0.0, 0.0, 0, 0, Vector2(0.46928746, -0.107186675), 0.0, 0.0, 0, 0, Vector2(0.5135135, 0.054729044), 0.0, 0.0, 0, 0, Vector2(0.66339064, -0.07604903), 0.0, 0.0, 0, 0, Vector2(0.86240786, 0.054729044), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 12
+
+[sub_resource type="Curve" id="Curve_ur6c5"]
+_limits = [-0.5, 0.51556605, 0.0, 1.0]
+_data = [Vector2(0, 0.042274), 0.0, 0.0, 0, 0, Vector2(0.051597048, -0.13209677), 0.0, 0.0, 0, 0, Vector2(0.09336609, 0.21041724), 0.0, 0.0, 0, 0, Vector2(0.14742014, -0.25664735), 0.0, 0.0, 0, 0, Vector2(0.22850122, 0.098321736), 0.0, 0.0, 0, 0, Vector2(0.31203932, -0.107186675), 0.0, 0.0, 0, 0, Vector2(0.44717443, 0.054729044), 0.0, 0.0, 0, 0, Vector2(0.5995086, -0.08227658), 0.0, 0.0, 0, 0, Vector2(0.8132678, 0.042274), 0.0, 0.0, 0, 0, Vector2(1, 0), 0.0, 0.0, 0, 0]
+point_count = 10
+
+[sub_resource type="Curve" id="Curve_qelc7"]
+_data = [Vector2(0, 0.57688683), 0.0, 0.0, 0, 0, Vector2(0.14250615, 0.77311325), 0.0, 0.0, 0, 0, Vector2(0.2850123, 0.6443397), 0.0, 0.0, 0, 0, Vector2(0.41769046, 0.7976416), 0.0, 0.0, 0, 0, Vector2(0.5503686, 0.74245286), 0.0, 0.0, 0, 0, Vector2(0.6781328, 0.8712265), 0.0, 0.0, 0, 0, Vector2(0.79606885, 0.8528303), 0.0, 0.0, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
+point_count = 8
+
+[resource]
+script = ExtResource("1_ur6c5")
+bbcode = "shaky_in"
+time = 0.4
+color_modulate = SubResource("Gradient_ur6c5")
+scale_enabled = true
+scale_curve = SubResource("Curve_qelc7")
+scale_pivot = Vector2(0.5, 0.5)
+position_enabled = true
+position_x_curve = SubResource("Curve_5qe3f")
+position_y_curve = SubResource("Curve_ur6c5")
+test_value = -0.1
+metadata/_custom_type_script = "uid://wf7hpguw17ex"

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -133,7 +133,7 @@ func _execute() -> void:
 			var segment: String = dialogic.Text.parse_text(split_text[section_idx][0])
 			var is_append: bool = split_text[section_idx][1]
 
-			final_text = segment
+			final_text = ProjectSettings.get_setting("dialogic/text/dialog_text_prefix", "")+segment
 			dialogic.Text.about_to_show_text.emit({'text':final_text, 'character':character, 'portrait':portrait, 'append': is_append})
 
 			await dialogic.Text.update_textbox(final_text, false)

--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -125,16 +125,18 @@ func continue_reveal() -> void:
 
 		custom_fx_update()
 	else:
-		finish_text()
+		finish_text(true)
 		# if the text finished organically, add a small input block
 		# this prevents accidental skipping when you expected the text to be longer
 		DialogicUtil.autoload().Inputs.block_input(ProjectSettings.get_setting('dialogic/text/advance_delay', 0.1))
 
 
 ## Reveals the entire text instantly.
-func finish_text() -> void:
+func finish_text(is_organic := false) -> void:
 	visible_ratio = 1
 	custom_fx_update()
+	if not is_organic:
+		custom_fx_skip()
 	DialogicUtil.autoload().Text.execute_effects(-1, self, true)
 	revealing = false
 	DialogicUtil.autoload().current_state = DialogicGameHandler.States.IDLE
@@ -175,7 +177,14 @@ func custom_fx_update() -> void:
 		if "visible_characters" in effect:
 			effect.visible_characters = visible_characters
 
+
 func custom_fx_reset() -> void:
 	for effect in custom_effects:
 		if effect.has_method("reset"):
 			effect.reset()
+
+
+func custom_fx_skip() -> void:
+	for effect in custom_effects:
+		if effect.has_method("skip"):
+			effect.skip()

--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -52,6 +52,12 @@ func _ready() -> void:
 		textbox_root.hide()
 	text = ""
 
+	var custom_bbcode_effects: Array = ProjectSettings.get_setting("dialogic/text/custom_bbcode_effects", "").split(",")
+	for i in custom_bbcode_effects:
+		var x : Resource = load(i.strip_edges())
+		if x is RichTextEffect:
+			custom_effects.append(x)
+
 
 # this is called by the DialogicGameHandler to set text
 
@@ -59,6 +65,8 @@ func reveal_text(_text: String, keep_previous:=false) -> void:
 	if !enabled:
 		return
 	show()
+
+	custom_fx_reset()
 
 	if !keep_previous:
 		text = _text
@@ -73,6 +81,7 @@ func reveal_text(_text: String, keep_previous:=false) -> void:
 	else:
 		base_visible_characters = len(text)
 		visible_characters = len(get_parsed_text())
+		custom_fx_update()
 		text = text + _text
 
 		# If Auto-Skip is enabled and we append the text (keep_previous),
@@ -113,6 +122,8 @@ func continue_reveal() -> void:
 
 		if visible_characters > -1 and visible_characters <= len(get_parsed_text()):
 			continued_revealing_text.emit(get_parsed_text()[visible_characters-1])
+
+		custom_fx_update()
 	else:
 		finish_text()
 		# if the text finished organically, add a small input block
@@ -123,6 +134,7 @@ func continue_reveal() -> void:
 ## Reveals the entire text instantly.
 func finish_text() -> void:
 	visible_ratio = 1
+	custom_fx_update()
 	DialogicUtil.autoload().Text.execute_effects(-1, self, true)
 	revealing = false
 	DialogicUtil.autoload().current_state = DialogicGameHandler.States.IDLE
@@ -156,3 +168,14 @@ func _on_meta_clicked(_meta:Variant) -> void:
 ## Handle mouse input
 func on_gui_input(event:InputEvent) -> void:
 	DialogicUtil.autoload().Inputs.handle_node_gui_input(event)
+
+
+func custom_fx_update() -> void:
+	for effect in custom_effects:
+		if "visible_characters" in effect:
+			effect.visible_characters = visible_characters
+
+func custom_fx_reset() -> void:
+	for effect in custom_effects:
+		if effect.has_method("reset"):
+			effect.reset()

--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -12,6 +12,8 @@ const _SETTING_TEXT_REVEAL_SKIPPABLE_DELAY 	:= 'dialogic/text/text_reveal_skip_d
 const _SETTING_TEXT_ADVANCE_DELAY 			:= 'dialogic/text/advance_delay'
 
 const _SETTING_AUTOCOLOR_NAMES 				:= 'dialogic/text/autocolor_names'
+const _SETTING_TEXT_PREFIX 					:= 'dialogic/text/dialog_text_prefix'
+const _SETTING_CUSTOM_BBCODE_EFFECTS 		:= 'dialogic/text/custom_bbcode_effects'
 const _SETTING_SPLIT_AT_NEW_LINES 			:= 'dialogic/text/split_at_new_lines'
 const _SETTING_SPLIT_AT_NEW_LINES_AS 		:= 'dialogic/text/split_at_new_lines_as'
 
@@ -44,6 +46,8 @@ func _ready() -> void:
 	%AdvanceDelay.value_changed.connect(_on_float_set.bind(_SETTING_TEXT_ADVANCE_DELAY))
 
 	%AutocolorNames.toggled.connect(_on_bool_set.bind(_SETTING_AUTOCOLOR_NAMES))
+	%TextPrefix.text_changed.connect(_on_string_set.bind(_SETTING_TEXT_PREFIX))
+	%CustomBBCodeEffects.text_changed.connect(_on_string_set.bind(_SETTING_CUSTOM_BBCODE_EFFECTS))
 
 	%NewEvents.toggled.connect(_on_bool_set.bind(_SETTING_SPLIT_AT_NEW_LINES))
 
@@ -69,6 +73,8 @@ func _refresh() -> void:
 	%AdvanceDelay.value = ProjectSettings.get_setting(_SETTING_TEXT_ADVANCE_DELAY, 0.1)
 
 	%AutocolorNames.button_pressed = ProjectSettings.get_setting(_SETTING_AUTOCOLOR_NAMES, false)
+	%TextPrefix.text = ProjectSettings.get_setting(_SETTING_TEXT_PREFIX, "")
+	%CustomBBCodeEffects.text = ProjectSettings.get_setting(_SETTING_CUSTOM_BBCODE_EFFECTS, "")
 
 	%NewEvents.button_pressed = ProjectSettings.get_setting(_SETTING_SPLIT_AT_NEW_LINES, false)
 	%NewEventOption.select(ProjectSettings.get_setting(_SETTING_SPLIT_AT_NEW_LINES_AS, 0))
@@ -115,14 +121,18 @@ func _on_float_set(value:float, setting:String) -> void:
 	ProjectSettings.save()
 
 
+func _on_string_set(value:String, setting:String) -> void:
+	ProjectSettings.set_setting(setting, value)
+	ProjectSettings.save()
+
 #region BEHAVIOUR
 ################################################################################
 
-func _on_InputAction_value_changed(property_name:String, value:String) -> void:
+func _on_InputAction_value_changed(_property_name:String, value:String) -> void:
 	ProjectSettings.set_setting(_SETTING_INPUT_ACTION, value)
 	ProjectSettings.save()
 
-func suggest_actions(search:String) -> Dictionary:
+func suggest_actions(_search:String) -> Dictionary:
 	var suggs := {}
 	for prop in ProjectSettings.get_property_list():
 		if prop.name.begins_with('input/') and not prop.name.begins_with('input/ui_') :

--- a/addons/dialogic/Modules/Text/settings_text.tscn
+++ b/addons/dialogic/Modules/Text/settings_text.tscn
@@ -1,26 +1,17 @@
-[gd_scene load_steps=6 format=3 uid="uid://cf3qks3v18xmr"]
+[gd_scene load_steps=5 format=3 uid="uid://cf3qks3v18xmr"]
 
 [ext_resource type="Script" uid="uid://cdxck874xobqh" path="res://addons/dialogic/Modules/Text/settings_text.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/field_options_dynamic.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="3_s7xhj"]
 
-[sub_resource type="Image" id="Image_15d2e"]
-data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
-
-[sub_resource type="ImageTexture" id="ImageTexture_3xcp4"]
-image = SubResource("Image_15d2e")
+[sub_resource type="SVGTexture" id="SVGTexture_15d2e"]
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#ff5d5d\" d=\"M2 1v8.586l1.293-1.293a1 1 0 0 1 1.414 0L7 10.587l2.293-2.293a1 1 0 0 1 1.414 0L13 10.586l1-1V6H9V1H2zm8 0v4h4zm-6 9.414-2 2V15h12v-2.586l-.293.293a1 1 0 0 1-1.414 0L10 10.414l-2.293 2.293a1 1 0 0 1-1.414 0L4 10.414z\"/></svg>
+"
 
 [node name="DialogText" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_bottom = -156.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("2")
@@ -48,7 +39,7 @@ text = "Default letter speed"
 [node name="HintTooltip2" parent="VBoxContainer/VBox/DefaultSpeedLabel" instance=ExtResource("3_s7xhj")]
 layout_mode = 2
 tooltip_text = "The speed in seconds per character. A speed of 0 will reveal the full text instantly (still taking pauses into consideration)."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "The speed in seconds per character. A speed of 0 will reveal the full text instantly (still taking pauses into consideration)."
 
 [node name="DefaultSpeed" type="SpinBox" parent="VBoxContainer/VBox"]
@@ -67,7 +58,7 @@ text = "Input action"
 layout_mode = 2
 tooltip_text = "The action that skips text and generally advances to the next event.
 You can modify actions in the Project Settings > Input Map."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "The action that skips text and generally advances to the next event.
 You can modify actions in the Project Settings > Input Map."
 
@@ -87,7 +78,7 @@ text = "Text Reveal Skippable"
 layout_mode = 2
 tooltip_text = "If enabled the revealing of text can be skipped with the input action.
 If disabled you can only advance to the next event when revealing has finnished."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "If enabled the revealing of text can be skipped with the input action.
 If disabled you can only advance to the next event when revealing has finnished."
 
@@ -110,7 +101,7 @@ layout_mode = 2
 tooltip_text = "Delay before you can skip. 
 
 Use this to prevent users from skipping through your timeline to quickly."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "Delay before you can skip. 
 
 Use this to prevent users from skipping through your timeline too quickly."
@@ -134,7 +125,7 @@ layout_mode = 2
 tooltip_text = "Delay before you can advance (if the text finishes revealing on its own). 
 
 This is used to prevent players from advancing when they actually wanted to skip the revealing, but did so very shortly after the text was already fully revealed."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "Delay before you can advance (only if the text finishes revealing on its own). 
 
 This is used to prevent players from advancing when they actually wanted to skip the revealing, but did so very shortly after the text was already fully revealed."
@@ -156,10 +147,44 @@ text = "Autocolor names"
 [node name="HintTooltip5" parent="VBoxContainer/VBox/ColorNames" instance=ExtResource("3_s7xhj")]
 layout_mode = 2
 tooltip_text = "If enabled character names will be colored in the characters color in text events."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "If enabled character names will be colored in the characters color in text events."
 
 [node name="AutocolorNames" type="CheckBox" parent="VBoxContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="TextPrefixLabel" type="HBoxContainer" parent="VBoxContainer/VBox"]
+layout_mode = 2
+
+[node name="Label4" type="Label" parent="VBoxContainer/VBox/TextPrefixLabel"]
+layout_mode = 2
+text = "Text prefix"
+
+[node name="HintTooltip5" parent="VBoxContainer/VBox/TextPrefixLabel" instance=ExtResource("3_s7xhj")]
+layout_mode = 2
+tooltip_text = "If enabled character names will be colored in the characters color in text events."
+texture = null
+hint_text = "This is put before the text. Can be used to apply bbcode effects to all texts."
+
+[node name="TextPrefix" type="LineEdit" parent="VBoxContainer/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="BBCodeEffectLabel" type="HBoxContainer" parent="VBoxContainer/VBox"]
+layout_mode = 2
+
+[node name="Label4" type="Label" parent="VBoxContainer/VBox/BBCodeEffectLabel"]
+layout_mode = 2
+text = "Custom BBCode Effects"
+
+[node name="HintTooltip5" parent="VBoxContainer/VBox/BBCodeEffectLabel" instance=ExtResource("3_s7xhj")]
+layout_mode = 2
+tooltip_text = "This is put before the text. Can be used to apply bbcode effects to all texts."
+texture = SubResource("SVGTexture_15d2e")
+hint_text = "Supply a list of bbcode effect resources (paths or uids) separated by comma."
+
+[node name="CustomBBCodeEffects" type="LineEdit" parent="VBoxContainer/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 
@@ -174,7 +199,7 @@ text = "New lines as new events"
 layout_mode = 2
 tooltip_text = "If enabled dialogic, new lines will be treated as [n] effects,
 seemingly waiting for input before starting a new text."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "If enabled dialogic, new lines will be treated as [n] effects,
 seemingly waiting for input before starting a new text."
 
@@ -188,9 +213,9 @@ layout_mode = 2
 [node name="NewEventOption" type="OptionButton" parent="VBoxContainer/VBox/HBoxContainer4"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 2
 selected = 0
 fit_to_longest_item = false
+item_count = 2
 popup/item_0/text = "As new event"
 popup/item_0/id = 0
 popup/item_1/text = "Appended"
@@ -219,7 +244,7 @@ These add up, so if any of them is true, Auto-Advance will happen.
 Unless manual advancement is disabled, the Auto-Advance time can always be skipped by the player.
 
 The Auto-Advance will wait for Voice audio to finish playing. This behaviour can be disabled via code. "
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "Autoadvance is the concept of automatically progressing to the next event upon completing text display, usually after a certain delay.
 
 You can enabled Auto-Advance from code using either:
@@ -245,7 +270,7 @@ text = "Base Delay"
 [node name="HintTooltip" parent="VBoxContainer/AutoadvanceSettings/HBox_BaseDelay2" instance=ExtResource("3_s7xhj")]
 layout_mode = 2
 tooltip_text = "This is the base delay for autoadvancment."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "This is the base delay for autoadvancment."
 
 [node name="FixedDelay" type="SpinBox" parent="VBoxContainer/AutoadvanceSettings"]
@@ -268,7 +293,7 @@ layout_mode = 2
 tooltip_text = "An additional delay per character or word can be added.
 
 Note: When changing values via code, you can actually use both modes simultaniously."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "An additional delay per character or word can be added.
 
 Note: When changing values via code, you can actually use both modes simultaniously."
@@ -279,9 +304,9 @@ layout_mode = 2
 [node name="AdditionalDelayMode" type="OptionButton" parent="VBoxContainer/AutoadvanceSettings/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 3
 selected = 0
 fit_to_longest_item = false
+item_count = 3
 popup/item_0/text = "None"
 popup/item_0/id = 0
 popup/item_1/text = "Per Word"
@@ -308,7 +333,7 @@ tooltip_text = "An ignored character will add no delay, this is useful to exclud
 
 If disabled, the general line of text length will be used, stripping the BBCode tags first.
 If enabled, the text will be scanned and the matching characters will be skipped."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "An ignored character will add no delay, this is useful to exclude interpunction and whitespaces.
 
 If disabled, the general line of text length will be used, stripping the BBCode tags first.
@@ -336,7 +361,7 @@ layout_mode = 2
 tooltip_text = "While you would usually enable Auto-Advance via code,
 if this is true it will be initially enabled.
 This kind of Auto-Advance (system) only stops when disabled via code. "
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "While you would usually enable Auto-Advance via code,
 if this is true it will be initially enabled.
 This kind of Auto-Advance (system) only stops when disabled via code. "
@@ -366,7 +391,7 @@ Dialogic.Inputs.auto_skip.enabled = true
 By default, Auto-Skip will cancel on user input.
 You can disable this by calling:
 Dialogic.Inputs.auto_skip.disable_on_user_input = false"
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "Auto-Skip is the concept of automatically skipping Timeline Events to the next unread Text Event or Event demanding user inputs (e.g. Choice, Wait Input, and Text Input).
 
 You can enable Auto-Skip from code via:
@@ -393,7 +418,7 @@ tooltip_text = "The time until Auto-Skip will execute the next event.
 
 If this is set to 0.1s, each event should finish within that time.
 Custom events must respect this time, built-in events already handle Auto-Skip."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "The time until Auto-Skip will execute the next event.
 
 If this is set to 0.1s, each event should finish within that time.
@@ -424,7 +449,7 @@ tooltip_text = "Adds pauses after certain letters.
 
 Each set can contain multiple letters that will (individually)
 have a pause of the given length added after them."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "Adds pauses after certain letters.
 
 Each set can contain multiple letters that will (individually)
@@ -452,7 +477,7 @@ text = "Absolute auto-pause times"
 [node name="HintTooltip7" parent="VBoxContainer/HBoxContainer3" instance=ExtResource("3_s7xhj")]
 layout_mode = 2
 tooltip_text = "If not enabled autopauses will be multiplied by the speed and user speed. When enabled those will be ignored."
-texture = SubResource("ImageTexture_3xcp4")
+texture = null
 hint_text = "If not enabled autopauses will be multiplied by the speed and user speed. When enabled those will be ignored."
 
 [node name="AutoPausesAbsolute" type="CheckBox" parent="VBoxContainer/HBoxContainer3"]

--- a/addons/dialogic/Modules/Text/settings_text.tscn
+++ b/addons/dialogic/Modules/Text/settings_text.tscn
@@ -1,12 +1,8 @@
-[gd_scene load_steps=5 format=3 uid="uid://cf3qks3v18xmr"]
+[gd_scene load_steps=4 format=3 uid="uid://cf3qks3v18xmr"]
 
 [ext_resource type="Script" uid="uid://cdxck874xobqh" path="res://addons/dialogic/Modules/Text/settings_text.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/field_options_dynamic.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="3_s7xhj"]
-
-[sub_resource type="SVGTexture" id="SVGTexture_15d2e"]
-_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#ff5d5d\" d=\"M2 1v8.586l1.293-1.293a1 1 0 0 1 1.414 0L7 10.587l2.293-2.293a1 1 0 0 1 1.414 0L13 10.586l1-1V6H9V1H2zm8 0v4h4zm-6 9.414-2 2V15h12v-2.586l-.293.293a1 1 0 0 1-1.414 0L10 10.414l-2.293 2.293a1 1 0 0 1-1.414 0L4 10.414z\"/></svg>
-"
 
 [node name="DialogText" type="VBoxContainer"]
 anchors_preset = 15
@@ -181,7 +177,7 @@ text = "Custom BBCode Effects"
 [node name="HintTooltip5" parent="VBoxContainer/VBox/BBCodeEffectLabel" instance=ExtResource("3_s7xhj")]
 layout_mode = 2
 tooltip_text = "This is put before the text. Can be used to apply bbcode effects to all texts."
-texture = SubResource("SVGTexture_15d2e")
+texture = null
 hint_text = "Supply a list of bbcode effect resources (paths or uids) separated by comma."
 
 [node name="CustomBBCodeEffects" type="LineEdit" parent="VBoxContainer/VBox"]

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -381,8 +381,12 @@ func collect_text_effects() -> void:
 ## Use get_parsed_text_effects() after calling this to get all effect information
 func parse_text_effects(text:String) -> String:
 	parsed_text_effect_info.clear()
-	var rtl := RichTextLabel.new()
-	rtl.bbcode_enabled = true
+	var rtl: RichTextLabel = null
+	if get_tree().get_first_node_in_group("dialogic_dialog_text"):
+		rtl = get_tree().get_first_node_in_group("dialogic_dialog_text").duplicate()
+	else:
+		rtl = RichTextLabel.new()
+		rtl.bbcode_enabled = true
 	var position_correction := 0
 	var bbcode_correction := 0
 	for effect_match in text_effects_regex.search_all(text):


### PR DESCRIPTION
Adds two new settings:
- Text prefix allows to put any prefix on all text events, I added this so it's easy to add a fade RichTextEffect to all events
- Custom BBCode Effects (a comma-separated list of uids or paths to RichTextEffect resources)

![grafik](https://github.com/user-attachments/assets/fc734548-4334-4162-9ee3-94690d8bde8d)

This also adds a series of rich text fade effects, all extending the DialogicRichTextFadeEffect. This effect makes it very easy to customize the fade-in. 

https://github.com/user-attachments/assets/0fb1e0fe-64d4-4f9a-a4b7-da5b9feb2c22

