### PR TITLE
Simple fix for zero-value pitch errors in the typing-sounds node.

### DIFF
--- a/addons/dialogic/Modules/Text/node_type_sound.gd
+++ b/addons/dialogic/Modules/Text/node_type_sound.gd
@@ -92,7 +92,7 @@ func _on_continued_revealing_text(new_character:String) -> void:
 	audio_player.stream = current_overwrite_data.get('sounds', sounds)[RNG.randi_range(0, current_overwrite_data.get('sounds', sounds).size() - 1)]
 
 	#choose a random pitch and volume
-	audio_player.pitch_scale = max(0, current_overwrite_data.get('pitch_base', base_pitch) + current_overwrite_data.get('pitch_variance', pitch_variance) * RNG.randf_range(-1.0, 1.0))
+	audio_player.pitch_scale = max(0.0001, current_overwrite_data.get('pitch_base', base_pitch) + current_overwrite_data.get('pitch_variance', pitch_variance) * RNG.randf_range(-1.0, 1.0))
 	audio_player.volume_db = current_overwrite_data.get('volume_base', base_volume) + current_overwrite_data.get('volume_variance',volume_variance) * RNG.randf_range(-1.0, 1.0)
 
 	#play the sound


### PR DESCRIPTION
- Simple fix for zero-value pitch errors in the typing-sounds node

###  **Problem**
If the pitch variance for a sound file is set to anything greater than or equal to the base pitch value this will continuously produce errors in Godot 4, due to pitch being zero.  These errors flood the console and likely degrade performance, as well as prevent any sound from being played at random intervals. This is not the expected behavior.

I ran into this issue in my own projects but the fix is extremely simple. It is only one value in one line of code.

###  **Fix**
This PR is a fix to prevent the errors by setting the minimum value for pitch above zero. 
I took the value from Dialogic 1.x code ("0.0001") and applied it to current. Nothing more is in this PR.

