### PR TITLE
DialogTextNode: add a resource file checker before loading; there was…

### DIFF
--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -54,9 +54,10 @@ func _ready() -> void:
 
 	var custom_bbcode_effects: Array = ProjectSettings.get_setting("dialogic/text/custom_bbcode_effects", "").split(",")
 	for i in custom_bbcode_effects:
-		var x : Resource = load(i.strip_edges())
-		if x is RichTextEffect:
-			custom_effects.append(x)
+		if ResourceLoader.exists(i.strip_edges()):
+			var x : Resource = load(i.strip_edges())
+			if x is RichTextEffect:
+				custom_effects.append(x)
 
 
 # this is called by the DialogicGameHandler to set text


### PR DESCRIPTION
DialogTextNode: 
Add a resource file checker before loading. 
There was an error when `custom_bbcode_effects`(in `Settings/Text/Custom BBCode Effects`) is empty.

<img width="830" height="681" alt="image" src="https://github.com/user-attachments/assets/aee5df67-3580-463b-b532-9eef62bb8434" />
<img width="749" height="273" alt="image" src="https://github.com/user-attachments/assets/d71bddba-fa6c-44ee-8609-e1ddbf7dc575" />
