### PR TITLE
Fix and improve conditional modifier

### DIFF
--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -120,7 +120,7 @@ func get_current_question_info() -> Dictionary:
 			if not hide:
 				button_idx += 1
 
-		choice_info.text = dialogic.Text.parse_text(choice_info.text, true, true, false, true, false, false)
+		choice_info.text = dialogic.Text.parse_text(choice_info.text, 1)
 
 		choice_info.merge(choice_event.extra_data)
 

--- a/addons/dialogic/Modules/Core/index.gd
+++ b/addons/dialogic/Modules/Core/index.gd
@@ -23,5 +23,5 @@ func _get_text_effects() -> Array[Dictionary]:
 
 func _get_text_modifiers() -> Array[Dictionary]:
 	return [
-		{'subsystem':'Expressions', 'method':"modifier_condition", 'command':'if', 'mode':-1},
+		{'subsystem':'Expressions', 'method':"modifier_condition", 'command':'if', 'mode':-1, "order":20},
 	]

--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -55,13 +55,21 @@ func execute_condition(condition:String) -> bool:
 	return false
 
 
-var condition_modifier_regex := RegEx.create_from_string(r"(?(DEFINE)(?<nobraces>([^{}]|\{(?P>nobraces)\})*))\[if *(?<condition>\{(?P>nobraces)\})(?<truetext>(\\\]|\\\/|[^\]\/])*)(\/(?<falsetext>(\\\]|[^\]])*))?\]")
+var condition_modifier_regex := RegEx.create_from_string(r"(?(DEFINE)(?<nobraces>([^{}]|\{(?P>nobraces)\})*))\[if *(?<condition>(\{(?P>nobraces)\}|true\b|false\b))(?<truetext>(\\\]|\\\/|[^\]\/])*)(\/(?<falsetext>(\\\]|[^\]])*))?\]")
 func modifier_condition(text:String) -> String:
 	for find in condition_modifier_regex.search_all(text):
+		var insert := ""
 		if execute_condition(find.get_string("condition")):
-			text = text.replace(find.get_string(), find.get_string("truetext").strip_edges())
+			insert = find.get_string("truetext")
 		else:
-			text = text.replace(find.get_string(), find.get_string("falsetext").strip_edges())
+			insert = find.get_string("falsetext")
+		
+		# Avoid double spaces at the insert position if the insert is empty.
+		if not insert.strip_edges() and " "+find.get_string()+" " in text:
+			text = text.replace(find.get_string()+" ", insert.strip_edges())
+		else:
+			text = text.replace(find.get_string(), insert.strip_edges())
+		
 	return text
 #endregion
 

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -130,7 +130,7 @@ func _execute() -> void:
 
 			dialogic.current_state_info['text_sub_idx'] = section_idx
 
-			var segment: String = dialogic.Text.parse_text(split_text[section_idx][0])
+			var segment: String = dialogic.Text.parse_text(split_text[section_idx][0], 0)
 			var is_append: bool = split_text[section_idx][1]
 
 			final_text = ProjectSettings.get_setting("dialogic/text/dialog_text_prefix", "")+segment

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -59,7 +59,7 @@ var text_already_read := false
 var text_effects := {}
 var parsed_text_effect_info: Array[Dictionary] = []
 var text_effects_regex := RegEx.new()
-enum TextModifierModes {ALL=-1, TEXT_ONLY=0, CHOICES_ONLY=1}
+enum ParserModes {ALL=-1, TEXT_ONLY=0, CHOICES_ONLY=1}
 enum TextTypes {DIALOG_TEXT, CHOICE_TEXT}
 var text_modifiers := []
 
@@ -73,6 +73,8 @@ var _letter_speed_absolute := false
 var _voice_synced_text := false
 
 var _autopauses := {}
+
+var parse_stack: Array[Dictionary] = []
 
 
 #region STATE
@@ -113,19 +115,55 @@ func post_install() -> void:
 #region MAIN METHODS
 ####################################################################################################
 
-## Applies modifiers, effects and coloring to the text
-func parse_text(text:String, type:int=TextTypes.DIALOG_TEXT, variables := true, glossary := true, modifiers:= true, effects:= true, color_names:= true) -> String:
-	if variables and dialogic.has_subsystem('VAR'):
-		text = dialogic.VAR.parse_variables(text)
-	if modifiers:
-		text = parse_text_modifiers(text, type)
-	if effects:
-		text = parse_text_effects(text)
-	if color_names:
-		text = color_character_names(text)
-	if glossary and dialogic.has_subsystem('Glossary'):
-		text = dialogic.Glossary.parse_glossary(text)
+## Applies modifiers, effects and coloring to the text. 
+## Utilizes the parse stack created and sorted in [method load_parse_stack()].
+func parse_text(text:String, type:int=TextTypes.DIALOG_TEXT) -> String:
+	if parse_stack.is_empty():
+		load_parse_stack()
+	
+	for i in parse_stack:
+		if i.type != ParserModes.ALL and type != -1 and i.type != type:
+			continue
+		text = i.method.call(text)
+
 	return text
+
+
+## Creates and sorts a stack of methods that take a text and return it.
+## This includes: variables, text modifiers, text effects, autocolor names and the glossary.
+func load_parse_stack() -> void:
+	parse_stack.clear()
+	
+	if dialogic.has_subsystem('VAR'):
+		parse_stack.append(
+			{
+				"method":dialogic.VAR.parse_variables,
+				"type": ParserModes.ALL,
+				"order": 30,
+			})
+
+	parse_stack.append(
+		{
+			"method": parse_text_effects,
+			"type": ParserModes.TEXT_ONLY,
+			"order": 50,
+		})
+	for i in text_modifiers:
+		parse_stack.append(i)
+	parse_stack.append(
+		{
+			"method": color_character_names,
+			"type": ParserModes.TEXT_ONLY,
+			"order": 90,
+		})
+	parse_stack.append(
+		{
+			"method": dialogic.Glossary.parse_glossary,
+			"type": ParserModes.TEXT_ONLY,
+			"order": 95,
+		})
+	
+	parse_stack.sort_custom(func(a,b):return a["order"] < b["order"])
 
 
 ## When an event updates the text spoken, this can adjust the state of
@@ -422,15 +460,8 @@ func collect_text_modifiers() -> void:
 				text_modifiers.append({'method':Callable(dialogic.get_subsystem(modifier.subsystem), modifier.method)})
 			elif modifier.has('node_path') and modifier.has('method'):
 				text_modifiers.append({'method':Callable(get_node(modifier.node_path), modifier.method)})
-			text_modifiers[-1]['mode'] = modifier.get('mode', TextModifierModes.TEXT_ONLY)
-
-
-func parse_text_modifiers(text:String, type:int=TextTypes.DIALOG_TEXT) -> String:
-	for mod in text_modifiers:
-		if mod.mode != TextModifierModes.ALL and type != -1 and  type != mod.mode:
-			continue
-		text = mod.method.call(text)
-	return text
+			text_modifiers[-1]['type'] = modifier.get('mode', ParserModes.TEXT_ONLY)
+			text_modifiers[-1]['order'] = modifier.get('order', 40)
 
 
 #endregion


### PR DESCRIPTION
This is more complicated then I had hoped but I guess it's necessary. It introduces a parse-stack that contains all parsing methods. This allows modifiers to be injected into different points of the stack, not all at once. Now the conditional modifier can correctly run before variables, while the autopause modifier can correctly run after the variables.
This should also provide more flexibility later on if we need to have better control over other parsing order.

Compatibility breaking: This changes the signature of the Text.parse_text() method, removing all the individual flags.

- fixes #2610 
