### PR TITLE
fix: Bug where enum string exports would show as file exports because of handling of bitwise conditionals.

### DIFF
--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -305,7 +305,7 @@ static func apply_scene_export_overrides(node:Node, export_overrides:Dictionary,
 		return
 	var property_info: Array[Dictionary] = node.script.get_script_property_list()
 	for i in property_info:
-		if i['usage'] & PROPERTY_USAGE_EDITOR:
+		if i['usage'] & PROPERTY_USAGE_EDITOR == PROPERTY_USAGE_EDITOR:
 			if i['name'] in export_overrides:
 				if str_to_var(export_overrides[i['name']]) == null and typeof(node.get(i['name'])) == TYPE_STRING:
 					node.set(i['name'], export_overrides[i['name']])
@@ -331,7 +331,7 @@ static func get_scene_export_defaults(node:Node) -> Dictionary:
 	var defaults := {}
 	var property_info: Array[Dictionary] = node.script.get_script_property_list()
 	for i in property_info:
-		if i['usage'] & PROPERTY_USAGE_EDITOR:
+		if i['usage'] & PROPERTY_USAGE_EDITOR == PROPERTY_USAGE_EDITOR:
 			defaults[i['name']] = node.get(i['name'])
 	Engine.get_main_loop().get_meta('dialogic_scene_export_defaults')[node.script.resource_path] = defaults
 	return defaults
@@ -425,7 +425,7 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 			input.color_changed.connect(DialogicUtil._on_export_color_submitted.bind(property_info.name, property_changed))
 			input.custom_minimum_size.x = get_editor_scale() * 50
 		TYPE_INT:
-			if property_info['hint'] & PROPERTY_HINT_ENUM:
+			if property_info['hint'] & PROPERTY_HINT_ENUM == PROPERTY_HINT_ENUM:
 				input = OptionButton.new()
 				for x in property_info['hint_string'].split(','):
 					input.add_item(x.split(':')[0])
@@ -477,7 +477,7 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 			input.set_value(value)
 			input.value_changed.connect(DialogicUtil._on_export_vectori_submitted.bind(property_changed))
 		TYPE_STRING:
-			if property_info['hint'] & PROPERTY_HINT_FILE or property_info['hint'] & PROPERTY_HINT_DIR:
+			if property_info['hint'] & PROPERTY_HINT_FILE== PROPERTY_HINT_FILE  or property_info['hint'] & PROPERTY_HINT_DIR == PROPERTY_HINT_DIR:
 				input = load("res://addons/dialogic/Editor/Events/Fields/field_file.tscn").instantiate()
 				input.show_editing_button = true
 				input.file_filter = property_info['hint_string']
@@ -490,7 +490,7 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 				if value != null:
 					input.set_value(value)
 				input.value_changed.connect(DialogicUtil._on_export_file_submitted.bind(property_changed))
-			elif property_info['hint'] & PROPERTY_HINT_ENUM:
+			elif property_info['hint'] & PROPERTY_HINT_ENUM == PROPERTY_HINT_ENUM:
 				input = OptionButton.new()
 				var options: PackedStringArray = []
 				for x in property_info['hint_string'].split(','):

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_exports.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_exports.gd
@@ -47,7 +47,7 @@ func _recheck(data: Dictionary, force:=false):
 
 	var skip := false
 	for i in scene.script.get_script_property_list():
-		if i['usage'] & PROPERTY_USAGE_EDITOR and !skip:
+		if i['usage'] & PROPERTY_USAGE_EDITOR == PROPERTY_USAGE_EDITOR and !skip:
 			var label := Label.new()
 			label.text = i['name'].capitalize()
 			$Grid.add_child(label)

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main_exports.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main_exports.gd
@@ -46,7 +46,7 @@ func load_portrait_scene_export_variables() -> void:
 	scene = scene.instantiate()
 	var skip := true
 	for i in scene.script.get_script_property_list():
-		if i['usage'] & PROPERTY_USAGE_EDITOR and !skip:
+		if i['usage'] & PROPERTY_USAGE_EDITOR == PROPERTY_USAGE_EDITOR and !skip:
 			var label := Label.new()
 			label.text = i['name'].capitalize()
 			$Grid.add_child(label)

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -444,21 +444,21 @@ func collect_settings(properties:Array[Dictionary]) -> Array[Dictionary]:
 	var current_subgroup := {}
 
 	for i in properties:
-		if i['usage'] & PROPERTY_USAGE_CATEGORY:
+		if i['usage'] & PROPERTY_USAGE_CATEGORY == PROPERTY_USAGE_CATEGORY:
 			continue
 
-		if (i['usage'] & PROPERTY_USAGE_GROUP):
+		if i['usage'] & PROPERTY_USAGE_GROUP == PROPERTY_USAGE_GROUP:
 			current_group = i
 			current_group['added'] = false
 			current_group['id'] = &'GROUP'
 			current_subgroup = {}
 
-		elif i['usage'] & PROPERTY_USAGE_SUBGROUP:
+		elif i['usage'] & PROPERTY_USAGE_SUBGROUP == PROPERTY_USAGE_SUBGROUP:
 			current_subgroup = i
 			current_subgroup['added'] = false
 			current_subgroup['id'] = &'SUBGROUP'
 
-		elif i['usage'] & PROPERTY_USAGE_EDITOR:
+		elif i['usage'] & PROPERTY_USAGE_EDITOR == PROPERTY_USAGE_EDITOR:
 			if current_group.get('name', '') == 'Private':
 				continue
 


### PR DESCRIPTION
I'm playing with dialogic so I can develop a game in the future, and I found another issue where my character scenes had two string enum export props which were treated as file exports strangely enough. I went days finding out why and I found out, with the help of a debugger cause tbh I'm trying to understand bitwise operations, that some bitwise operation conditionals were behaving weird.

Bitwise operations, like bitwise AND, return a number not a boolean, and that number can be either a 0, which in a godot conditional would be treated as false, or anything else like 1, 2, 3, 50... which would be treated as true for godot.

<img width="1547" height="699" alt="image" src="https://github.com/user-attachments/assets/fdce531e-4103-4d2a-ae20-fd8c9a91e532" />

In this case when you have a string enum property export that has a hint of PROPERTY_HINT_ENUM with value of 2 or 0010 in binary, and you make a bitwise AND operation with the global constant PROPERTY_HINT_DIR with value of 14 or 1110, the result is 2 or 0010 because the 3nd bit from left to right match... and godot takes that as true, so it treats the enum as a file prop.

You should compare the result with the global constant enum you want the usage to be, and in this case do something like "property_info['hint'] & PROPERTY_HINT_DIR == PROPERTY_HINT_DIR".

I went out of my way to change every bitwise operation so to standardize it, although if you ask how something like this didn't make any more bugs besides this... it's probably because you can mostly get away with it with certain global constant enums, for example:
PROPERTY_USAGE_EDITOR has a value of 4 or 100 in binary, which means the AND operation can ONLY be 0 or 4.
PROPERTY_USAGE_GROUP has a value of 64 or 1 000 000 in binary and can only be 0 or 64.
PROPERTY_USAGE_SUBGROUP value 256... well, let's just say it can only be 0 or 256.

Maybe in retrospect it's not that you're doing an improper comparison, the reason of this bug is because of how the global enum for PropertyHint is weird and doesn't go in exponentials of 2s like all the other enums which would absolutely make the comparison "value & ENUM = ENUM" unnecessary... well I guess compare it just in case there's a pesky bitwise enum that can make undesirable behaviors.

Dude, what a rabbit hole I went into...

---

Here is some testing, I used this export prop to break it:

@export_enum("Idle", "Run", "Jump", "Shoot")
var state: String = "Idle"

Here is an example broken:
<img width="1264" height="622" alt="image" src="https://github.com/user-attachments/assets/db35e1e0-1c21-4916-a7f3-06e230c1d35e" />

Here is the example with the changes from this PR:
<img width="1275" height="695" alt="image" src="https://github.com/user-attachments/assets/c734f971-0d1c-4276-9eae-765571765fcc" />


