### PR TITLE
Background Layer options

### DIFF
--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -425,13 +425,17 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 			input.color_changed.connect(DialogicUtil._on_export_color_submitted.bind(property_info.name, property_changed))
 			input.custom_minimum_size.x = get_editor_scale() * 50
 		TYPE_INT:
-			if property_info['hint'] & PROPERTY_HINT_ENUM == PROPERTY_HINT_ENUM:
+			if property_info["hint"] & PROPERTY_HINT_ENUM == PROPERTY_HINT_ENUM:
 				input = OptionButton.new()
-				for x in property_info['hint_string'].split(','):
-					input.add_item(x.split(':')[0])
-				if value != null:
-					input.select(value)
-				input.item_selected.connect(DialogicUtil._on_export_int_enum_submitted.bind(property_info.name, property_changed))
+				var idx := 0
+				for x in property_info["hint_string"].split(","):
+					input.add_item(x.split(":")[0])
+					var id := int(x.split(":")[1])
+					input.set_item_metadata(idx, id)
+					if value == id:
+						input.select(idx)
+					idx += 1
+				input.item_selected.connect(DialogicUtil._on_export_int_enum_submitted.bind(property_info.name, property_changed, input))
 			else:
 				input = load("res://addons/dialogic/Editor/Events/Fields/field_number.tscn").instantiate()
 				input.property_name = property_info['name']
