### PR TITLE
Fix: Fast dialogue skipping can crash in execute_effects

### DIFF
--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -449,6 +449,7 @@ func execute_effects(current_index:int, text_node:Control, skipping := false) ->
 		if current_index != -1 and current_index < parsed_text_effect_info[0]['index']:
 			return
 		var effect: Dictionary = parsed_text_effect_info.pop_front()
+		var callable: Callable = effect['execution_info']['callable']
 		if is_instance_valid(text_node):
 			await callable.call(text_node, skipping, effect['value'])
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -449,7 +449,8 @@ func execute_effects(current_index:int, text_node:Control, skipping := false) ->
 		if current_index != -1 and current_index < parsed_text_effect_info[0]['index']:
 			return
 		var effect: Dictionary = parsed_text_effect_info.pop_front()
-		await (effect['execution_info']['callable'] as Callable).call(text_node, skipping, effect['value'])
+		if is_instance_valid(text_node):
+			await callable.call(text_node, skipping, effect['value'])
 
 
 func collect_text_modifiers() -> void:


### PR DESCRIPTION
fixes a bug where skipping dialogue too fast could crash the game

(Patches "Invalid type in function 'Node(subsystem_text.gd)::effect_pause (Callable)'. The Object-derived class of argument 1 (previously freed) is not a subclass of the expected argument class." in execute_effects)