### PR TITLE
Alpha19

### DIFF
--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -638,7 +638,7 @@ static func get_character_suggestions(_search_text:String, current_value:Dialogi
 	return suggestions
 
 
-static func get_portrait_suggestions(search_text:String, character:DialogicCharacter, allow_empty := false, empty_text := "Don't Change") -> Dictionary:
+static func get_portrait_suggestions(search_text:String, character:DialogicCharacter, allow_empty := false, empty_text := "Don't Change", allow_anything:=false) -> Dictionary:
 	var icon := load("res://addons/dialogic/Editor/Images/Resources/portrait.svg")
 	var suggestions := {}
 
@@ -646,6 +646,9 @@ static func get_portrait_suggestions(search_text:String, character:DialogicChara
 		suggestions[empty_text] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
 
 	if "{" in search_text:
+		suggestions[search_text] = {'value':search_text, 'editor_icon':["Variant", "EditorIcons"]}
+
+	elif allow_anything and search_text:
 		suggestions[search_text] = {'value':search_text, 'editor_icon':["Variant", "EditorIcons"]}
 
 	if character != null:

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -661,7 +661,9 @@ func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 
 		elif portrait.is_empty():
 			continue
-
+		if portrait.is_empty():
+			if is_character_joined(speaker):
+				portrait = dialogic.current_state_info.portraits[speaker.get_identifier()].get("portrait", "")
 		if portrait.is_empty():
 			portrait = speaker.default_portrait
 

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -33,7 +33,7 @@ var character_identifier: String:
 	set(value):
 		character_identifier = value
 		character = DialogicResourceUtil.get_character_resource(value)
-		if Engine.is_editor_hint() and ((not character) or (character and not character.portraits.has(portrait))):
+		if Engine.is_editor_hint() and ((not character) or (character and not portrait in character.portraits)) and not (not character and (character_identifier or character_identifier.begins_with("{"))):
 			portrait = ""
 			ui_update_needed.emit()
 
@@ -434,7 +434,8 @@ func build_event_editor() -> void:
 
 
 func should_show_portrait_selector() -> bool:
-	return character and not character.portraits.is_empty() and not character.portraits.size() == 1
+	return (character and not character.portraits.is_empty() and not character.portraits.size() == 1) or \
+		(not character and (character_identifier.begins_with("{") or not character_identifier.is_empty()))
 
 
 func do_any_characters_exist() -> bool:
@@ -450,8 +451,9 @@ func get_character_suggestions(search_text:String) -> Dictionary:
 			"editor_icon":["GuiEllipsis", "EditorIcons"]}
 	return suggestions
 
+
 func get_portrait_suggestions(search_text:String) -> Dictionary:
-	return DialogicUtil.get_portrait_suggestions(search_text, character, true, "Don't change")
+	return DialogicUtil.get_portrait_suggestions(search_text, character, true, "Don't change", true)
 
 #endregion
 

--- a/addons/dialogic/plugin.cfg
+++ b/addons/dialogic/plugin.cfg
@@ -3,6 +3,6 @@
 name="Dialogic"
 description="Create dialogs, characters and scenes to display conversations in your Godot games.
 https://github.com/dialogic-godot/dialogic"
-author="Jowan Spooner, Emi, Cake and more!"
-version="2.0-Alpha-19 WIP (Godot 4.3+)"
+author="Jowan, Emi, Cake and more!"
+version="2.0-Alpha-19 (Godot 4.4+)"
 script="plugin.gd"


### PR DESCRIPTION
## Small fix to speaker portraits
Speaker portraits only show when the character talks. If however the character has joined before, the user might have specified their portrait before on a join event. This tries to get the speaker portrait if they are joined and no portrait is specified on the text event.

## Adjust text event portrait field visibility in visual editor
This better allows temporary characters in the visual editor (it now shows the portrait field if the character doesn't exist). This allows entering a portrait if the character is specified by a variable or a color if the character is likely temporary.

## Update plugin version to Alpha 19 (Godot 4.4+)