### PR TITLE
Add option to update CSV files without erasing content for default locale, original content is replaced instead (#2644)

### DIFF
--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/csv_file.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/csv_file.gd
@@ -89,11 +89,15 @@ func _read_file_into_lines() -> void:
 ##
 ## If this is the character name CSV file, use this method to
 ## take previously collected characters from other [class DialogicCsvFile]s.
-func collect_lines_from_characters(characters: Dictionary) -> void:
+func collect_lines_from_characters(characters: Dictionary, update_text: bool = false, text_dict: Dictionary = {}) -> void:
 	for character: DialogicCharacter in characters.values():
 		# Add row for display names.
 		var name_property := DialogicCharacter.TranslatedProperties.NAME
 		var display_name_key: String = character.get_property_translation_key(name_property)
+		
+		if update_text and display_name_key in text_dict and text_dict[display_name_key]:
+			character.display_name = text_dict[display_name_key]
+		
 		var line_value: String = character.display_name
 		var array_line := PackedStringArray([display_name_key, line_value])
 		lines.append(array_line)
@@ -104,6 +108,11 @@ func collect_lines_from_characters(characters: Dictionary) -> void:
 			var nick_name_property := DialogicCharacter.TranslatedProperties.NICKNAMES
 			var nickname_string: String = ",".join(nicknames)
 			var nickname_name_line_key: String = character.get_property_translation_key(nick_name_property)
+			
+			if update_text and nickname_name_line_key in text_dict and text_dict[nickname_name_line_key]:
+				nickname_string = text_dict[nickname_name_line_key]
+				character.nicknames = nickname_string.split(",")
+			
 			var nick_array_line := PackedStringArray([nickname_name_line_key, nickname_string])
 			lines.append(nick_array_line)
 
@@ -226,10 +235,12 @@ func _sort_glossary_entry_property_keys(property_key_a: String, property_key_b: 
 
 	return value_a < value_b
 
+# We use a space after the comma to make it easier to read.
+var glossary_item_array_separator = ", "
 
 ## Collects properties from glossary entries from the given [param glossary] and
 ## adds them to the [member lines].
-func collect_lines_from_glossary(glossary: DialogicGlossary) -> void:
+func collect_lines_from_glossary(glossary: DialogicGlossary, update_text: bool = false, text_dict: Dictionary = {}) -> void:
 
 	for glossary_value: Variant in glossary.entries.values():
 
@@ -257,8 +268,7 @@ func collect_lines_from_glossary(glossary: DialogicGlossary) -> void:
 
 			if item_value is Array:
 				var item_array := item_value as Array
-				# We use a space after the comma to make it easier to read.
-				item_value_str = " ,".join(item_array)
+				item_value_str = glossary_item_array_separator.join(item_array)
 
 			elif not item_value is String or item_value.is_empty():
 				continue
@@ -267,7 +277,15 @@ func collect_lines_from_glossary(glossary: DialogicGlossary) -> void:
 				item_value_str = item_value
 
 			var glossary_csv_key := glossary._get_glossary_translation_key(entry_translation_id, entry_key)
-
+			
+			if update_text and glossary_csv_key in text_dict and text_dict[glossary_csv_key]:
+				item_value_str = glossary_entry[entry_key]
+				
+				if item_value is Array:
+					glossary_entry[entry_key] = text_dict[glossary_csv_key].split(glossary_item_array_separator)
+				else:
+					glossary_entry[entry_key] = text_dict[glossary_csv_key]
+			
 			if (entry_key == DialogicGlossary.NAME_PROPERTY
 			or entry_key == DialogicGlossary.ALTERNATIVE_PROPERTY):
 				glossary.entries[glossary_csv_key] = entry_name_property
@@ -284,7 +302,7 @@ func collect_lines_from_glossary(glossary: DialogicGlossary) -> void:
 
 ## Collects translatable events from the given [param timeline] and adds
 ## them to the [member lines].
-func collect_lines_from_timeline(timeline: DialogicTimeline) -> void:
+func collect_lines_from_timeline(timeline: DialogicTimeline, update_text: bool = false, text_dict: Dictionary = {}) -> void:
 	for event: DialogicEvent in timeline.events:
 
 		if event.can_be_translated():
@@ -292,12 +310,19 @@ func collect_lines_from_timeline(timeline: DialogicTimeline) -> void:
 			if event._translation_id.is_empty():
 				event.add_translation_id()
 				event.update_text_version()
+					
 
 			var properties: Array = event._get_translatable_properties()
 
 			for property: String in properties:
 				var line_key: String = event.get_property_translation_key(property)
+				
+				if update_text and line_key in text_dict and text_dict[line_key]:
+					event._set_property_original_translation(property, text_dict[line_key])
+					event.update_text_version()
+				
 				var line_value: String = event._get_property_original_translation(property)
+				
 				var array_line := PackedStringArray([line_key, line_value])
 				lines.append(array_line)
 

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.gd
@@ -415,6 +415,10 @@ func update_csv_files(update_text: bool = false, text_dict: Dictionary = {}) -> 
 
 	var current_timeline := _close_active_timeline()
 
+	var current_character : Resource = null
+	if update_text:
+		current_character = _close_active_character()
+	
 	var csv_per_project: DialogicCsvFile = null
 	var per_project_csv_path := translation_folder_path.path_join(DEFAULT_TIMELINE_CSV_NAME)
 
@@ -493,6 +497,9 @@ func update_csv_files(update_text: bool = false, text_dict: Dictionary = {}) -> 
 		csv_per_project.update_csv_file_on_disk()
 
 	_silently_open_timeline(current_timeline)
+	
+	if update_text:
+		_silently_open_character(current_character)
 
 	# Trigger reimport.
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_resource_filesystem().scan_sources()
@@ -786,6 +793,15 @@ func _close_active_timeline() -> Resource:
 
 	return current_timeline
 
+func _close_active_character() -> Resource:
+	var character_node: DialogicEditor = settings_editor.editors_manager.editors['CharacterEditor']['node']
+	# We will close this character to ensure it will properly update.
+	# By saving this reference, we can open it again.
+	var current_character := character_node.current_resource
+	# Clean the current editor, this will also close the character.
+	settings_editor.editors_manager.clear_editor(character_node)
+
+	return current_character
 
 ## Opens the timeline resource into the Dialogic Editor.
 ## If the timeline is null, does nothing.
@@ -793,6 +809,11 @@ func _silently_open_timeline(timeline_to_open: Resource) -> void:
 	if timeline_to_open != null:
 		settings_editor.editors_manager.edit_resource(timeline_to_open, true, true)
 
+## Opens the character resource into the Dialogic Editor.
+## If the character is null, does nothing.
+func _silently_open_character(character_to_open: Resource) -> void:
+	if character_to_open != null:
+		settings_editor.editors_manager.edit_resource(character_to_open, true, true)
 
 ## Checks [param locale] for unique locales that have not been added
 ## to the [_unique_locales] array yet.

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.tscn
@@ -119,6 +119,7 @@ hint_text = "The locale of the language your timelines are written in."
 [node name="OrigLocale" parent="TranslationSettings/VBoxContainer/Grid" instance=ExtResource("3_dq4j2")]
 unique_name_in_owner = true
 layout_mode = 2
+mode = 3
 
 [node name="TransFile" type="HBoxContainer" parent="TranslationSettings/VBoxContainer/Grid"]
 layout_mode = 2

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.tscn
@@ -7,14 +7,14 @@
 
 [sub_resource type="Image" id="Image_4jaem"]
 data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"data": PackedByteArray(255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 92, 92, 127, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 90, 90, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 42, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 93, 93, 41, 255, 90, 90, 0, 255, 94, 94, 0, 255, 91, 91, 42, 255, 93, 93, 233, 255, 92, 92, 232, 255, 92, 92, 0, 255, 92, 92, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 93, 93, 0, 255, 91, 91, 45, 255, 93, 93, 44, 255, 91, 91, 0, 255, 91, 91, 42, 255, 91, 91, 42, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 45, 255, 92, 92, 235, 255, 92, 92, 234, 255, 89, 89, 43, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 91, 91, 0, 255, 92, 92, 0, 255, 92, 92, 0, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 91, 91, 59, 255, 92, 92, 61, 255, 92, 92, 0, 255, 92, 92, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0, 255, 93, 93, 0),
 "format": "RGBA8",
 "height": 16,
 "mipmaps": false,
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_xbph7"]
+[sub_resource type="ImageTexture" id="ImageTexture_ih5gb"]
 image = SubResource("Image_4jaem")
 
 [node name="Translations" type="VBoxContainer"]
@@ -73,7 +73,7 @@ text = "Testing locale"
 layout_mode = 2
 tooltip_text = "Change this locale to test your game in a different language (only in-editor).
 Equivalent of the testing local project setting. "
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Change this locale to test your game in a different language (only in-editor).
 Equivalent of the testing local project setting. 
 
@@ -113,7 +113,7 @@ text = "Default locale"
 [node name="HintTooltip" parent="TranslationSettings/VBoxContainer/Grid/VBox" instance=ExtResource("2_k2lou")]
 layout_mode = 2
 tooltip_text = "The locale of the language your timelines are written in."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "The locale of the language your timelines are written in."
 
 [node name="OrigLocale" parent="TranslationSettings/VBoxContainer/Grid" instance=ExtResource("3_dq4j2")]
@@ -131,7 +131,7 @@ text = "Translation folder"
 layout_mode = 2
 tooltip_text = "Choose a folder to let Dialogic save CSV files in.
 Also used when saving \"Inside Translation Folder\""
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Choose a folder to let Dialogic save CSV files in.
 Also used when saving \"Inside Translation Folder\""
 
@@ -159,7 +159,7 @@ For example, 10 timelines will be combined into 1 CSV file.
 For example, 10 timelines will result in 10 CSV files.
 
 The \"Per File\" option utilises \"Output location\", in contrast, the \"Per Type\" will always use the Translation folder."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Decides how many CSV files will be created.
 
 • \"Per Type\": Uses one CSV file for each type of resource: Timelines, characters, and glossaries.
@@ -173,8 +173,8 @@ The \"Per File\" option utilises \"Output location\", in contrast, the \"Per Typ
 [node name="TransMode" type="OptionButton" parent="TranslationSettings/VBoxContainer/Grid"]
 unique_name_in_owner = true
 layout_mode = 2
-item_count = 2
 selected = 0
+item_count = 2
 popup/item_0/text = "Per Type"
 popup/item_0/id = 0
 popup/item_1/text = "Per File"
@@ -197,7 +197,7 @@ tooltip_text = "Decides where to save the generated CSV files.
 
 This button requires the \"Per File\" Output mode.
 A resource type can be: Timelines, characters, and glossaries."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Decides where to save the generated CSV files.
 
 • \"Inside Translation Folder\": Uses the \"Translation folder\".
@@ -211,8 +211,8 @@ A resource type can be: Timelines, characters, and glossaries."
 unique_name_in_owner = true
 layout_mode = 2
 disabled = true
-item_count = 2
 selected = 0
+item_count = 2
 popup/item_0/text = "Inside Translation Folder"
 popup/item_0/id = 0
 popup/item_1/text = "Next to File"
@@ -234,7 +234,7 @@ layout_mode = 2
 tooltip_text = "Adds an empty line into per-project CSVs to differentiate between sections.
 
 For example, when a new glossary item or timeline starts, an empty line will be added."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Adds an empty line into per-project CSVs to differentiate between sections.
 
 For example, when a new glossary item or timeline starts, an empty line will be added."
@@ -267,7 +267,7 @@ unique_name_in_owner = true
 layout_mode = 2
 disabled = true
 text = "Update CSV files"
-icon = SubResource("ImageTexture_xbph7")
+icon = SubResource("ImageTexture_ih5gb")
 
 [node name="HintTooltip5" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
@@ -276,8 +276,31 @@ tooltip_text = "This button will scan all timelines and generate or update their
 A Dialogic CSV file will be prefixed with \"dialogic_\".
 
 This action will be disabled if the \"Translation folder\" is missing or has an invalid path."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "This button will scan all timelines and generate or update their CSV files.
+
+This will erase any change made to default locale strings in the CSV files.
+
+A Dialogic CSV file will be prefixed with \"dialogic_\".
+
+This action will be disabled if the \"Translation folder\" is missing or has an invalid path."
+
+[node name="UseTextFromCsvFiles" type="Button" parent="TranslationSettings/VBoxContainer2/Actions"]
+unique_name_in_owner = true
+layout_mode = 2
+disabled = true
+text = "Use text from CSV files"
+icon = SubResource("ImageTexture_ih5gb")
+
+[node name="HintTooltip8" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
+layout_mode = 2
+tooltip_text = "Godot imports CSV files as \".translation\" files.
+This buttons adds them to \"Project Settings -> Localization\".
+"
+texture = null
+hint_text = "This button will scan all timelines and generate or update their CSV files.
+
+This will replace original text with text from the CSV files for default locale.
 
 A Dialogic CSV file will be prefixed with \"dialogic_\".
 
@@ -287,14 +310,14 @@ This action will be disabled if the \"Translation folder\" is missing or has an 
 unique_name_in_owner = true
 layout_mode = 2
 text = "Collect translations"
-icon = SubResource("ImageTexture_xbph7")
+icon = SubResource("ImageTexture_ih5gb")
 
 [node name="HintTooltip6" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
 tooltip_text = "Godot imports CSV files as \".translation\" files.
 This buttons adds them to \"Project Settings -> Localization\".
 "
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Godot imports CSV files as \".translation\" files.
 This buttons adds them to \"Project Settings -> Localization\".
 "
@@ -311,7 +334,7 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 text = "Remove translations"
-icon = SubResource("ImageTexture_xbph7")
+icon = SubResource("ImageTexture_ih5gb")
 
 [node name="HintTooltip7" parent="TranslationSettings/VBoxContainer2/Actions" instance=ExtResource("2_k2lou")]
 layout_mode = 2
@@ -321,7 +344,7 @@ It will try to delete any \".csv\" and \".translation\" files that are related t
 CSV and translation files prefixed with \"dialogic_\" are treated as Dialogic-related.
 
 Removes translation IDs (eg. #id:33) from timelines and characters."
-texture = SubResource("ImageTexture_xbph7")
+texture = null
 hint_text = "Be very careful with this button!
 
 It will try to delete any \".csv\" and \".translation\" files that are related to Dialogic.

--- a/addons/dialogic/Modules/Choice/event_choice.gd
+++ b/addons/dialogic/Modules/Choice/event_choice.gd
@@ -130,15 +130,21 @@ func _get_translatable_properties() -> Array:
 	return ['text', 'disabled_text']
 
 
-func _get_property_original_translation(property:String) -> String:
-	match property:
+func _get_property_original_translation(property_name:String) -> String:
+	match property_name:
 		'text':
 			return text
 		'disabled_text':
 			return disabled_text
 	return ''
-#endregion
 
+func _set_property_original_translation(property_name:String, value:String) -> void:
+	match property_name:
+		'text':
+			text = value
+		'disabled_text':
+			disabled_text = value
+#endregion
 
 #region EDITOR REPRESENTATION
 ################################################################################

--- a/addons/dialogic/Modules/Glossary/glossary_resource.gd
+++ b/addons/dialogic/Modules/Glossary/glossary_resource.gd
@@ -88,7 +88,7 @@ func _remove_entry_alias(entry_key: String) -> bool:
 	return true
 
 
-## Updates the glossary entry's name and related alias keys.
+## Updates the glossary entry's name.
 ## The [param old_entry_key] is the old unique name of the entry.
 ## The [param new_entry_key] is the new unique name of the entry.
 ##

--- a/addons/dialogic/Modules/Jump/event_label.gd
+++ b/addons/dialogic/Modules/Jump/event_label.gd
@@ -89,6 +89,12 @@ func _get_property_original_translation(property_name:String) -> String:
 			return display_name
 	return ''
 
+func _set_property_original_translation(property_name:String, value:String) -> void:
+	match property_name:
+		'display_name':
+			display_name = value
+
+
 ################################################################################
 ## 						EDITOR REPRESENTATION
 ################################################################################

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -369,12 +369,16 @@ func _get_translatable_properties() -> Array:
 	return ['text']
 
 
-func _get_property_original_translation(property:String) -> String:
-	match property:
+func _get_property_original_translation(property_name:String) -> String:
+	match property_name:
 		'text':
 			return text
 	return ''
 
+func _set_property_original_translation(property_name:String, value:String) -> void:
+	match property_name:
+		'text':
+			text = value
 
 #endregion
 

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -195,6 +195,9 @@ func _get_translatable_properties() -> Array:
 func _get_property_original_translation(_property_name:String) -> String:
 	return ''
 
+## Overwrite if this events needs translation.
+func _set_property_original_translation(property_name:String, value:String) -> void:
+	pass
 
 ## Returns true if there is any translatable properties on this event.
 ## Overwrite [_get_translatable_properties()] to change this.


### PR DESCRIPTION
This makes it possible to change update text for default locale directly from the CSV files.

It also makes it possible to change the default locale used in dialogic and update the text accordingly.


https://github.com/user-attachments/assets/221bfae5-c0ea-4ea8-be83-6ec4887aeb9a

