### PR TITLE
Fixes: The "move_to_foreground()" method is deprecated, use "grab_focus()" instead.

### DIFF
--- a/addons/dialogic/Editor/Common/reference_manager_window.gd
+++ b/addons/dialogic/Editor/Common/reference_manager_window.gd
@@ -163,7 +163,6 @@ func open() -> void:
 	DialogicResourceUtil.update_directory('dch')
 	DialogicResourceUtil.update_directory('dtl')
 	popup_centered_ratio(0.5)
-	move_to_foreground()
 	grab_focus()
 
 

--- a/addons/dialogic/Editor/Common/update_install_window.gd
+++ b/addons/dialogic/Editor/Common/update_install_window.gd
@@ -20,7 +20,6 @@ func open() -> void:
 	get_parent().popup_centered_ratio(0.5)
 	get_parent().mode = Window.MODE_WINDOWED
 	get_parent().grab_focus()
-	get_parent().grab_focus()
 
 
 func load_info(info:Dictionary, update_type:int) -> void:

--- a/addons/dialogic/Editor/Common/update_install_window.gd
+++ b/addons/dialogic/Editor/Common/update_install_window.gd
@@ -19,7 +19,7 @@ func _ready() -> void:
 func open() -> void:
 	get_parent().popup_centered_ratio(0.5)
 	get_parent().mode = Window.MODE_WINDOWED
-	get_parent().move_to_foreground()
+	get_parent().grab_focus()
 	get_parent().grab_focus()
 
 
@@ -108,7 +108,7 @@ func _on_update_manager_downdload_completed(result:int):
 func _on_resources_reimported(resources:Array) -> void:
 	if is_inside_tree():
 		await get_tree().process_frame
-		get_parent().move_to_foreground()
+		get_parent().grab_focus()
 
 
 func markdown_to_bbcode(text:String) -> String:


### PR DESCRIPTION
I believe it was deprecated in Godot 4.3.
Referenc: https://github.com/godotengine/godot/issues/82936