### PR TITLE
Many Improvements

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://bnkck3hocbkk5"]
+[gd_scene format=3 uid="uid://bnkck3hocbkk5"]
 
 [ext_resource type="Script" uid="uid://c0nilv2pybryh" path="res://addons/dialogic/Editor/CharacterEditor/char_edit_section_general.gd" id="1_3e1i1"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_cxfqm"]
@@ -31,7 +31,7 @@ text = "Display Name"
 layout_mode = 2
 tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable. E.g. :{Player.name}"
 texture = null
-hint_text = "This name will be displayed on the name label. You can use a dialogic variable. E.g. :{Player.name}"
+hint_text = "This name will be displayed on the name label. If you want it to change, you can use a dialogic variable. E.g.: {Player.Name}"
 
 [node name="DisplayName" type="HBoxContainer" parent="." unique_id=1051746999]
 layout_mode = 2

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -17,9 +17,9 @@ var selected_item: TreeItem
 var def_portrait_path: String = DialogicUtil.get_module_path('Character').path_join('default_portrait.tscn')
 
 
-######### EDITOR STUFF and LOADING/SAVING ######################################
+#region EDITOR STUFF and LOADING/SAVING
+################################################################################
 
-#region Resource Logic
 ## Method is called once editors manager is ready to accept registers.
 func _register() -> void:
 	## Makes the editor open this when a .dch file is selected.
@@ -138,9 +138,9 @@ func new_character(path: String) -> void:
 #endregion
 
 
-######### INTERFACE ############################################################
+#region INTERFACE
+################################################################################
 
-#region Interface
 func _ready() -> void:
 	if get_parent() is SubViewport:
 		return
@@ -232,15 +232,15 @@ func add_settings_section(edit:Control, parent:Node) ->  void:
 		_on_section_button_pressed(button)
 
 
-func get_settings_section_by_name(name:String, main:=true) -> Node:
+func get_settings_section_by_name(section_name:String, main:=true) -> Node:
 	var parent := %MainSettingsSections
 	if not main:
 		parent = %PortraitSettingsSection
 
-	if parent.has_node(name):
-		return parent.get_node(name)
-	elif parent.has_node(name+"BOX/"+name):
-		return parent.get_node(name+"BOX/"+name)
+	if parent.has_node(section_name):
+		return parent.get_node(section_name)
+	elif parent.has_node(section_name+"BOX/"+section_name):
+		return parent.get_node(section_name+"BOX/"+section_name)
 	else:
 		return null
 
@@ -259,10 +259,9 @@ func _on_section_button_pressed(button:Button) -> void:
 		section_header.get_parent().get_child(section_header.get_index()+2).visible = section_header.get_parent().get_child(section_header.get_index()+1).visible
 
 
-func something_changed(fake_argument = "", fake_arg2 = null) -> void:
+func something_changed(_fake_argument = "", _fake_arg2 = null) -> void:
 	if not loading:
 		current_resource_state = ResourceStates.UNSAVED
-
 
 
 func hide_main_settings() -> void:
@@ -277,7 +276,6 @@ func show_main_settings() -> void:
 	%MainSettingsHidden.hide()
 	%MainSettingsPanel.size_flags_horizontal = SIZE_EXPAND_FILL
 	%MainHSplit.collapsed = false
-
 
 
 func _on_switch_portrait_settings_position_pressed() -> void:
@@ -561,9 +559,10 @@ func report_name_change(item: TreeItem) -> void:
 
 #endregion
 
-########### PREVIEW ############################################################
 
-#region Preview
+#region PREVIEW
+################################################################################
+
 func update_preview(force := false, ignore_settings_reload := false) -> void:
 	%ScenePreviewWarning.hide()
 
@@ -693,6 +692,7 @@ func _on_fit_preview_toggle_toggled(button_pressed):
 	update_preview(false, true)
 
 #endregion
+
 
 ## Open the reference manager
 func _on_reference_manger_button_pressed() -> void:

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
@@ -89,8 +89,6 @@ layout_mode = 2
 tooltip_text = "Hide Main Settings"
 theme_type_variation = &"FlatButton"
 text = "     "
-icon_alignment = 1
-expand_icon = true
 
 [node name="MainSettingsScroll" type="ScrollContainer" parent="Scroll/VBox/MainHSplit/MainSettingsPanel/MainSettings" unique_id=802937484]
 unique_name_in_owner = true
@@ -118,7 +116,6 @@ size_flags_vertical = 3
 tooltip_text = "Show Main Settings"
 theme_type_variation = &"FlatButton"
 theme_override_constants/icon_max_width = 20
-icon_alignment = 1
 
 [node name="Split" type="HSplitContainer" parent="Scroll/VBox/MainHSplit" unique_id=203063071]
 layout_mode = 2

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
@@ -3,8 +3,6 @@
 [ext_resource type="Script" uid="uid://cwhe7tpe75oh7" path="res://addons/dialogic/Editor/CharacterEditor/character_editor.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_uhhqs"]
 [ext_resource type="Script" uid="uid://deliic6d8vajo" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd" id="2_vad0i"]
-[ext_resource type="Texture2D" uid="uid://bff65e82555qr" path="res://addons/dialogic/Editor/Images/Pieces/close-icon.svg" id="3_2ogmx"]
-[ext_resource type="Texture2D" uid="uid://dx3o2ild56i76" path="res://addons/dialogic/Editor/Images/Pieces/closed-icon.svg" id="4_wg7ys"]
 [ext_resource type="Texture2D" uid="uid://my600mb32ydt" path="res://addons/dialogic/Editor/Images/Toolbar/add-character.svg" id="6_2ogmx"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_es2rd"]
@@ -91,7 +89,6 @@ layout_mode = 2
 tooltip_text = "Hide Main Settings"
 theme_type_variation = &"FlatButton"
 text = "     "
-icon = ExtResource("3_2ogmx")
 icon_alignment = 1
 expand_icon = true
 
@@ -121,7 +118,6 @@ size_flags_vertical = 3
 tooltip_text = "Show Main Settings"
 theme_type_variation = &"FlatButton"
 theme_override_constants/icon_max_width = 20
-icon = ExtResource("4_wg7ys")
 icon_alignment = 1
 
 [node name="Split" type="HSplitContainer" parent="Scroll/VBox/MainHSplit" unique_id=203063071]

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -105,10 +105,16 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 
 
 func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
+	if typeof(data) == TYPE_DICTIONARY and 'files' in data.keys():
+		return true
 	return data is TreeItem
 
 
 func _drop_data(at_position: Vector2, item: Variant) -> void:
+	if item is Dictionary:
+		owner.import_portraits_from_file_list(item.files)
+		return
+
 	var to_item := get_item_at_position(at_position)
 	if to_item:
 		var test_item := to_item

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -86,8 +86,9 @@ func update_left_item_margin(margin_on:bool) -> void:
 	else:
 		remove_theme_constant_override("item_margin")
 
-################################################################################
-##					DRAG AND DROP
+
+
+#region DRAG AND DROP
 ################################################################################
 
 func _get_drag_data(at_position: Vector2) -> Variant:
@@ -156,3 +157,5 @@ func copy_branch_or_item(item: TreeItem, new_parent: TreeItem) -> TreeItem:
 	for child in item.get_children():
 		copy_branch_or_item(child, new_item)
 	return new_item
+
+#endregion

--- a/addons/dialogic/Editor/Events/Fields/field_number.tscn
+++ b/addons/dialogic/Editor/Events/Fields/field_number.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://kdpp3mibml33"]
+[gd_scene format=3 uid="uid://kdpp3mibml33"]
 
 [ext_resource type="Script" uid="uid://dbegwhxegm271" path="res://addons/dialogic/Editor/Events/Fields/field_number.gd" id="1_0jdnn"]
 [ext_resource type="Texture2D" uid="uid://dh1ycbmw8anqh" path="res://addons/dialogic/Editor/Images/Interactable/increment_icon.svg" id="3_v5cne"]
@@ -30,7 +30,7 @@ content_margin_bottom = 6.0
 bg_color = Color(0.94, 0.94, 0.94, 0)
 border_color = Color(0, 0, 0, 0)
 
-[node name="Field_Number" type="HBoxContainer"]
+[node name="Field_Number" type="HBoxContainer" unique_id=724455253]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -41,16 +41,16 @@ grow_vertical = 2
 theme_override_constants/separation = 0
 script = ExtResource("1_0jdnn")
 
-[node name="Value_Panel" type="PanelContainer" parent="."]
+[node name="Value_Panel" type="PanelContainer" parent="." unique_id=571684938]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_type_variation = &"DialogicEventEdit"
 
-[node name="Layout" type="HBoxContainer" parent="Value_Panel"]
+[node name="Layout" type="HBoxContainer" parent="Value_Panel" unique_id=905640067]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="Prefix" type="RichTextLabel" parent="Value_Panel/Layout"]
+[node name="Prefix" type="RichTextLabel" parent="Value_Panel/Layout" unique_id=1747277733]
 unique_name_in_owner = true
 visible = false
 clip_contents = false
@@ -72,7 +72,7 @@ shortcut_keys_enabled = false
 drag_and_drop_selection_enabled = false
 text_direction = 1
 
-[node name="Value" type="LineEdit" parent="Value_Panel/Layout"]
+[node name="Value" type="LineEdit" parent="Value_Panel/Layout" unique_id=1339360196]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -85,7 +85,7 @@ text = "0"
 expand_to_text_length = true
 virtual_keyboard_type = 3
 
-[node name="Suffix" type="RichTextLabel" parent="Value_Panel/Layout"]
+[node name="Suffix" type="RichTextLabel" parent="Value_Panel/Layout" unique_id=1306629312]
 unique_name_in_owner = true
 visible = false
 clip_contents = false
@@ -106,13 +106,13 @@ shortcut_keys_enabled = false
 drag_and_drop_selection_enabled = false
 text_direction = 1
 
-[node name="Spin" type="VBoxContainer" parent="Value_Panel/Layout"]
+[node name="Spin" type="VBoxContainer" parent="Value_Panel/Layout" unique_id=614686235]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_constants/separation = 0
+theme_override_constants/separation = -6
 alignment = 1
 
-[node name="Increment" type="Button" parent="Value_Panel/Layout/Spin"]
+[node name="Increment" type="Button" parent="Value_Panel/Layout/Spin" unique_id=1014774233]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_vertical = 3
@@ -130,7 +130,7 @@ icon = ExtResource("3_v5cne")
 flat = true
 vertical_icon_alignment = 2
 
-[node name="Decrement" type="Button" parent="Value_Panel/Layout/Spin"]
+[node name="Decrement" type="Button" parent="Value_Panel/Layout/Spin" unique_id=439554030]
 auto_translate_mode = 2
 layout_mode = 2
 size_flags_vertical = 3

--- a/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_options_dynamic.gd
@@ -222,6 +222,7 @@ func _on_Search_text_changed(new_text:String, just_update:bool = false) -> void:
 			line_length = max(line_length, curr_line_length)
 
 			%Suggestions.set_item_tooltip(idx, suggestions[element].get('tooltip', ''))
+			%Suggestions.set_item_disabled(idx, suggestions[element].get("disabled", false))
 			%Suggestions.set_item_metadata(idx, suggestions[element].value)
 			idx += 1
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -195,7 +195,7 @@ func _ready() -> void:
 	load_event_buttons()
 	_on_right_sidebar_resized()
 	_initialized = true
-	
+
 	TimelineUndoRedo.version_changed.connect(_on_undoredo_changed)
 
 
@@ -327,7 +327,7 @@ func update_content_list() -> void:
 		if 'event_name' in event.resource and event.resource is DialogicAudioEvent:
 			if not event.resource.channel_name in channels:
 				channels.append(event.resource.channel_name)
-	
+
 	timeline_editor.update_label_cache(labels)
 	timeline_editor.update_audio_channel_cache(channels)
 
@@ -691,13 +691,7 @@ func select_item(item: Node, multi_possible:bool = true) -> void:
 	if item == null:
 		return
 
-	if Input.is_key_pressed(KEY_CTRL) and multi_possible:
-		# deselect the item if it is selected
-		if _is_item_selected(item):
-			selected_items.erase(item)
-		else:
-			selected_items.append(item)
-	elif Input.is_key_pressed(KEY_SHIFT) and multi_possible:
+	if Input.is_key_pressed(KEY_SHIFT) and multi_possible:
 		if len(selected_items) == 0:
 			selected_items = [item]
 		else:
@@ -711,6 +705,12 @@ func select_item(item: Node, multi_possible:bool = true) -> void:
 
 				if index == goal_idx:
 					break
+	elif Input.is_key_pressed(KEY_CTRL) and multi_possible:
+		# deselect the item if it is selected
+		if _is_item_selected(item):
+			selected_items.erase(item)
+		else:
+			selected_items.append(item)
 	else:
 		if len(selected_items) == 1:
 			if _is_item_selected(item):

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -34,7 +34,7 @@ func _register() -> void:
 	play_timeline_button = editors_manager.add_button(
 		get_theme_icon("PlayScene", "EditorIcons"),
 		"Play Timeline",
-		"Play the current timeline {0}".format("(Command+B)" if OS.get_name() == "macOS" else "(CTRL+F5)"),
+		"Play the current timeline {0}".format(["(Command+B)" if OS.get_name() == "macOS" else "(CTRL+F5)"]),
 		self,
 		editors_manager.ButtonPlacement.TOOLBAR_MAIN)
 	play_timeline_button.pressed.connect(play_timeline)

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -34,7 +34,7 @@ func _register() -> void:
 	play_timeline_button = editors_manager.add_button(
 		get_theme_icon("PlayScene", "EditorIcons"),
 		"Play Timeline",
-		"Play the current timeline {0}".format(["(Command+B)" if OS.get_name() == "macOS" else "(CTRL+F5)"]),
+		"Play the current timeline {0}".format(["(Command+B)" if OS.get_name() == "macOS" else "(CTRL+F6)"]),
 		self,
 		editors_manager.ButtonPlacement.TOOLBAR_MAIN)
 	play_timeline_button.pressed.connect(play_timeline)
@@ -93,7 +93,7 @@ func _save() -> void:
 
 func _input(event: InputEvent) -> void:
 	if event is InputEventKey:
-		var keycode := KEY_F5
+		var keycode := KEY_F6
 		if OS.get_name() == "macOS":
 			keycode = KEY_B
 		if event.keycode == keycode and event.pressed:

--- a/addons/dialogic/Modules/Background/event_background.gd
+++ b/addons/dialogic/Modules/Background/event_background.gd
@@ -29,8 +29,10 @@ var _arg_type := ArgumentTypes.IMAGE:
 			return ArgumentTypes.IMAGE
 		elif argument.begins_with("#") and argument.is_valid_html_color():
 			return ArgumentTypes.COLOR
-		else:
+		elif argument.is_empty():
 			return _arg_type
+		else:
+			return ArgumentTypes.STRING
 	set(value):
 		if value == ArgumentTypes.STRING:
 			if not argument.begins_with(" "):
@@ -156,11 +158,11 @@ func build_event_editor() -> void:
 				'icon': ["Color", "EditorIcons"]
 			},
 			{
-				'label': 'Custom Argument',
+				'label': 'Argument',
 				'value': ArgumentTypes.STRING,
 				'icon': ["String", "EditorIcons"]
 			}
-		], "symbol_only": true})
+		]})
 	add_header_edit('argument', ValueType.FILE,
 			{'file_filter':'*.jpg, *.jpeg, *.png, *.webp, *.tga, *svg, *.bmp, *.dds, *.exr, *.hdr; Supported Image Files',
 			'placeholder': "No Image",

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -112,18 +112,22 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 	var portrait_node: Node = null
 	var previous_portrait: Node = null
 	var portrait_count := character_node.get_child_count()
+	var copy_state_vars := {}
 
 	if portrait_count > 0:
 		previous_portrait = character_node.get_child(-1)
 
 	# Check if the scene is the same as the currently loaded scene.
-	if (not previous_portrait == null and
-		previous_portrait.get_meta('scene', '') == scene_path and
+	if not previous_portrait == null and previous_portrait.get_meta('scene', '') == scene_path:
 		# Also check if the scene supports changing to the given portrait.
-		previous_portrait.has_method('_should_do_portrait_update') and
-		previous_portrait._should_do_portrait_update(character, portrait)):
-			portrait_node = previous_portrait
-			info['same_scene'] = true
+		if previous_portrait is DialogicPortrait:
+			if previous_portrait._should_do_portrait_update(character, portrait):
+				portrait_node = previous_portrait
+				info['same_scene'] = true
+
+				for i in previous_portrait.get_property_list():
+					if i.name.begins_with("state_"):
+						copy_state_vars[i.name] = previous_portrait.get(i.name)
 
 	else:
 
@@ -151,6 +155,10 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 
 
 	if portrait_node:
+		for i in copy_state_vars:
+			if i in portrait_node:
+				portrait_node.set(i, copy_state_vars[i])
+
 		portrait_node.set_meta('portrait', portrait)
 		character_node.set_meta('portrait', portrait)
 
@@ -630,7 +638,6 @@ func get_character_info(character:DialogicCharacter) -> Dictionary:
 ## Updates all portrait containers set to SPEAKER.
 func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 	for container: Node in get_tree().get_nodes_in_group('dialogic_portrait_con_speaker'):
-
 		var just_joined := true
 		for character_node: Node in container.get_children():
 			if not character_node.get_meta('character') == speaker:

--- a/addons/dialogic/Modules/Choice/event_choice.gd
+++ b/addons/dialogic/Modules/Choice/event_choice.gd
@@ -34,8 +34,8 @@ var regex := RegEx.create_from_string(r'- (?<text>(?>\\\||(?(?=.*\|)[^|]|(?!\[if
 
 func _execute() -> void:
 	if dialogic.Choices.is_question(dialogic.current_event_idx):
-		dialogic.Choices.show_current_question(false)
 		dialogic.current_state = dialogic.States.AWAITING_CHOICE
+		dialogic.Choices.show_current_question(false)
 
 
 func _is_branch_starter() -> bool:

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -7,8 +7,10 @@ signal choice_selected(info:Dictionary)
 ## Emitted when a set of choices is reached and shown.
 ## Info includes the keys 'choices' (an array of dictionaries with infos on all the choices).
 signal question_shown(info:Dictionary)
+## Emitted when a question was reached that has no usable choice (all hidden or disabled).
+signal invalid_question_reached
 
-## Contains information on the latest question.
+## Contains information on the latest question. See [method get_current_question_info] for info on content.
 var last_question_info := {}
 
 ## The delay between the text finishing revealing and the choices appearing
@@ -31,7 +33,8 @@ enum HotkeyBehaviour {NONE, NUMBERS}
 ## Will add some hotkeys to the choices if different then HotkeyBehaviour.NONE.
 var hotkey_behaviour := HotkeyBehaviour.NONE
 
-
+enum InvalidChoiceBehaviour {NOTHING, AUTO_SKIP}
+var invalid_choice_behaviour := InvalidChoiceBehaviour.AUTO_SKIP
 ### INTERNALS
 
 ## Used to block choices from being clicked for a couple of seconds (if delay is set in settings).
@@ -81,12 +84,13 @@ func hide_all_choices() -> void:
 ##		{'event_index':10, 'button_index':1, 'disabled':false, 'text':"My Choice", 'visible':true},
 ##		{'event_index':15, 'button_index':2, 'disabled':false, 'text':"My Choice2", 'visible':true},
 ##	]
+## 'invalid':false # is true if all choices are either invisible or disabled
+## }
 func get_current_question_info() -> Dictionary:
 	var question_info := {'choices':[]}
 
 	var button_idx := 1
-	last_question_info = {'choices':[]}
-
+	var any_valid := false
 	for choice_index in get_current_choice_indexes():
 		var event: DialogicEvent = dialogic.current_timeline_events[choice_index]
 
@@ -102,6 +106,7 @@ func get_current_question_info() -> Dictionary:
 		var condition: String = choice_event.condition
 
 		if condition.is_empty() or dialogic.Expressions.execute_condition(choice_event.condition):
+			any_valid = true
 			choice_info['disabled'] = false
 			choice_info['text'] = choice_event.get_property_translated('text')
 			choice_info['visible'] = true
@@ -128,8 +133,8 @@ func get_current_question_info() -> Dictionary:
 			choice_info['visited_before'] = dialogic.History.has_event_been_visited(choice_index)
 
 		question_info['choices'].append(choice_info)
-		last_question_info['choices'].append(choice_info['text'])
 
+	question_info["invalid"] = not any_valid
 	return question_info
 
 
@@ -137,6 +142,7 @@ func get_current_question_info() -> Dictionary:
 func show_current_question(instant:=true) -> void:
 	hide_all_choices()
 	_choice_blocker.stop()
+	last_question_info = get_current_question_info()
 
 	if !instant and (reveal_delay != 0 or reveal_by_input):
 		if reveal_delay != 0:
@@ -164,6 +170,7 @@ func show_current_question(instant:=true) -> void:
 
 		node._load_info(choice)
 
+
 		if choice.button_index == 1 and autofocus_first_choice:
 			node.grab_focus()
 
@@ -188,9 +195,25 @@ func show_current_question(instant:=true) -> void:
 
 	_choice_blocker.start(block_delay)
 	question_shown.emit(question_info)
+	if question_info.invalid:
+		invalid_question_reached.emit()
+		printerr("[Dialogic] An invalid question was reached (all choices disabled or invisible).")
+		dialogic.print_debug_moment()
+		if invalid_choice_behaviour == InvalidChoiceBehaviour.AUTO_SKIP:
+			skip_question()
 
 	if missing_button:
 		printerr("[Dialogic] The layout you are using doesn't have enough Choice Buttons for the choices you are trying to display.")
+
+
+## Skips to the end of the current question.
+func skip_question() -> void:
+	if not last_question_info:
+		return
+	hide_all_choices()
+	dialogic.current_state = dialogic.States.IDLE
+	dialogic.current_event_idx = dialogic.current_timeline.get_event(last_question_info.choices[0].event_index).get_end_branch_index()-1
+	dialogic.handle_next_event()
 
 
 func focus_choice(button_index:int) -> void:
@@ -221,7 +244,6 @@ func get_choice_button(button_index:int) -> DialogicNode_ChoiceButton:
 		if node.choice_index > 0:
 			idx = node.choice_index
 		idx += 1
-
 	return null
 
 
@@ -230,7 +252,7 @@ func _on_choice_selected(choice_info := {}) -> void:
 		return
 
 	if dialogic.has_subsystem('History'):
-		var all_choices: Array = dialogic.Choices.last_question_info['choices']
+		var all_choices: Array = last_question_info['choices']["text"]
 		if dialogic.has_subsystem('VAR'):
 			dialogic.History.store_simple_history_entry(dialogic.VAR.parse_variables(choice_info.text), "Choice", {'all_choices': all_choices})
 		else:

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -252,7 +252,7 @@ func _on_choice_selected(choice_info := {}) -> void:
 		return
 
 	if dialogic.has_subsystem('History'):
-		var all_choices: Array = last_question_info['choices']["text"]
+		var all_choices: Array = last_question_info['choices'].map(func(x): return x["text"])
 		if dialogic.has_subsystem('VAR'):
 			dialogic.History.store_simple_history_entry(dialogic.VAR.parse_variables(choice_info.text), "Choice", {'all_choices': all_choices})
 		else:

--- a/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.gd
+++ b/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.gd
@@ -4,8 +4,13 @@ extends DialogicPortrait
 @export_group('Main')
 @export_file var image := ""
 
+
 var unhighlighted_color := Color.DARK_GRAY
-var _prev_z_index := 0
+
+## Variables prefixed with `state_` will get copied to the next portrait if it uses the same scene.
+var state_highlighted := false
+var state_prev_z_index := 0
+
 
 ## Load anything related to the given character and portrait
 func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
@@ -15,20 +20,27 @@ func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String
 
 
 func _ready() -> void:
-	if not Engine.is_editor_hint():
+	if Engine.is_editor_hint():
+		return
+	if state_highlighted:
+		self.modulate = Color.WHITE
+	else:
 		self.modulate = unhighlighted_color
 
 
+
 func _should_do_portrait_update(_character: DialogicCharacter, _portrait: String) -> bool:
-	return true
+	return false
 
 
 func _highlight() -> void:
 	create_tween().tween_property(self, 'modulate', Color.WHITE, 0.15)
-	_prev_z_index = DialogicUtil.autoload().Portraits.get_character_info(character).get('z_index', 0)
+	state_prev_z_index = DialogicUtil.autoload().Portraits.get_character_info(character).get('z_index', 0)
 	DialogicUtil.autoload().Portraits.change_character_z_index(character, 99)
+	state_highlighted = true
 
 
 func _unhighlight() -> void:
 	create_tween().tween_property(self, 'modulate', unhighlighted_color, 0.15)
-	DialogicUtil.autoload().Portraits.change_character_z_index(character, _prev_z_index)
+	DialogicUtil.autoload().Portraits.change_character_z_index(character, state_prev_z_index)
+	state_highlighted = false

--- a/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.tscn
+++ b/addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://br18lgpga2y2v"]
+[gd_scene format=3 uid="uid://br18lgpga2y2v"]
 
 [ext_resource type="Script" uid="uid://24gbl2wbl1d5" path="res://addons/dialogic/Modules/HighlightPortrait/simple_highlight_portrait.gd" id="1_ceqva"]
 
-[node name="DefaultPortrait" type="Node2D"]
+[node name="DefaultPortrait" type="Node2D" unique_id=651658253]
 script = ExtResource("1_ceqva")
 
-[node name="Portrait" type="Sprite2D" parent="."]
+[node name="Portrait" type="Sprite2D" parent="." unique_id=1997322178]
 centered = false

--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -134,10 +134,12 @@ func get_timeline_suggestions(_filter:String= "") -> Dictionary:
 
 func get_label_suggestions(_filter:String="") -> Dictionary:
 	var suggestions := {}
-	suggestions['at the beginning'] = {'value':'', 'editor_icon':['GuiRadioUnchecked', 'EditorIcons']}
+	suggestions['at the beginning'] = {'value':'', 'editor_icon':['GuiRadioUnchecked', 'EditorIcons'], "tooltip":"Starts the timeline from the beginning."}
 	if timeline_identifier in DialogicResourceUtil.get_label_cache().keys():
 		for label in DialogicResourceUtil.get_label_cache()[timeline_identifier]:
 			suggestions[label] = {'value': label, 'tooltip':label, 'editor_icon': ["ArrowRight", "EditorIcons"]}
+	if len(suggestions) == 1:
+		suggestions["No label events found."] = {'value': "NOTHING", 'tooltip':"By adding label events to this timeline you can jump directly to them.", "disabled":true,}
 	if _filter.begins_with("{"):
 		for var_path in DialogicUtil.list_variables(DialogicUtil.get_default_variables()):
 			suggestions["{"+var_path+"}"] = {'value':"{"+var_path+"}", 'icon':load("res://addons/dialogic/Editor/Images/Pieces/variable.svg")}

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
@@ -15,8 +15,8 @@ func _init() -> void:
 func _get_title() -> String:
 	return "Typing Sounds"
 
-################################################################################
-##					COMMUNICATION WITH EDITOR
+
+#region COMMUNICATION WITH EDITOR
 ################################################################################
 
 func _load_character(character:DialogicCharacter):
@@ -48,22 +48,22 @@ func set_portrait_data(data:Dictionary) -> void:
 	if character_editor.selected_item and is_instance_valid(character_editor.selected_item):
 		character_editor.selected_item.set_metadata(0, data)
 
+#endregion
 
-################################################################################
-##					OWN STUFF
+
+#region OWN STUFF
 ################################################################################
 
 func _ready() -> void:
 	if get_parent() is SubViewport:
 		return
 
-	%ListPanel.self_modulate = get_theme_color("background", "Editor")
+	self_modulate = get_theme_color("dark_color_1", "Editor")
 	%Add.icon = get_theme_icon("Add", "EditorIcons")
 	%Delete.icon = get_theme_icon("Remove", "EditorIcons")
 	%Duplicate.icon = get_theme_icon("Duplicate", "EditorIcons")
 	%Play.icon = get_theme_icon("Play", "EditorIcons")
 	%Default.icon = get_theme_icon("NonFavorite", "EditorIcons")
-
 	%NameWarning.texture = get_theme_icon("StatusWarning", "EditorIcons")
 
 
@@ -232,3 +232,5 @@ func preview() -> void:
 		await preview_timer.timeout
 
 	preview_timer.queue_free()
+
+#endregion

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd
@@ -54,7 +54,10 @@ func set_portrait_data(data:Dictionary) -> void:
 ################################################################################
 
 func _ready() -> void:
-	%ListPanel.self_modulate = get_theme_color("base_color", "Editor")
+	if get_parent() is SubViewport:
+		return
+
+	%ListPanel.self_modulate = get_theme_color("background", "Editor")
 	%Add.icon = get_theme_icon("Add", "EditorIcons")
 	%Delete.icon = get_theme_icon("Remove", "EditorIcons")
 	%Duplicate.icon = get_theme_icon("Duplicate", "EditorIcons")

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
@@ -5,28 +5,22 @@
 [ext_resource type="PackedScene" uid="uid://kdpp3mibml33" path="res://addons/dialogic/Editor/Events/Fields/field_number.tscn" id="3_yjcns"]
 [ext_resource type="Script" uid="uid://dpv2dfiv5dhmr" path="res://addons/dialogic/Modules/Text/node_type_sound.gd" id="5_yscws"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y7t05"]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 10.0
-content_margin_bottom = 10.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_vv4dt"]
+content_margin_left = 3.0
+content_margin_top = 3.0
+content_margin_right = 3.0
+content_margin_bottom = 3.0
 bg_color = Color(1, 1, 1, 1)
-corner_radius_top_left = 20
-corner_radius_top_right = 20
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_40fkd"]
-content_margin_top = 10.0
-content_margin_bottom = 10.0
-bg_color = Color(1, 1, 1, 0.0588235)
-border_width_left = 1
-border_width_right = 1
-border_width_bottom = 1
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
-
-[node name="Typing Sounds" type="VBoxContainer" unique_id=640122489]
+[node name="Typing Sounds" type="PanelContainer" unique_id=368458129]
+self_modulate = Color(0.38170326, 0.38170323, 0.38170323, 1)
 offset_right = 443.0
-offset_bottom = 144.0
+offset_bottom = 397.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_vv4dt")
 script = ExtResource("1_3px07")
 
 [node name="VBox" type="VBoxContainer" parent="." unique_id=1736388576]
@@ -35,9 +29,7 @@ theme_override_constants/separation = 0
 
 [node name="ListPanel" type="PanelContainer" parent="VBox" unique_id=1562827715]
 unique_name_in_owner = true
-self_modulate = Color(0.083385, 0.083385, 0.083385, 1)
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_y7t05")
 
 [node name="Vbox" type="VBoxContainer" parent="VBox/ListPanel" unique_id=1991868687]
 layout_mode = 2
@@ -87,7 +79,6 @@ layout_mode = 2
 [node name="Settings" type="PanelContainer" parent="VBox" unique_id=44966764]
 unique_name_in_owner = true
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_40fkd")
 
 [node name="Grid" type="GridContainer" parent="VBox/Settings" unique_id=1230303108]
 layout_mode = 2

--- a/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
+++ b/addons/dialogic/Modules/Text/character_settings/character_moods_settings.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://8ad1pwbjuqpt"]
+[gd_scene format=3 uid="uid://8ad1pwbjuqpt"]
 
 [ext_resource type="Script" uid="uid://6qkd50m2lqnx" path="res://addons/dialogic/Modules/Text/character_settings/character_moods_settings.gd" id="1_3px07"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/field_file.tscn" id="2_e1vyd"]
@@ -14,18 +14,6 @@ bg_color = Color(1, 1, 1, 1)
 corner_radius_top_left = 20
 corner_radius_top_right = 20
 
-[sub_resource type="Image" id="Image_vv4dt"]
-data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
-
-[sub_resource type="ImageTexture" id="ImageTexture_drtd2"]
-image = SubResource("Image_vv4dt")
-
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_40fkd"]
 content_margin_top = 10.0
 content_margin_bottom = 10.0
@@ -36,81 +24,80 @@ border_width_bottom = 1
 corner_radius_bottom_right = 10
 corner_radius_bottom_left = 10
 
-[node name="Typing Sounds" type="VBoxContainer"]
+[node name="Typing Sounds" type="VBoxContainer" unique_id=640122489]
 offset_right = 443.0
 offset_bottom = 144.0
 script = ExtResource("1_3px07")
 
-[node name="VBox" type="VBoxContainer" parent="."]
+[node name="VBox" type="VBoxContainer" parent="." unique_id=1736388576]
 layout_mode = 2
 theme_override_constants/separation = 0
 
-[node name="ListPanel" type="PanelContainer" parent="VBox"]
+[node name="ListPanel" type="PanelContainer" parent="VBox" unique_id=1562827715]
 unique_name_in_owner = true
-self_modulate = Color(0, 0, 0, 1)
+self_modulate = Color(0.083385, 0.083385, 0.083385, 1)
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_y7t05")
 
-[node name="Vbox" type="VBoxContainer" parent="VBox/ListPanel"]
+[node name="Vbox" type="VBoxContainer" parent="VBox/ListPanel" unique_id=1991868687]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBox/ListPanel/Vbox"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBox/ListPanel/Vbox" unique_id=232301700]
 layout_mode = 2
 alignment = 2
 
-[node name="Add" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer"]
+[node name="Add" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=149189447]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "Add type sound mood"
-icon = SubResource("ImageTexture_drtd2")
+tooltip_text = "Add Mood"
+theme_type_variation = &"FlatButton"
 
-[node name="Duplicate" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer"]
+[node name="Default" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=1147972556]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "Duplicate"
-icon = SubResource("ImageTexture_drtd2")
+tooltip_text = "Make Default"
+theme_type_variation = &"FlatButton"
+toggle_mode = true
 
-[node name="Delete" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer"]
+[node name="Duplicate" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=1807805409]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "Delete mood"
-icon = SubResource("ImageTexture_drtd2")
+tooltip_text = "Duplicate Mood"
+theme_type_variation = &"FlatButton"
 
-[node name="VSeparator" type="VSeparator" parent="VBox/ListPanel/Vbox/HBoxContainer"]
+[node name="Delete" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=966103407]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Delete Mood"
+theme_type_variation = &"FlatButton"
+
+[node name="VSeparator" type="VSeparator" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=1375207989]
 layout_mode = 2
 
-[node name="Play" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer"]
+[node name="Play" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer" unique_id=361440151]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Preview"
-icon = SubResource("ImageTexture_drtd2")
 
-[node name="Default" type="Button" parent="VBox/ListPanel/Vbox/HBoxContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-tooltip_text = "Default"
-toggle_mode = true
-icon = SubResource("ImageTexture_drtd2")
-
-[node name="MoodList" type="ItemList" parent="VBox/ListPanel/Vbox"]
+[node name="MoodList" type="ItemList" parent="VBox/ListPanel/Vbox" unique_id=696500971]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 
-[node name="Settings" type="PanelContainer" parent="VBox"]
+[node name="Settings" type="PanelContainer" parent="VBox" unique_id=44966764]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_40fkd")
 
-[node name="Grid" type="GridContainer" parent="VBox/Settings"]
+[node name="Grid" type="GridContainer" parent="VBox/Settings" unique_id=1230303108]
 layout_mode = 2
 columns = 2
 
-[node name="Label" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label" type="Label" parent="VBox/Settings/Grid" unique_id=1989017327]
 layout_mode = 2
 text = "Name:"
 
-[node name="Name" type="LineEdit" parent="VBox/Settings/Grid"]
+[node name="Name" type="LineEdit" parent="VBox/Settings/Grid" unique_id=1564051984]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -119,7 +106,7 @@ text = "New Mood"
 placeholder_text = "Enter Mood Name"
 caret_blink = true
 
-[node name="NameWarning" type="TextureRect" parent="VBox/Settings/Grid/Name"]
+[node name="NameWarning" type="TextureRect" parent="VBox/Settings/Grid/Name" unique_id=1908393613]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 11
@@ -129,21 +116,20 @@ anchor_bottom = 1.0
 offset_left = -31.0
 grow_horizontal = 0
 grow_vertical = 2
-texture = SubResource("ImageTexture_drtd2")
 stretch_mode = 3
 
-[node name="Label6" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label6" type="Label" parent="VBox/Settings/Grid" unique_id=1843999425]
 layout_mode = 2
 text = "Mode:"
 
-[node name="Mode" type="OptionButton" parent="VBox/Settings/Grid"]
+[node name="Mode" type="OptionButton" parent="VBox/Settings/Grid" unique_id=1911787281]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Interrupt = The next sound will stop the previous
 Overlap = Multiple sounds may play at once
 Await = A sound will only be played if the previous has finished"
-item_count = 3
 selected = 0
+item_count = 3
 popup/item_0/text = "Interrupt"
 popup/item_0/id = 0
 popup/item_1/text = "Overlap"
@@ -151,11 +137,11 @@ popup/item_1/id = 1
 popup/item_2/text = "Await"
 popup/item_2/id = 2
 
-[node name="Label4" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label4" type="Label" parent="VBox/Settings/Grid" unique_id=26102657]
 layout_mode = 2
 text = "File/Folder:"
 
-[node name="SoundFolder" parent="VBox/Settings/Grid" instance=ExtResource("2_e1vyd")]
+[node name="SoundFolder" parent="VBox/Settings/Grid" unique_id=49354159 instance=ExtResource("2_e1vyd")]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
@@ -163,72 +149,69 @@ size_flags_horizontal = 3
 file_filter = "*.ogg, *.mp3, *.wav"
 file_mode = 3
 
-[node name="Label2" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label2" type="Label" parent="VBox/Settings/Grid" unique_id=784538409]
 layout_mode = 2
 text = "Pitch:"
 
-[node name="Pitch" type="HBoxContainer" parent="VBox/Settings/Grid"]
+[node name="Pitch" type="HBoxContainer" parent="VBox/Settings/Grid" unique_id=722375208]
 layout_mode = 2
 theme_override_constants/separation = -6
 alignment = 2
 
-[node name="PitchBase" parent="VBox/Settings/Grid/Pitch" instance=ExtResource("3_yjcns")]
+[node name="PitchBase" parent="VBox/Settings/Grid/Pitch" unique_id=380073313 instance=ExtResource("3_yjcns")]
 unique_name_in_owner = true
 layout_mode = 2
 enforce_step = false
-max = 4.0
 
-[node name="Label4" type="Label" parent="VBox/Settings/Grid/Pitch"]
+[node name="Label4" type="Label" parent="VBox/Settings/Grid/Pitch" unique_id=1612625108]
 layout_mode = 2
 text = "+/-  "
 
-[node name="PitchVariance" parent="VBox/Settings/Grid/Pitch" instance=ExtResource("3_yjcns")]
+[node name="PitchVariance" parent="VBox/Settings/Grid/Pitch" unique_id=869874398 instance=ExtResource("3_yjcns")]
 unique_name_in_owner = true
 layout_mode = 2
 enforce_step = false
 
-[node name="Label3" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label3" type="Label" parent="VBox/Settings/Grid" unique_id=1026921332]
 layout_mode = 2
 text = "Volume:"
 
-[node name="Volume" type="HBoxContainer" parent="VBox/Settings/Grid"]
+[node name="Volume" type="HBoxContainer" parent="VBox/Settings/Grid" unique_id=2065678471]
 layout_mode = 2
 theme_override_constants/separation = -6
 alignment = 2
 
-[node name="VolumeBase" parent="VBox/Settings/Grid/Volume" instance=ExtResource("3_yjcns")]
+[node name="VolumeBase" parent="VBox/Settings/Grid/Volume" unique_id=1752846059 instance=ExtResource("3_yjcns")]
 unique_name_in_owner = true
 layout_mode = 2
-min = -60.0
-max = 30.0
 
-[node name="Label4" type="Label" parent="VBox/Settings/Grid/Volume"]
+[node name="Label4" type="Label" parent="VBox/Settings/Grid/Volume" unique_id=314895744]
 layout_mode = 2
 text = "+/-  "
 
-[node name="VolumeVariance" parent="VBox/Settings/Grid/Volume" instance=ExtResource("3_yjcns")]
+[node name="VolumeVariance" parent="VBox/Settings/Grid/Volume" unique_id=1389737528 instance=ExtResource("3_yjcns")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Label5" type="Label" parent="VBox/Settings/Grid"]
+[node name="Label5" type="Label" parent="VBox/Settings/Grid" unique_id=989596440]
 layout_mode = 2
 text = "Skip:"
 
-[node name="Skip" parent="VBox/Settings/Grid" instance=ExtResource("3_yjcns")]
+[node name="Skip" parent="VBox/Settings/Grid" unique_id=486018047 instance=ExtResource("3_yjcns")]
 unique_name_in_owner = true
 layout_mode = 2
 alignment = 2
 step = 1.0
 
-[node name="Preview" type="AudioStreamPlayer" parent="."]
+[node name="Preview" type="AudioStreamPlayer" parent="." unique_id=1781375955]
 script = ExtResource("5_yscws")
 play_every_character = 0
 
 [connection signal="pressed" from="VBox/ListPanel/Vbox/HBoxContainer/Add" to="." method="_on_add_pressed"]
+[connection signal="toggled" from="VBox/ListPanel/Vbox/HBoxContainer/Default" to="." method="_on_default_toggled"]
 [connection signal="pressed" from="VBox/ListPanel/Vbox/HBoxContainer/Duplicate" to="." method="_on_duplicate_pressed"]
 [connection signal="pressed" from="VBox/ListPanel/Vbox/HBoxContainer/Delete" to="." method="_on_delete_pressed"]
 [connection signal="pressed" from="VBox/ListPanel/Vbox/HBoxContainer/Play" to="." method="preview"]
-[connection signal="toggled" from="VBox/ListPanel/Vbox/HBoxContainer/Default" to="." method="_on_default_toggled"]
 [connection signal="item_selected" from="VBox/ListPanel/Vbox/MoodList" to="." method="_on_mood_list_item_selected"]
 [connection signal="focus_exited" from="VBox/Settings/Grid/Name" to="." method="_on_name_focus_exited"]
 [connection signal="text_changed" from="VBox/Settings/Grid/Name" to="." method="_on_name_text_changed"]

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -67,12 +67,10 @@ func _execute() -> void:
 	## Change Portrait and Active Speaker
 	if dialogic.has_subsystem("Portraits"):
 		if character:
-
 			dialogic.Portraits.change_speaker(character, portrait)
 
 			if portrait and dialogic.Portraits.is_character_joined(character):
 				dialogic.Portraits.change_character_portrait(character, portrait)
-
 		else:
 			dialogic.Portraits.change_speaker(null)
 

--- a/addons/dialogic/Modules/Text/node_type_sound.gd
+++ b/addons/dialogic/Modules/Text/node_type_sound.gd
@@ -34,10 +34,10 @@ func _ready() -> void:
 	# add to necessary group
 	add_to_group('dialogic_type_sounds')
 
-	if bus == "Master":
-		bus = ProjectSettings.get_setting("dialogic/audio/type_sound_bus", "Master")
+	if not Engine.is_editor_hint() and get_parent() is DialogicNode_DialogText:
+		if bus == "Master":
+			bus = ProjectSettings.get_setting("dialogic/audio/type_sound_bus", "Master")
 
-	if !Engine.is_editor_hint() and get_parent() is DialogicNode_DialogText:
 		get_parent().started_revealing_text.connect(_on_started_revealing_text)
 		get_parent().continued_revealing_text.connect(_on_continued_revealing_text)
 		get_parent().finished_revealing_text.connect(_on_finished_revealing_text)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -204,13 +204,6 @@ func update_dialog_text(text: String, instant := false, additional := false) -> 
 				text_node.text = text
 
 			else:
-				var current_character := get_current_speaker()
-
-				if current_character:
-					var character_prefix: String = current_character.custom_info.get(DialogicCharacterPrefixSuffixSection.PREFIX_CUSTOM_KEY, DialogicCharacterPrefixSuffixSection.DEFAULT_PREFIX)
-					var character_suffix: String = current_character.custom_info.get(DialogicCharacterPrefixSuffixSection.SUFFIX_CUSTOM_KEY, DialogicCharacterPrefixSuffixSection.DEFAULT_SUFFIX)
-					text = character_prefix + text + character_suffix
-
 				text_node.reveal_text(text, additional)
 
 				if !text_node.finished_revealing_text.is_connected(_on_dialog_text_finished):
@@ -218,14 +211,15 @@ func update_dialog_text(text: String, instant := false, additional := false) -> 
 
 			dialogic.current_state_info['text_parsed'] = (text_node as RichTextLabel).get_parsed_text()
 
-	# Reset speed multiplier
-	update_text_speed(-1, false, 1)
-	# Reset Auto-Advance temporarily and the No-Skip setting:
-	dialogic.Inputs.auto_advance.enabled_until_next_event = false
-	dialogic.Inputs.auto_advance.override_delay_for_current_event = -1
-	dialogic.Inputs.manual_advance.disabled_until_next_event = false
+	if not additional:
+		# Reset speed multiplier
+		update_text_speed(-1, false, 1)
+		# Reset Auto-Advance temporarily and the No-Skip setting:
+		dialogic.Inputs.auto_advance.enabled_until_next_event = false
+		dialogic.Inputs.auto_advance.override_delay_for_current_event = -1
+		dialogic.Inputs.manual_advance.disabled_until_next_event = false
 
-	set_text_reveal_skippable(true, true)
+		set_text_reveal_skippable(true, true)
 
 	return text
 


### PR DESCRIPTION
## General
- change Play Timeline shortcut to CTRL+F6 on windows/linux (godot now claims CTRL+F5), also fix tooltip
- decrease Number field height (was bigger then other fields)

## Timeline Editor (visual)
- range select (while holding SHIFT) now takes precedent over multi-select (while holding CTRL) changing the behaviour when both SHIFT and CTRL are pressed

## Character Editor
- capitalize new characters display name
- replace Open and Close Main section button icons
- Allow dragging files into the portrait list and correctly import them as portraits with images or scenes
- clean up UI of Typing Sound mood section in new godot theme

## Background Event
- Add color picker to background event
- Add Await Transition to background event

## Jump event
- adds a note when no labels are found to explain how to add label events

## Choices
The choice subsystem now detects if the shown question is "invalid" meaning all choices are disabled or hidden thus completely blocking all progress.
Dialogic will now also automatically skip such questions (this can be disabled via code if needed).

## Character Suffix/Prefix & Append Text mode
- prefix/suffix logic moved to the text event. this allows them to be processed, e.g. contain text effects or variables. same for the global prefix
- prefix and suffix are now more correctly placed around "append" texts ([n+]), meaning only once at the beginning and end instead of beginning and end of each section
- also stop `update_dialog_text` from resetting temporary speed, autoadvance, manual advance and skippable if additional is true. This feels much more intuitive.
- Adds an additional check for whether the final processed text ends up as empty, in which case the text reveal will be skipped (previously such an empty text would deadlock the game with no textbox showing up but also no way to continue).

## Portraits (especially simple highlight portrait)
- Adds a simple system to allow portraits to carry over variables even when the instance gets replaced. Now any variable with a name starting with `state_` will get copied to the new portrait if they both use the same scene.
- Makes `_should_do_portrait_update` default to `false` in the simple-highlight portrait scene. This allows this scene to use the cross fades. Adds a bit of logic using the above state carrying to avoid this scene unhiglighting on every portrait change.