@@ -530,8 +534,8 @@ static func _on_export_bool_submitted(value:bool, property_name:String, callable
 static func _on_export_color_submitted(color:Color, property_name:String, callable: Callable) -> void:
 	callable.call(property_name, var_to_str(color))
 
-static func _on_export_int_enum_submitted(item:int, property_name:String, callable: Callable) -> void:
-	callable.call(property_name, var_to_str(item))
+static func _on_export_int_enum_submitted(item:int, property_name:String, callable: Callable, option_button:OptionButton) -> void:
+	callable.call(property_name, var_to_str(option_button.get_item_metadata(item)))
 
 static func _on_export_number_submitted(property_name:String, value:float, callable: Callable) -> void:
 	callable.call(property_name, var_to_str(value))
@@ -554,6 +558,22 @@ static func _on_export_vectori_submitted(property_name:String, value:Variant, ca
 
 static func _on_export_dict_submitted(property_name:String, value:Variant, callable: Callable) -> void:
 	callable.call(property_name, var_to_str(value))
+
+static func set_property_edit_node_value(node:Control, value:Variant) -> void:
+	if node is CheckBox:
+		node.button_pressed = value
+	elif node is LineEdit:
+		node.text = value
+	elif node.has_method("set_value"):
+		node.set_value(value)
+	elif node is ColorPickerButton:
+		node.color = value
+	elif node is OptionButton:
+		for i in range(node.item_count):
+			if node.get_item_metadata(i) == value:
+				node.select(i)
+	elif node is SpinBox:
+		node.value = value
 
 #endregion
 

--- a/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
@@ -92,6 +92,7 @@ func update_background(scene := "", argument := "", fade_time := 0.0, transition
 		old_viewport = background_holder.get_meta('current_viewport', null)
 
 	var new_viewport: SubViewportContainer
+	
 	if scene.ends_with('.tscn') and ResourceLoader.exists(scene):
 		new_viewport = add_background_node(load(scene), background_holder)
 	elif argument:
@@ -175,7 +176,16 @@ func add_background_node(scene:PackedScene, parent:DialogicNode_BackgroundHolder
 	viewport.transparent_bg = true
 	viewport.disable_3d = true
 	viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
-	viewport.canvas_item_default_texture_filter = ProjectSettings.get_setting("rendering/textures/canvas_textures/default_texture_filter")
+
+	if parent.get_parent().get('bg_texture_filter') != null and parent.get_parent().bg_texture_filter > -1:
+		viewport.canvas_item_default_texture_filter = parent.get_parent().bg_texture_filter
+	else:
+		viewport.canvas_item_default_texture_filter = ProjectSettings.get_setting("rendering/textures/canvas_textures/default_texture_filter")
+
+	if parent.get_parent().get('bg_texture_repeat') != null and parent.get_parent().bg_texture_repeat > -1:
+		viewport.canvas_item_default_texture_repeat = parent.get_parent().bg_texture_repeat
+	else:
+		viewport.canvas_item_default_texture_repeat = ProjectSettings.get_setting("rendering/textures/canvas_textures/default_texture_repeat")
 
 	viewport.add_child(b_scene)
 	b_scene.viewport = viewport

--- a/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
@@ -92,7 +92,7 @@ func update_background(scene := "", argument := "", fade_time := 0.0, transition
 		old_viewport = background_holder.get_meta('current_viewport', null)
 
 	var new_viewport: SubViewportContainer
-	
+
 	if scene.ends_with('.tscn') and ResourceLoader.exists(scene):
 		new_viewport = add_background_node(load(scene), background_holder)
 	elif argument:
@@ -177,12 +177,12 @@ func add_background_node(scene:PackedScene, parent:DialogicNode_BackgroundHolder
 	viewport.disable_3d = true
 	viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
 
-	if parent.get_parent().get('bg_texture_filter') != null and parent.get_parent().bg_texture_filter > -1:
+	if parent.get_parent().get("bg_texture_filter") != null and parent.get_parent().bg_texture_filter > -1:
 		viewport.canvas_item_default_texture_filter = parent.get_parent().bg_texture_filter
 	else:
 		viewport.canvas_item_default_texture_filter = ProjectSettings.get_setting("rendering/textures/canvas_textures/default_texture_filter")
 
-	if parent.get_parent().get('bg_texture_repeat') != null and parent.get_parent().bg_texture_repeat > -1:
+	if parent.get_parent().get("bg_texture_repeat") != null and parent.get_parent().bg_texture_repeat > -1:
 		viewport.canvas_item_default_texture_repeat = parent.get_parent().bg_texture_repeat
 	else:
 		viewport.canvas_item_default_texture_repeat = ProjectSettings.get_setting("rendering/textures/canvas_textures/default_texture_repeat")

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.gd
@@ -1,2 +1,31 @@
 @tool
 extends DialogicLayoutLayer
+
+# Awkward way of doing this, but we need a 'none' default to preserve compatiblity
+# These enums are just copies of Viewport.DefaultCanvasItemTextureFilter
+enum DefaultCanvasItemTextureFilter {
+	USE_PROJECT_SETTINGS,
+	NEAREST,
+	LINEAR,
+	LINEAR_WITH_MIPMAPS,
+	NEAREST_WITH_MIPMAPS
+}
+
+# These enums are just copies of Viewport.DefaultCanvasItemTextureRepeat
+enum DefaultCanvasItemTextureRepeat {
+	USE_PROJECT_SETTINGS,
+	DISABLED,
+	ENABLED,
+	REPEAT_MIRROR
+}
+
+
+@export var bg_texture_filter : DefaultCanvasItemTextureFilter = DefaultCanvasItemTextureFilter.USE_PROJECT_SETTINGS
+@export var bg_texture_repeat : DefaultCanvasItemTextureRepeat = DefaultCanvasItemTextureRepeat.USE_PROJECT_SETTINGS
+
+
+func _ready() -> void:
+	# This is a work around to the style editor not accepting negative numbered enums
+	# This allows the enum values to properly match the Viewport defaults
+	bg_texture_filter = bg_texture_filter -1
+	bg_texture_repeat = bg_texture_repeat -1

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.gd
@@ -4,28 +4,21 @@ extends DialogicLayoutLayer
 # Awkward way of doing this, but we need a 'none' default to preserve compatiblity
 # These enums are just copies of Viewport.DefaultCanvasItemTextureFilter
 enum DefaultCanvasItemTextureFilter {
-	USE_PROJECT_SETTINGS,
-	NEAREST,
-	LINEAR,
-	LINEAR_WITH_MIPMAPS,
-	NEAREST_WITH_MIPMAPS
+	USE_PROJECT_SETTINGS=-1,
+	NEAREST=0,
+	LINEAR=1,
+	LINEAR_WITH_MIPMAPS=2,
+	NEAREST_WITH_MIPMAPS=3
 }
 
 # These enums are just copies of Viewport.DefaultCanvasItemTextureRepeat
 enum DefaultCanvasItemTextureRepeat {
-	USE_PROJECT_SETTINGS,
-	DISABLED,
-	ENABLED,
-	REPEAT_MIRROR
+	USE_PROJECT_SETTINGS=-1,
+	DISABLED=0,
+	ENABLED=1,
+	REPEAT_MIRROR=2
 }
 
 
 @export var bg_texture_filter : DefaultCanvasItemTextureFilter = DefaultCanvasItemTextureFilter.USE_PROJECT_SETTINGS
 @export var bg_texture_repeat : DefaultCanvasItemTextureRepeat = DefaultCanvasItemTextureRepeat.USE_PROJECT_SETTINGS
-
-
-func _ready() -> void:
-	# This is a work around to the style editor not accepting negative numbered enums
-	# This allows the enum values to properly match the Viewport defaults
-	bg_texture_filter = bg_texture_filter -1
-	bg_texture_repeat = bg_texture_repeat -1

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=3 format=3 uid="uid://c1k5m0w3r40xf"]
+[gd_scene format=3 uid="uid://c1k5m0w3r40xf"]
 
 [ext_resource type="Script" uid="uid://bqdylb4maacf0" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_FullBackground/full_background_layer.gd" id="1_tu40u"]
 [ext_resource type="Script" uid="uid://oxcjhq2817c7" path="res://addons/dialogic/Modules/Background/node_background_holder.gd" id="2_ghan2"]
 
-[node name="BackgroundLayer" type="Control"]
+[node name="BackgroundLayer" type="Control" unique_id=301919803]
+texture_filter = null
 layout_direction = 2
 layout_mode = 3
 anchors_preset = 15
@@ -12,8 +13,9 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_tu40u")
+texture_filter = null
 
-[node name="DialogicNode_BackgroundHolder" type="ColorRect" parent="."]
+[node name="DialogicNode_BackgroundHolder" type="ColorRect" parent="." unique_id=237541635]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -496,23 +496,9 @@ func set_export_override(property_name:String, value:String = "") -> void:
 func _on_export_override_reset(property_name:String) -> void:
 	current_style.remove_layer_setting(current_layer_id, property_name)
 	customization_editor_info[property_name]["reset"].disabled = true
-	set_customization_value(property_name, customization_editor_info[property_name]["orig"])
-
-
-func set_customization_value(property_name:String, value:Variant) -> void:
 	var node: Node = customization_editor_info[property_name]["node"]
-	if node is CheckBox:
-		node.button_pressed = value
-	elif node is LineEdit:
-		node.text = value
-	elif node.has_method("set_value"):
-		node.set_value(value)
-	elif node is ColorPickerButton:
-		node.color = value
-	elif node is OptionButton:
-		node.select(value)
-	elif node is SpinBox:
-		node.value = value
+	DialogicUtil.set_property_edit_node_value(node, customization_editor_info[property_name]["orig"])
+
 
 #endregion
 


### PR DESCRIPTION
Fix for #2424
Added adjustable settings to the background layer to override project settings for texture filtering and texture repeating.

Its a pretty straightforward PR, but the style editor 'hacks' to make it work are a touch annoying.

Line 180 and line 185 in Subsytem_backgrounds do use a parent.get_parent() i don't quite like, but is pretty safe in this context, but if there is a cleaner way to get to the background layer I'd rather do that. In addition I could pass the parameters to the background_holder, but that seemed a bit more annoying to do. Thoughts?