### PR TITLE
Editor: Fix/Improve number fields

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_layout.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_layout.gd
@@ -10,13 +10,13 @@ func _get_title() -> String:
 
 func _load_portrait_data(data:Dictionary) -> void:
 	%IgnoreScale.set_pressed_no_signal(data.get('ignore_char_scale', false))
-	%PortraitScale.value = data.get('scale', 1.0)*100
+	%PortraitScale.set_value(data.get('scale', 1.0)*100)
 	%PortraitOffset.set_value(data.get('offset', Vector2()))
 	%PortraitOffset._load_display_info({'step':1})
 	%PortraitMirror.set_pressed_no_signal(data.get('mirror', false))
 
 
-func _on_portrait_scale_value_changed(value:float) -> void:
+func _on_portrait_scale_value_changed(_property:String, value:float) -> void:
 	var data: Dictionary = selected_item.get_metadata(0)
 	data['scale'] = value/100.0
 	update_preview.emit()
@@ -37,7 +37,7 @@ func _on_ignore_scale_toggled(button_pressed:bool) -> void:
 	changed.emit()
 
 
-func _on_portrait_offset_value_changed(property:String, value:Vector2) -> void:
+func _on_portrait_offset_value_changed(_property:String, value:Vector2) -> void:
 	var data: Dictionary = selected_item.get_metadata(0)
 	data['offset'] = value
 	update_preview.emit()

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_layout.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_layout.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://crke8suvv52c6"]
+[gd_scene load_steps=4 format=3 uid="uid://crke8suvv52c6"]
 
 [ext_resource type="Script" uid="uid://uv6dx3sofwae" path="res://addons/dialogic/Editor/CharacterEditor/char_edit_p_section_layout.gd" id="1_76vf2"]
 [ext_resource type="PackedScene" uid="uid://dtimnsj014cu" path="res://addons/dialogic/Editor/Events/Fields/field_vector2.tscn" id="2_c8kyi"]
+[ext_resource type="PackedScene" uid="uid://kdpp3mibml33" path="res://addons/dialogic/Editor/Events/Fields/field_number.tscn" id="2_daw3l"]
 
 [node name="Layout" type="HFlowContainer"]
 offset_right = 428.0
@@ -25,13 +26,13 @@ layout_mode = 2
 layout_mode = 2
 text = "Scale:"
 
-[node name="PortraitScale" type="SpinBox" parent="HBoxContainer"]
+[node name="PortraitScale" parent="HBoxContainer" instance=ExtResource("2_daw3l")]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "A scale to be applied on top of the main scale 
-(unless ignore main scale is pressed)."
-value = 100.0
-allow_greater = true
+mode = 1
+step = 1.0
+min_value = 0.0
+max_value = 100.0
 suffix = "%"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="."]

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_section_portraits.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_section_portraits.gd
@@ -33,7 +33,7 @@ func main_portrait_settings_update(_something=null, _value=null) -> void:
 	character_editor.something_changed()
 
 
-func default_portrait_changed(property:String, value:String) -> void:
+func default_portrait_changed(_property:String, value:String) -> void:
 	character_editor.current_resource.default_portrait = value
 	character_editor.update_default_portrait_star(value)
 
@@ -47,7 +47,7 @@ func _load_character(resource:DialogicCharacter) -> void:
 	loading = true
 	%DefaultPortraitPicker.set_value(resource.default_portrait)
 
-	%MainScale.value = 100*resource.scale
+	%MainScale.set_value(100*resource.scale)
 	%MainOffset.set_value(resource.offset)
 	%MainMirror.button_pressed = resource.mirror
 	loading = false
@@ -69,7 +69,7 @@ func _save_changes(resource:DialogicCharacter) -> DialogicCharacter:
 
 
 ## Get suggestions for DefaultPortraitPicker
