### PR TITLE
Add support for Spaces as Indentation

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -112,10 +112,11 @@ func _gui_input(event):
 			for caret in range(get_caret_count()):
 				var line := get_line(get_caret_line(caret)).strip_edges()
 				var event_res := DialogicTimeline.event_from_string(line, DialogicResourceUtil.get_event_cache())
+				var indent_format: String = timeline_editor.current_resource.indent_format
 				if event_res.can_contain_events:
-					insert_text_at_caret("\n"+"\t".repeat(get_indent_level(get_caret_line(caret))/4+1), caret)
+					insert_text_at_caret("\n"+indent_format.repeat(get_indent_level(get_caret_line(caret))/4+1), caret)
 				else:
-					insert_text_at_caret("\n"+"\t".repeat(get_indent_level(get_caret_line(caret))/4), caret)
+					insert_text_at_caret("\n"+indent_format.repeat(get_indent_level(get_caret_line(caret))/4), caret)
 		_:
 			return
 	get_viewport().set_input_as_handled()


### PR DESCRIPTION
Dialogic will now correctly use the first sort of indentation used in the file and expect it throughout the file. It will also remember that indentation and use it when saving or auto-indenting in the text editor. You cannot mix different indentations in one file.

- fixes #1190 
- fixes #2659 