### PR TITLE
fix: While a text event starts which changes the portrait, the new character portrait scene is created after the signal text_started is emited

### DIFF
--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -68,13 +68,13 @@ func _execute() -> void:
 	if dialogic.has_subsystem("Portraits"):
 		if character:
 
-			dialogic.Portraits.change_speaker(character, portrait)
+			await dialogic.Portraits.change_speaker(character, portrait)
 
 			if portrait and dialogic.Portraits.is_character_joined(character):
-				dialogic.Portraits.change_character_portrait(character, portrait)
+				await dialogic.Portraits.change_character_portrait(character, portrait)
 
 		else:
-			dialogic.Portraits.change_speaker(null)
+			await dialogic.Portraits.change_speaker(null)
 
 	## Change and Type Sound Mood
 	if character:


### PR DESCRIPTION
This fix just awaits the change_speaker and change_character_portrait calls so it instantiates the new character portrait scene before the calling the text_started and about_to_show_text signals.

I think it makes more sense if when changing the portrait, the latest portrait character scene is there to receive the signal.  