-func suggest_portraits(search:String) -> Dictionary:
+func suggest_portraits(_search:String) -> Dictionary:
 	var suggestions := {}
 	for portrait in character_editor.get_updated_portrait_dict().keys():
 		suggestions[portrait] = {'value':portrait}

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_section_portraits.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_section_portraits.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://cmrgbo8qi145o"]
+[gd_scene load_steps=5 format=3 uid="uid://cmrgbo8qi145o"]
 
 [ext_resource type="Script" uid="uid://yulfiomudcob" path="res://addons/dialogic/Editor/CharacterEditor/char_edit_section_portraits.gd" id="1_6sxsl"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/field_options_dynamic.tscn" id="2_birla"]
 [ext_resource type="PackedScene" uid="uid://dtimnsj014cu" path="res://addons/dialogic/Editor/Events/Fields/field_vector2.tscn" id="3_vcvin"]
+[ext_resource type="PackedScene" uid="uid://kdpp3mibml33" path="res://addons/dialogic/Editor/Events/Fields/field_number.tscn" id="4_w4pvv"]
 
 [node name="Portraits" type="GridContainer"]
 offset_right = 453.0
@@ -29,13 +30,24 @@ layout_mode = 2
 size_flags_vertical = 0
 text = "Main Scale"
 
-[node name="MainScale" type="SpinBox" parent="."]
+[node name="MainScaleOld" type="SpinBox" parent="."]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 size_flags_horizontal = 8
 value = 100.0
 allow_greater = true
 alignment = 1
+suffix = "%"
+
+[node name="MainScale" parent="." instance=ExtResource("4_w4pvv")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+mode = 1
+step = 1.0
+min_value = 0.0
+max_value = 100.0
 suffix = "%"
 
 [node name="Label2" type="Label" parent="."]

--- a/addons/dialogic/Editor/Events/Fields/field_number.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_number.gd
@@ -146,12 +146,12 @@ func _on_gui_input(event: InputEvent) -> void:
 
 func _on_increment_button_down(button: NodePath) -> void:
 	_on_value_text_submitted(str(value+step))
-	_holding_button(1.0, get_node(button) as BaseButton)
+	_holding_button(1, get_node(button) as BaseButton)
 
 
 func _on_decrement_button_down(button: NodePath) -> void:
 	_on_value_text_submitted(str(value-step))
-	_holding_button(-1.0, get_node(button) as BaseButton)
+	_holding_button(-1, get_node(button) as BaseButton)
 
 
 func _on_value_text_submitted(new_text: String, no_signal:= false) -> void:
@@ -165,10 +165,14 @@ func _on_value_text_submitted(new_text: String, no_signal:= false) -> void:
 			value = snapped(temp, step)
 	elif allow_string:
 		value = new_text
-	%Value.text = str(value).pad_decimals(
-		max(
-			len(str(float(step)-floorf(step)))-2,
-			len(str(float(value)-floorf(value)))-2,))
+
+	if int(step) == step and step != 0:
+		%Value.text = str(int(value))
+	else:
+		%Value.text = str(value).pad_decimals(
+			max(
+				len(str(float(step)-floorf(step)))-2,
+				len(str(float(value)-floorf(value)))-2,))
 	if not no_signal:
 		value_changed.emit(property_name, value)
 	# Visually disable Up or Down arrow when limit is reached to better indicate a limit has been hit

--- a/addons/dialogic/Editor/Events/Fields/field_number.tscn
+++ b/addons/dialogic/Editor/Events/Fields/field_number.tscn
@@ -40,8 +40,6 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 0
 script = ExtResource("1_0jdnn")
-min_value = 0.0
-max_value = null
 
 [node name="Value_Panel" type="PanelContainer" parent="."]
 layout_mode = 2


### PR DESCRIPTION
Number fields defaulted to a minimum of 0, which meant negative offsets were no longer possible. This has been fixed.

Additionally the display of integer fields (when step is 1) no longer displays a fractional .0 at all times. 

Replaces the Scale SpinBoxes in the character editor with NumberField.