### PR TITLE
Fix Save Game Loading Bug

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -711,7 +711,10 @@ func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 			dialogic.current_state_info["portraits"][prev_speaker.get_identifier()].node.get_child(-1)._unhighlight()
 
 		if is_character_joined(speaker):
-			dialogic.current_state_info["portraits"][speaker.get_identifier()].node.get_child(-1)._highlight()
+			var portrait_info = dialogic.current_state_info["portraits"][speaker.get_identifier()]
+
+			if portrait_info.node and portrait_info.node.get_child_count() > 0:
+				portrait_info.node.get_child(-1)._highlight()
 
 #endregion
 


### PR DESCRIPTION
A game using Godot was crashing when loading a saved game. This conditional check fixes the crash.

The game was being loaded with the following script:
```gdscript
extends Node2D

func _ready() -> void:
	if Dialogic.Save.has_slot(GlobalData.slot_to_load):
		await get_tree().process_frame
		Dialogic.Save.load(GlobalData.slot_to_load)
		GlobalData.slot_to_load = ""
	else:
		Dialogic.start("res://timelines/first-scene.dtl")
```

I don't anticipate this will be the final fix given if this is the pattern the is_character_joined branch could possibly also benefit from this extra check. Or, if this is just hinting at a deeper fix that needs to be done.

In any case I wanted to share what worked and use this PR as a starting point for feedback in hopes of eventually getting a fix into main.

(Using Godot 4.5 on macOS btw.)