### PR TITLE
Fix text_bubble run _process() before starting dialog

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
@@ -36,6 +36,7 @@ func _ready() -> void:
 
 
 func reset() -> void:
+	set_process(false)
 	scale = Vector2.ZERO
 	modulate.a = 0.0
 


### PR DESCRIPTION
Fix:  #2620 