### PR TITLE
Fix bubble's height not support [img]'s height

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.gd
@@ -112,7 +112,7 @@ func close() -> void:
 
 
 func _on_dialog_text_started_revealing_text() -> void:
-	_resize_bubble(get_base_content_size(), true)
+	_resize_bubble(await get_base_content_size(), true)
 
 
 func _resize_bubble(content_size:Vector2, popup:=false) -> void:
@@ -145,7 +145,7 @@ func _on_question_shown(info:Dictionary) -> void:
 
 	await get_tree().process_frame
 
-	var content_size := get_base_content_size()
+	var content_size := await get_base_content_size()
 	content_size.y += choice_container.size.y
 	content_size.x = max(content_size.x, choice_container.size.x)
 	_resize_bubble(content_size)
@@ -153,12 +153,23 @@ func _on_question_shown(info:Dictionary) -> void:
 
 func get_base_content_size() -> Vector2:
 	var font: Font = text.get_theme_font(&"normal_font")
-	return font.get_multiline_string_size(
+	var text_width = font.get_multiline_string_size(
 		text.get_parsed_text(),
 		HORIZONTAL_ALIGNMENT_LEFT,
 		max_width,
 		text.get_theme_font_size(&"normal_font_size")
-		)
+		).x
+		
+	# Let text use content's width, and let text auto shrink height to its content.
+	text.size = Vector2(text_width, 0)
+	await get_tree().process_frame
+	
+	# Don't know why text.size.y != content's height,
+	# so we re-set text.size.y to 0 to let text shrink to its content again.
+	# Finally works this time.
+	text.size.y = 0
+	await get_tree().process_frame
+	return text.size
 
 
 func add_choice_container(node:Container, alignment:=FlowContainer.ALIGNMENT_BEGIN, choices_button_path:="", maximum_choices:=5) -> void:

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_Textbubble/text_bubble.tscn
@@ -79,6 +79,7 @@ offset_bottom = 12.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_colors/default_color = Color(0, 0, 0, 1)
+fit_content = true
 scroll_active = false
 visible_characters_behavior = 1
 script = ExtResource("3_syv35")


### PR DESCRIPTION
Fix: #2635 

before:
<img height="200" alt="屏幕截图 2025-07-16 224342" src="https://github.com/user-attachments/assets/1533b519-f4c2-423b-a7b8-58ac55b78b48" />

after:
<img height="200" alt="屏幕截图 2025-07-16 224820" src="https://github.com/user-attachments/assets/8fc9aa09-1714-4aab-82bf-7c666f01bbc4" />
