### PR TITLE
Change clear event to use textbox fade animation length

### DIFF
--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -28,9 +28,11 @@ func _execute() -> void:
 
 	if clear_textbox and dialogic.has_subsystem("Text") and dialogic.Text.is_textbox_visible():
 		dialogic.Text.update_dialog_text('')
-		dialogic.Text.hide_textbox(final_time == 0)
+		if step_by_step:
+			await dialogic.Text.hide_textbox(final_time == 0)
+		else:
+			dialogic.Text.hide_textbox(final_time == 0)
 		dialogic.current_state = dialogic.States.IDLE
-		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
 	if clear_portraits and dialogic.has_subsystem('Portraits') and len(dialogic.Portraits.get_joined_characters()) != 0:
 		if final_time == 0:


### PR DESCRIPTION
This slightly changes the behaviour of the clear event. Instead of the given time, it will now just await the textbox hide animation.

This is good because previously it would default to a second of delay even when the textbox animation was instant, which felt very unexpected to users, especially now that a clear event is automatically added at the end of dialog.