### PR TITLE
Fix bubble's initial position is too far away from speaker

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
@@ -9,7 +9,12 @@ extends Control
 @onready var name_label_box: PanelContainer = (%NameLabelPanel as PanelContainer)
 @onready var name_label_holder: HBoxContainer = $DialogText/NameLabelPositioner
 
-var node_to_point_at: Node = null
+var node_to_point_at: Node = null:
+	set(val):
+		node_to_point_at = val
+		base_position = get_speaker_canvas_position() + base_direction * safe_zone
+		position = base_position
+		
 var current_character: DialogicCharacter = null
 
 var max_width := 300


### PR DESCRIPTION
Fix: #2622 


before:

https://github.com/user-attachments/assets/8030ae40-d2a5-4697-893f-8c1c714af11c


after:

https://github.com/user-attachments/assets/472c031e-2045-4dce-839d-3d531f163784

