### PR TITLE
Settings Fixes / Improvements

### DIFF
--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -19,7 +19,7 @@ static func get_editor_scale() -> float:
 static func get_dialogic_plugin() -> Node:
 	for child in Engine.get_main_loop().get_root().get_children():
 		if child.get_class() == "EditorNode":
-			return child.get_node('DialogicPlugin')
+			return child.get_node("DialogicPlugin")
 	return null
 
 #endregion
@@ -134,6 +134,9 @@ static func pretty_name(file_path: String) -> String:
 
 #region EDITOR SETTINGS & COLORS
 ################################################################################
+
+const SETTING_HIDDEN_BUTTONS_DEFAULT := ["Setting", "History", "Save"]
+const SETTING_BUTTON_SECTION_ORDER := ["Main", "Flow", "Audio", "Visuals", "Logic", "Other", "Helpers"]
 
 static func set_editor_setting(setting:String, value:Variant) -> void:
 	var cfg := ConfigFile.new()

--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -512,6 +512,11 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 			input.property_name = property_info["name"]
 			input.set_value(value)
 			input.value_changed.connect(_on_export_dict_submitted.bind(property_changed))
+		TYPE_ARRAY:
+			input = load("res://addons/dialogic/Editor/Events/Fields/field_array.tscn").instantiate()
+			input.property_name = property_info["name"]
+			input.set_value(value)
+			input.value_changed.connect(_on_export_array_submitted.bind(property_changed))
 		TYPE_OBJECT:
 			input = load("res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn").instantiate()
 			input.hint_text = "Objects/Resources as settings are currently not supported. \nUse @export_file('*.extension') instead and load the resource once needed."
@@ -556,6 +561,9 @@ static func _on_export_vectori_submitted(property_name:String, value:Variant, ca
 	callable.call(property_name, var_to_str(value))
 
 static func _on_export_dict_submitted(property_name:String, value:Variant, callable: Callable) -> void:
+	callable.call(property_name, var_to_str(value))
+
+static func _on_export_array_submitted(property_name:String, value:Variant, callable: Callable) -> void:
 	callable.call(property_name, var_to_str(value))
 
 #endregion

--- a/addons/dialogic/Core/DialogicUtil.gd
+++ b/addons/dialogic/Core/DialogicUtil.gd
@@ -136,7 +136,7 @@ static func pretty_name(file_path: String) -> String:
 ################################################################################
 
 const SETTING_HIDDEN_BUTTONS_DEFAULT := ["Setting", "History", "Save"]
-const SETTING_BUTTON_SECTION_ORDER := ["Main", "Flow", "Audio", "Visuals", "Logic", "Other", "Helpers"]
+const SETTING_BUTTON_SECTION_ORDER := ["Main", "Flow", "Audio", "Visuals", "Logic", "Other"]
 
 static func set_editor_setting(setting:String, value:Variant) -> void:
 	var cfg := ConfigFile.new()

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -53,10 +53,10 @@ func _ready() -> void:
 	%Logo.texture = load("res://addons/dialogic/Editor/Images/dialogic-logo.svg")
 	%Logo.custom_minimum_size.y = 30 * editor_scale
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
-	
-	## RESOURCE LIST OPTIONS MENU 
+
+	## RESOURCE LIST OPTIONS MENU
 	%Options.icon = get_theme_icon("GuiTabMenuHl", "EditorIcons")
-	
+
 	var grouping_menu := PopupMenu.new()
 	#grouping_menu.hide_on_item_selection = false
 	grouping_menu.hide_on_checkable_item_selection = false
@@ -64,7 +64,7 @@ func _ready() -> void:
 	grouping_menu.add_icon_radio_check_item(get_theme_icon("Folder", "EditorIcons"), "By Type", 1)
 	grouping_menu.add_icon_radio_check_item(get_theme_icon("FolderBrowse", "EditorIcons"), "By Folder", 2)
 	grouping_menu.add_icon_radio_check_item(get_theme_icon("AnimationTrackGroup", "EditorIcons"), "By Path", 3)
-	
+
 	var options_popup: PopupMenu = %Options.get_popup()
 	options_popup.hide_on_checkable_item_selection = false
 	options_popup.add_submenu_node_item("Grouping", grouping_menu)
@@ -72,7 +72,7 @@ func _ready() -> void:
 	options_popup.add_check_item("Trim Folder Paths", 12)
 	options_popup.add_item("List All", 21)
 	options_popup.add_item("Clear List", 22)
-	
+
 	grouping_menu.id_pressed.connect(_on_grouping_changed)
 	options_popup.id_pressed.connect(_on_resource_list_options_id_pressed)
 
@@ -112,7 +112,7 @@ func _ready() -> void:
 		idx += 1
 
 	%MainVSplit.split_offset = DialogicUtil.get_editor_setting("sidebar_v_split", 0)
-	
+
 	group_mode = DialogicUtil.get_editor_setting("sidebar_group_mode", GroupMode.TYPE)
 	grouping_menu.set_item_checked(grouping_menu.get_item_index(group_mode), true)
 	options_popup.set_item_checked(options_popup.get_item_index(11), DialogicUtil.get_editor_setting("sidebar_use_folder_colors", true))
@@ -508,12 +508,12 @@ func update_content_list() -> void:
 	if not current_resource is DialogicTimeline:
 		%ContentListSection.hide()
 		return
-	
+
 	var current_labels := DialogicResourceUtil.get_label_cache().get(current_resource.get_identifier(), [])
 	if current_labels.is_empty():
 		%ContentListSection.hide()
 		return
-	
+
 	var prev_selected := ""
 	if %ContentList.is_anything_selected():
 		prev_selected = %ContentList.get_item_text(%ContentList.get_selected_items()[0])
@@ -525,7 +525,7 @@ func update_content_list() -> void:
 		%ContentList.add_item(i)
 		if i == prev_selected:
 			%ContentList.select(%ContentList.item_count - 1)
-	
+
 	%ContentListSection.show()
 
 #endregion
@@ -535,7 +535,7 @@ func update_content_list() -> void:
 func _on_resource_list_options_id_pressed(id:int) -> void:
 	var popup: PopupMenu = %Options.get_popup()
 	var index := popup.get_item_index(id)
-	
+
 	match id:
 		11: # Folder Colors
 			popup.toggle_item_checked(index)
@@ -559,7 +559,7 @@ func _on_resource_list_options_id_pressed(id:int) -> void:
 func _on_grouping_changed(id: int) -> void:
 	if not (GroupMode as Dictionary).values().has(id):
 		return
-	
+
 	group_mode = (id as GroupMode)
 	DialogicUtil.set_editor_setting("sidebar_group_mode", id)
 	reload_resource_list_from_grouping()
@@ -567,33 +567,33 @@ func _on_grouping_changed(id: int) -> void:
 
 func reload_resource_list_from_grouping() -> void:
 	update_resource_list()
-	
+
 	if group_mode == GroupMode.NONE:
 		%ResourceTree.add_theme_constant_override("item_margin", 0)
 	else:
 		%ResourceTree.remove_theme_constant_override("item_margin")
-	
+
 	var popup: PopupMenu = %Options.get_popup()
 	var grouping_menu := popup.get_item_submenu_node(0)
 	for index in range(grouping_menu.item_count):
 		grouping_menu.set_item_checked(index, grouping_menu.get_item_id(index) == group_mode)
 	popup.set_item_disabled(popup.get_item_index(11), group_mode != GroupMode.PATH)
 	popup.set_item_disabled(popup.get_item_index(12), group_mode != GroupMode.PATH)
-	
+
 	var index := grouping_menu.get_item_index(group_mode)
 	popup.set_item_icon(0, grouping_menu.get_item_icon(index))
-	
+
 
 func list_all() -> void:
 	var character_directory: Dictionary = DialogicResourceUtil.get_character_directory()
 	var timeline_directory: Dictionary = DialogicResourceUtil.get_timeline_directory()
-	
+
 	var resource_list := []
 	for i in character_directory:
 		resource_list.append(character_directory[i])
 	for i in timeline_directory:
 		resource_list.append(timeline_directory[i])
-	
+
 	DialogicUtil.set_editor_setting("last_resources", resource_list)
 
 #endregion
@@ -621,7 +621,7 @@ func add_button(icon: Texture, label:String, tooltip: String, placement:int) -> 
 	button.tooltip_text = tooltip
 	button.theme_type_variation = "FlatButton"
 	button.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	
+
 	match placement:
 		editors_manager.ButtonPlacement.SIDEBAR_LEFT_OF_FILTER:
 			%LeftTools.add_child(button)

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -91,7 +91,7 @@ func _ready() -> void:
 	%RightClickItemMenu.add_icon_item(get_theme_icon("ActionCopy", "EditorIcons"), "Copy Identifier", 4)
 	%RightClickItemMenu.add_separator()
 	%RightClickItemMenu.add_icon_item(
-		get_theme_icon("Filesystem", "EditorIcons"), "Show in FileSystem", 2
+		get_theme_icon("ShowInFileSystem", "EditorIcons"), "Show in FileSystem", 2
 	)
 	%RightClickItemMenu.add_icon_item(
 		get_theme_icon("ExternalLink", "EditorIcons"), "Open in External Program", 3

--- a/addons/dialogic/Editor/Common/update_install_window.gd
+++ b/addons/dialogic/Editor/Common/update_install_window.gd
@@ -66,10 +66,10 @@ func load_info(info:Dictionary, update_type:int) -> void:
 		var reactions := {"laugh":"😂", "hooray":"🎉", "confused":"😕", "heart":"❤️", "rocket":"🚀", "eyes":"👀"}
 		for i in reactions:
 			%Reactions.get_node(i.capitalize()).visible = info.reactions[i] > 0
-			%Reactions.get_node(i.capitalize()).text = reactions[i]+" "+str(info.reactions[i]) if info.reactions[i] > 0 else reactions[i]
+			%Reactions.get_node(i.capitalize()).text = reactions[i]+" "+str(int(info.reactions[i])) if info.reactions[i] > 0 else reactions[i]
 		if info.reactions['+1']+info.reactions['-1'] > 0:
 			%Reactions.get_node("Likes").visible = true
-			%Reactions.get_node("Likes").text = "👍 "+str(info.reactions['+1']+info.reactions['-1'])
+			%Reactions.get_node("Likes").text = "👍 "+str(int(info.reactions['+1']+info.reactions['-1']))
 		else:
 			%Reactions.get_node("Likes").visible = false
 	else:

--- a/addons/dialogic/Editor/Common/update_install_window.tscn
+++ b/addons/dialogic/Editor/Common/update_install_window.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://vv3m5m68fwg7"]
+[gd_scene format=3 uid="uid://vv3m5m68fwg7"]
 
 [ext_resource type="Script" uid="uid://cskkip1wso0pu" path="res://addons/dialogic/Editor/Common/update_install_window.gd" id="1_p1pbx"]
 [ext_resource type="Texture2D" uid="uid://dybg3l5pwetne" path="res://addons/dialogic/Editor/Images/plugin-icon.svg" id="2_20ke0"]
@@ -48,7 +48,7 @@ corner_radius_top_right = 10
 corner_radius_bottom_right = 10
 corner_radius_bottom_left = 10
 
-[node name="UpdateInstallWindow" type="ColorRect"]
+[node name="UpdateInstallWindow" type="ColorRect" unique_id=1751342581]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -57,7 +57,7 @@ grow_vertical = 2
 color = Color(0.207843, 0.129412, 0.372549, 1)
 script = ExtResource("1_p1pbx")
 
-[node name="TextureRect" type="TextureRect" parent="."]
+[node name="TextureRect" type="TextureRect" parent="." unique_id=1067467084]
 modulate = Color(0.447059, 0.447059, 0.447059, 1)
 layout_mode = 1
 anchors_preset = 15
@@ -67,7 +67,7 @@ grow_horizontal = 2
 grow_vertical = 2
 texture = SubResource("GradientTexture2D_nl8ke")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1887947658]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -79,49 +79,49 @@ offset_bottom = -13.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer" unique_id=1695024647]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2"]
+[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2" unique_id=43588118]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 7
 
-[node name="VBox" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2"]
+[node name="VBox" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2" unique_id=1370860413]
 custom_minimum_size = Vector2(450, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 3.74
 alignment = 1
 
-[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer2/VBox"]
+[node name="ScrollContainer" type="ScrollContainer" parent="VBoxContainer/HBoxContainer2/VBox" unique_id=1215114222]
 clip_contents = false
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer" unique_id=1069603042]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 alignment = 1
 
-[node name="Panel" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer"]
+[node name="Panel" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer" unique_id=508342753]
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_1g1am")
 
-[node name="VBox" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel"]
+[node name="VBox" type="VBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel" unique_id=1356546827]
 layout_mode = 2
 theme_override_constants/separation = -8
 
-[node name="State" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox"]
+[node name="State" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox" unique_id=304146972]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"DialogicSubTitle"
 text = "Update Available!"
 
-[node name="UpdateName" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox"]
+[node name="UpdateName" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox" unique_id=1703854451]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"DialogicTitle"
@@ -129,14 +129,14 @@ theme_override_font_sizes/font_size = 25
 text = "Dialogic 2.0 - alpha 9"
 uppercase = true
 
-[node name="ShortInfo" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox"]
+[node name="ShortInfo" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel/VBox" unique_id=376285222]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"DialogicHintText2"
 theme_override_font_sizes/font_size = 10
 text = "12/31/23"
 
-[node name="Refresh" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel"]
+[node name="Refresh" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Panel" unique_id=1130499877]
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
@@ -144,7 +144,7 @@ text = "Refresh
 "
 flat = true
 
-[node name="Content" type="RichTextLabel" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer"]
+[node name="Content" type="RichTextLabel" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer" unique_id=1067043036]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -158,97 +158,97 @@ This alpha brings a couple of very useful new features to dialogic as well as so
 "
 fit_content = true
 
-[node name="Reactions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer"]
+[node name="Reactions" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer" unique_id=11798362]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Likes" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Likes" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=636944493]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "👍12"
 
-[node name="Hooray" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Hooray" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=949185995]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "🎉12"
 
-[node name="Laugh" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Laugh" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=183203802]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "👀12"
 
-[node name="Heart" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Heart" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=71371725]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "❤️12"
 
-[node name="Rocket" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Rocket" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=1656086777]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "😕12"
 
-[node name="Eyes" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Eyes" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=1808937606]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "🚀12"
 
-[node name="Confused" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="Confused" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=579545502]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 theme_override_styles/normal = SubResource("StyleBoxFlat_h4v2s")
 text = "😂12"
 
-[node name="ReadFull" type="LinkButton" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions"]
+[node name="ReadFull" type="LinkButton" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/Reactions" unique_id=2012014614]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 10
 text = "Read Full Announcement"
 
-[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer"]
+[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer" unique_id=1517373925]
 custom_minimum_size = Vector2(0, 20)
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer" unique_id=1651367355]
 layout_mode = 2
 alignment = 2
 
-[node name="InfoLabel" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="InfoLabel" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=607109208]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 horizontal_alignment = 2
 autowrap_mode = 3
 
-[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer" unique_id=1270745302]
 self_modulate = Color(0, 0, 0, 1)
 layout_mode = 2
 size_flags_horizontal = 4
 theme_override_styles/panel = SubResource("StyleBoxFlat_h4v2s")
 
-[node name="HBox" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="HBox" type="HBoxContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer" unique_id=741493187]
 layout_mode = 2
 alignment = 2
 
-[node name="Loading" type="CenterContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox"]
+[node name="Loading" type="CenterContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox" unique_id=1139489247]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
 
-[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Loading"]
+[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Loading" unique_id=119536783]
 layout_mode = 2
 
-[node name="LoadingIcon" type="Sprite2D" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Loading/Control"]
+[node name="LoadingIcon" type="Sprite2D" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Loading/Control" unique_id=1767382840]
 unique_name_in_owner = true
 texture = ExtResource("2_20ke0")
 
-[node name="Restart" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox"]
+[node name="Restart" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox" unique_id=987427271]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -256,14 +256,14 @@ size_flags_vertical = 4
 text = "Restart Now"
 flat = true
 
-[node name="Install" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox"]
+[node name="Install" type="Button" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox" unique_id=1595717196]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 4
 text = "Install"
 flat = true
 
-[node name="InstallWarning" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Install"]
+[node name="InstallWarning" type="PanelContainer" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Install" unique_id=205031465]
 unique_name_in_owner = true
 visible = false
 self_modulate = Color(0, 0, 0, 1)
@@ -278,23 +278,23 @@ offset_bottom = -8.0
 grow_horizontal = 0
 theme_override_styles/panel = SubResource("StyleBoxFlat_utju1")
 
-[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Install/InstallWarning"]
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer2/VBox/ScrollContainer/VBoxContainer/HBoxContainer/PanelContainer/HBox/Install/InstallWarning" unique_id=941681170]
 layout_mode = 2
 theme_override_font_sizes/font_size = 14
 text = "Be careful. This will delete the addons/dialogic folder and install the new version. Any custom changes in that folder will be lost.
 To be on the safe side, use version control!"
 autowrap_mode = 3
 
-[node name="Control2" type="Control" parent="VBoxContainer/HBoxContainer2"]
+[node name="Control2" type="Control" parent="VBoxContainer/HBoxContainer2" unique_id=1569425188]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 7
 
-[node name="Close" type="HBoxContainer" parent="VBoxContainer"]
+[node name="Close" type="HBoxContainer" parent="VBoxContainer" unique_id=871931908]
 layout_mode = 2
 alignment = 1
 
-[node name="CloseButton" type="Button" parent="VBoxContainer/Close"]
+[node name="CloseButton" type="Button" parent="VBoxContainer/Close" unique_id=589871687]
 unique_name_in_owner = true
 layout_mode = 2
 text = "Close"

--- a/addons/dialogic/Editor/Events/EventBlock/event_right_click_menu.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_right_click_menu.gd
@@ -4,6 +4,8 @@ extends PopupMenu
 var current_event: Node = null
 
 func _ready() -> void:
+	if owner.get_parent() is SubViewport:
+		return
 	clear()
 	add_icon_item(get_theme_icon("Duplicate", "EditorIcons"), "Duplicate", 0)
 	add_separator()
@@ -19,6 +21,5 @@ func _ready() -> void:
 
 	var menu_background := StyleBoxFlat.new()
 	menu_background.bg_color = get_parent().get_theme_color("base_color", "Editor")
-	add_theme_stylebox_override('panel', menu_background)
-	add_theme_stylebox_override('hover', get_theme_stylebox("FocusViewport", "EditorStyles"))
-	add_theme_color_override('font_color_hover', get_parent().get_theme_color("accent_color", "Editor"))
+	add_theme_stylebox_override("panel", menu_background)
+	add_theme_stylebox_override("hover", get_theme_stylebox("FocusViewport", "EditorStyles"))

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_editor.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_editor.tscn
@@ -1,21 +1,19 @@
-[gd_scene load_steps=5 format=3 uid="uid://dbdmosh6v536s"]
+[gd_scene format=3 uid="uid://dbdmosh6v536s"]
 
 [ext_resource type="Script" uid="uid://3akc4p71r5rn" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/settings_editor.gd" id="1_kdw7t"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_ey6hj"]
 
-[sub_resource type="Image" id="Image_1n4qk"]
-data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
+[sub_resource type="DPITexture" id="DPITexture_1n4qk"]
+_source = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\"><path fill=\"#e0e0e0\" d=\"M5 8a4 4 0 1 1 4 4v2a6 6 0 1 0-6-6H1l3 4 3-4z\"/></svg>
+"
+saturation = 2.0
+color_map = {
+Color(1, 0.37254903, 0.37254903, 1): Color(1, 0.47, 0.42, 1),
+Color(0.37254903, 1, 0.5921569, 1): Color(0.45, 0.95, 0.5, 1),
+Color(1, 0.8666667, 0.39607844, 1): Color(0.83, 0.78, 0.62, 1)
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_dfv70"]
-image = SubResource("Image_1n4qk")
-
-[node name="EditorSettingsPage" type="VBoxContainer"]
+[node name="EditorSettingsPage" type="VBoxContainer" unique_id=350772692]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -23,67 +21,67 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_kdw7t")
 
-[node name="PaletteTitle" type="HBoxContainer" parent="."]
+[node name="PaletteTitle" type="HBoxContainer" parent="." unique_id=270077919]
 layout_mode = 2
 
-[node name="SectionPaletteTitle" type="Label" parent="PaletteTitle"]
+[node name="SectionPaletteTitle" type="Label" parent="PaletteTitle" unique_id=1363742507]
 layout_mode = 2
 theme_type_variation = &"DialogicSettingsSection"
 text = "Color Palette"
 
-[node name="HintTooltip" parent="PaletteTitle" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="PaletteTitle" unique_id=1435911909 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 tooltip_text = "These colors are used for the events."
 texture = null
 hint_text = "These colors are used for the events."
 
-[node name="ResetColorsButton" type="Button" parent="PaletteTitle"]
+[node name="ResetColorsButton" type="Button" parent="PaletteTitle" unique_id=1870170187]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
 tooltip_text = "Reset Colors to default"
-icon = SubResource("ImageTexture_dfv70")
+icon = SubResource("DPITexture_1n4qk")
 flat = true
 
-[node name="ScrollContainer" type="ScrollContainer" parent="."]
+[node name="ScrollContainer" type="ScrollContainer" parent="." unique_id=485517901]
 layout_mode = 2
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 0
 
-[node name="Colors" type="HBoxContainer" parent="ScrollContainer"]
+[node name="Colors" type="HBoxContainer" parent="ScrollContainer" unique_id=1470285736]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="HSeparator" type="HSeparator" parent="."]
+[node name="HSeparator" type="HSeparator" parent="." unique_id=1945618169]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TimelineTitle" type="HBoxContainer" parent="."]
+[node name="TimelineTitle" type="HBoxContainer" parent="." unique_id=2051880068]
 layout_mode = 2
 
-[node name="SectionTimelineTitle" type="Label" parent="TimelineTitle"]
+[node name="SectionTimelineTitle" type="Label" parent="TimelineTitle" unique_id=1907156909]
 layout_mode = 2
 theme_type_variation = &"DialogicSettingsSection"
 text = "Visual Events"
 
-[node name="HintTooltip" parent="TimelineTitle" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="TimelineTitle" unique_id=1668214215 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 texture = null
 hint_text = "These settings affect the visual timeline editor."
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
+[node name="HBoxContainer" type="HBoxContainer" parent="." unique_id=1886023306]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="HBoxContainer"]
+[node name="Label" type="Label" parent="HBoxContainer" unique_id=217792898]
 layout_mode = 2
 text = "Image preview height"
 
-[node name="HintTooltip" parent="HBoxContainer" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="HBoxContainer" unique_id=862001461 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 texture = null
 hint_text = "If set to 0, image previews will be disabled."
 
-[node name="ImagePreviewHeight" type="SpinBox" parent="HBoxContainer"]
+[node name="ImagePreviewHeight" type="SpinBox" parent="HBoxContainer" unique_id=1027247449]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
@@ -92,19 +90,19 @@ update_on_text_changed = true
 suffix = "px"
 select_all_on_focus = true
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="."]
+[node name="HBoxContainer2" type="HBoxContainer" parent="." unique_id=2053565497]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="HBoxContainer2"]
+[node name="Label" type="Label" parent="HBoxContainer2" unique_id=670998033]
 layout_mode = 2
 text = "Event block bottom margin"
 
-[node name="HintTooltip" parent="HBoxContainer2" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="HBoxContainer2" unique_id=908718778 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 texture = null
 hint_text = "This adds extra space at the bottom of event blocks."
 
-[node name="EventBlockMargin" type="SpinBox" parent="HBoxContainer2"]
+[node name="EventBlockMargin" type="SpinBox" parent="HBoxContainer2" unique_id=70188244]
 unique_name_in_owner = true
 layout_mode = 2
 rounded = true
@@ -113,40 +111,40 @@ update_on_text_changed = true
 suffix = "px"
 select_all_on_focus = true
 
-[node name="HBoxContainer3" type="HBoxContainer" parent="."]
+[node name="HBoxContainer3" type="HBoxContainer" parent="." unique_id=1463499383]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="HBoxContainer3"]
+[node name="Label" type="Label" parent="HBoxContainer3" unique_id=721551439]
 layout_mode = 2
 text = "Show event names"
 
-[node name="HintTooltip" parent="HBoxContainer3" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="HBoxContainer3" unique_id=2082656670 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 texture = null
 hint_text = "Enabling this prepends the event name at the beginning of event blocks."
 
-[node name="ShowEventNames" type="CheckButton" parent="HBoxContainer3"]
+[node name="ShowEventNames" type="CheckButton" parent="HBoxContainer3" unique_id=1287811586]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="HSeparator5" type="HSeparator" parent="."]
+[node name="HSeparator5" type="HSeparator" parent="." unique_id=680318321]
 layout_mode = 2
 
-[node name="HBoxContainer4" type="HBoxContainer" parent="."]
+[node name="HBoxContainer4" type="HBoxContainer" parent="." unique_id=1665334534]
 layout_mode = 2
 
-[node name="SectionSections" type="Label" parent="HBoxContainer4"]
+[node name="SectionSections" type="Label" parent="HBoxContainer4" unique_id=1655583662]
 layout_mode = 2
 theme_type_variation = &"DialogicSettingsSection"
 text = "Section Order"
 
-[node name="HintTooltip" parent="HBoxContainer4" instance=ExtResource("2_ey6hj")]
+[node name="HintTooltip" parent="HBoxContainer4" unique_id=1476589096 instance=ExtResource("2_ey6hj")]
 layout_mode = 2
 tooltip_text = "You can change the order of the event sections here. "
 texture = null
 hint_text = "You can change the order of the event sections here. "
 
-[node name="SectionList" type="Tree" parent="."]
+[node name="SectionList" type="Tree" parent="." unique_id=1717025163]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(150, 150)
 layout_mode = 2

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
@@ -42,7 +42,7 @@ func _on_refresh_pressed() -> void:
 	load_modules_tree()
 
 
-func filters_updated(fake_arg:Variant) -> void:
+func filters_updated(_fake_arg:Variant) -> void:
 	load_modules_tree()
 
 
@@ -62,8 +62,6 @@ func _on_search_text_changed(new_text:String) -> void:
 	for filter in [%Filter_Events, %Filter_Subsystems, %Filter_Editors, %Filter_EffectsAndModifiers, %Filter_Settings, %Filter_Styles]:
 		filter.text = ""
 		filter.set_meta("counter", 0)
-
-	var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', [])
 
 	for child in %Tree.get_root().get_children():
 		if new_text.to_lower() in child.get_text(0).to_lower() or new_text.is_empty():
@@ -103,7 +101,8 @@ func load_modules_tree() -> void:
 	%Tree.clear()
 	var root: TreeItem = %Tree.create_item()
 	var cached_events := DialogicResourceUtil.get_event_cache()
-	var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', [])
+	var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
+
 	var indexers := DialogicUtil.get_indexers()
 	for i in indexers:
 		var module_item: TreeItem = %Tree.create_item(root)
@@ -120,10 +119,10 @@ func load_modules_tree() -> void:
 				if cached_event.get_script().resource_path == ev:
 					event_item.set_text(0, cached_event.event_name + " Event")
 					event_item.set_icon_modulate(0, cached_event.event_color)
-					var hidden: bool = cached_event.event_name in hidden_events
-					event_item.set_metadata(0, {'type':'Event', 'event':cached_event, 'hidden':hidden})
+					var is_hidden: bool = cached_event.event_name in hidden_events
+					event_item.set_metadata(0, {'type':'Event', 'event':cached_event, 'hidden':is_hidden})
 					event_item.add_button(0, get_theme_icon("GuiVisibilityVisible", "EditorIcons"), 0, false, "Toggle Event Button Visibility")
-					if hidden:
+					if is_hidden:
 						event_item.set_button(0, 0, get_theme_icon("GuiVisibilityHidden", "EditorIcons"))
 			event_item.set_meta('filter_button', %Filter_Events)
 			event_item.visible = %Filter_Events.button_pressed
@@ -194,7 +193,7 @@ func load_modules_tree() -> void:
 	if %Tree.get_root().get_child_count(): %Tree.set_selected(%Tree.get_root().get_child(0), 0)
 
 
-func _on_tree_button_clicked(item:TreeItem, column:int, id:int, mouse_button_index:int) -> void:
+func _on_tree_button_clicked(item:TreeItem, _column:int, id:int, _mouse_button_index:int) -> void:
 	match item.get_metadata(0)['type']:
 		'Module':
 			item.collapsed = false
@@ -270,7 +269,7 @@ func _on_tree_item_selected() -> void:
 			'Settings':
 				%GeneralInfo.text = "Settings pages provide settings that are usually used by subsystems, events and dialogic nodes."
 			# -------------------------------------------------
-			'_':
+			_:
 				%GeneralInfo.text = ""
 
 

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
@@ -19,16 +19,21 @@ func _ready() -> void:
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
 
 	%Filter_Events.icon = get_theme_icon("Favorites", "EditorIcons")
-	%Filter_Subsystems.icon = get_theme_icon("Callable", "EditorIcons")
+	%Filter_Subsystems.icon = get_theme_icon("Panels1", "EditorIcons")
 	%Filter_Styles.icon = get_theme_icon("PopupMenu", "EditorIcons")
 	%Filter_EffectsAndModifiers.icon = get_theme_icon("RichTextEffect", "EditorIcons")
 	%Filter_Editors.icon = get_theme_icon("ConfirmationDialog", "EditorIcons")
 	%Filter_Settings.icon = get_theme_icon("PluginScript", "EditorIcons")
 	%Collapse.icon = get_theme_icon("CollapseTree", "EditorIcons")
-
-	%EventDefaultsPanel.add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
+	for i in %Filters.get_children():
+		i.add_theme_color_override("icon_pressed_color", i.get_theme_color("font_pressed_color"))
+		i.add_theme_color_override("icon_hover_color", i.get_theme_color("font_hover_color"))
+		i.add_theme_color_override("icon_hover_pressed_color", i.get_theme_color("font_hover_pressed_color"))
 
 	%ExternalLink.icon = get_theme_icon("Help", "EditorIcons")
+	%ShowInFileSystem.icon = get_theme_icon("ShowInFileSystem", "EditorIcons")
+	%Documentation.icon = get_theme_icon("Help", "EditorIcons")
+	%Open.icon = get_theme_icon("Script", "EditorIcons")
 
 
 func _refresh() -> void:
@@ -42,8 +47,20 @@ func _on_refresh_pressed() -> void:
 	load_modules_tree()
 
 
-func filters_updated(_fake_arg:Variant) -> void:
+func _on_filter_toggled(toggled_on: bool, source: BaseButton) -> void:
+	if Input.is_key_pressed(KEY_SHIFT):
+		if not toggled_on:
+			for button in %Filters.get_children():
+				if button.button_pressed:
+					toggled_on = true
+					break
+		for button in %Filters.get_children():
+			if button != source:
+				button.set_pressed_no_signal(not toggled_on)
+			else:
+				button.set_pressed_no_signal(toggled_on)
 	load_modules_tree()
+
 
 
 func _on_collapse_toggled(button_pressed:bool) -> void:
@@ -59,24 +76,24 @@ func _on_collapse_toggled(button_pressed:bool) -> void:
 
 
 func _on_search_text_changed(new_text:String) -> void:
-	for filter in [%Filter_Events, %Filter_Subsystems, %Filter_Editors, %Filter_EffectsAndModifiers, %Filter_Settings, %Filter_Styles]:
+	for filter in %Filters.get_children():
 		filter.text = ""
 		filter.set_meta("counter", 0)
 
 	for child in %Tree.get_root().get_children():
 		if new_text.to_lower() in child.get_text(0).to_lower() or new_text.is_empty():
 			for sub_child in child.get_children():
-				sub_child.visible = sub_child.get_meta('filter_button').button_pressed
-				sub_child.get_meta('filter_button').set_meta('counter', sub_child.get_meta('filter_button').get_meta('counter')+1)
-				sub_child.get_meta('filter_button').text = str(sub_child.get_meta('filter_button').get_meta('counter'))
+				sub_child.visible = sub_child.get_meta("filter_button").button_pressed
+				sub_child.get_meta("filter_button").set_meta("counter", sub_child.get_meta("filter_button").get_meta("counter")+1)
+				sub_child.get_meta("filter_button").text = str(sub_child.get_meta("filter_button").get_meta("counter"))
 			child.visible = true
 		else:
 			for sub_child in child.get_children():
-				sub_child.visible = sub_child.get_meta('filter_button').button_pressed and new_text.to_lower() in sub_child.get_text(0).to_lower()
+				sub_child.visible = sub_child.get_meta("filter_button").button_pressed and new_text.to_lower() in sub_child.get_text(0).to_lower()
 
 				if new_text.to_lower() in sub_child.get_text(0).to_lower():
-					sub_child.get_meta('filter_button').set_meta('counter', sub_child.get_meta('filter_button').get_meta('counter')+1)
-					sub_child.get_meta('filter_button').text = str(sub_child.get_meta('filter_button').get_meta('counter'))
+					sub_child.get_meta("filter_button").set_meta("counter", sub_child.get_meta("filter_button").get_meta("counter")+1)
+					sub_child.get_meta("filter_button").text = str(sub_child.get_meta("filter_button").get_meta("counter"))
 
 		for i in range(child.get_button_count(0)):
 			child.erase_button(0, child.get_button_count(0)-1)
@@ -85,7 +102,7 @@ func _on_search_text_changed(new_text:String) -> void:
 		for sub_child in child.get_children():
 			if sub_child.visible:
 				child.add_button(0, sub_child.get_icon(0), counter, false, sub_child.get_text(0))
-				if sub_child.get_metadata(0) and sub_child.get_metadata(0)['type'] == 'Event' and sub_child.get_metadata(0)['hidden']:
+				if sub_child.get_metadata(0) and sub_child.get_metadata(0)["type"] == "Event" and sub_child.get_metadata(0)["hidden"]:
 					var color: Color = sub_child.get_icon_modulate(0)
 					color.a = 0.5
 					child.set_button_color(0, counter, color)
@@ -96,18 +113,17 @@ func _on_search_text_changed(new_text:String) -> void:
 		child.visible = any_visible
 
 
-
 func load_modules_tree() -> void:
 	%Tree.clear()
 	var root: TreeItem = %Tree.create_item()
 	var cached_events := DialogicResourceUtil.get_event_cache()
-	var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
+	var hidden_events: Array = DialogicUtil.get_editor_setting("hidden_event_buttons", DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
 
 	var indexers := DialogicUtil.get_indexers()
 	for i in indexers:
 		var module_item: TreeItem = %Tree.create_item(root)
-		module_item.set_text(0, i.get_script().resource_path.trim_suffix('/index.gd').get_file())
-		module_item.set_metadata(0, {'type':'Module'})
+		module_item.set_text(0, i.get_script().resource_path.trim_suffix("/index.gd").get_file())
+		module_item.set_metadata(0, {"type":"Module", "info":i})
 
 		# Events
 		for ev in i._get_events():
@@ -120,21 +136,21 @@ func load_modules_tree() -> void:
 					event_item.set_text(0, cached_event.event_name + " Event")
 					event_item.set_icon_modulate(0, cached_event.event_color)
 					var is_hidden: bool = cached_event.event_name in hidden_events
-					event_item.set_metadata(0, {'type':'Event', 'event':cached_event, 'hidden':is_hidden})
+					event_item.set_metadata(0, {"type":"Event", "event":cached_event, "hidden":is_hidden})
 					event_item.add_button(0, get_theme_icon("GuiVisibilityVisible", "EditorIcons"), 0, false, "Toggle Event Button Visibility")
 					if is_hidden:
 						event_item.set_button(0, 0, get_theme_icon("GuiVisibilityHidden", "EditorIcons"))
-			event_item.set_meta('filter_button', %Filter_Events)
+			event_item.set_meta("filter_button", %Filter_Events)
 			event_item.visible = %Filter_Events.button_pressed
 
 		# Subsystems
 		for subsys in i._get_subsystems():
 			var subsys_item: TreeItem = %Tree.create_item(module_item)
-			subsys_item.set_icon(0, get_theme_icon("Callable", "EditorIcons"))
+			subsys_item.set_icon(0, get_theme_icon("Panels1", "EditorIcons"))
 			subsys_item.set_text(0, subsys.name + " Subsystem")
 			subsys_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
-			subsys_item.set_metadata(0, {'type':'Subsystem', 'info':subsys})
-			subsys_item.set_meta('filter_button', %Filter_Subsystems)
+			subsys_item.set_metadata(0, {"type":"Subsystem", "info":subsys})
+			subsys_item.set_meta("filter_button", %Filter_Subsystems)
 			subsys_item.visible = %Filter_Subsystems.button_pressed
 
 		# Style scenes
@@ -143,8 +159,8 @@ func load_modules_tree() -> void:
 			style_item.set_icon(0, get_theme_icon("PopupMenu", "EditorIcons"))
 			style_item.set_text(0, style.name)
 			style_item.set_icon_modulate(0, get_theme_color("property_color_x", "Editor"))
-			style_item.set_metadata(0, {'type':'Style', 'info':style})
-			style_item.set_meta('filter_button', %Filter_Styles)
+			style_item.set_metadata(0, {"type":"Style", "info":style})
+			style_item.set_meta("filter_button", %Filter_Styles)
 			style_item.visible = %Filter_Styles.button_pressed
 
 		# Text Effects
@@ -153,8 +169,8 @@ func load_modules_tree() -> void:
 			effect_item.set_icon(0, get_theme_icon("RichTextEffect", "EditorIcons"))
 			effect_item.set_text(0, "Text effect ["+effect.command+"]")
 			effect_item.set_icon_modulate(0, get_theme_color("property_color_z", "Editor"))
-			effect_item.set_metadata(0, {'type':'Effect', 'info':effect})
-			effect_item.set_meta('filter_button', %Filter_EffectsAndModifiers)
+			effect_item.set_metadata(0, {"type":"Effect", "info":effect})
+			effect_item.set_meta("filter_button", %Filter_EffectsAndModifiers)
 			effect_item.visible = %Filter_EffectsAndModifiers.button_pressed
 
 		# Text Modifiers
@@ -163,8 +179,8 @@ func load_modules_tree() -> void:
 			mod_item.set_icon(0, get_theme_icon("RichTextEffect", "EditorIcons"))
 			mod_item.set_text(0, mod.method.capitalize())
 			mod_item.set_icon_modulate(0, get_theme_color("property_color_z", "Editor"))
-			mod_item.set_metadata(0, {'type':'Modifier', 'info':mod})
-			mod_item.set_meta('filter_button', %Filter_EffectsAndModifiers)
+			mod_item.set_metadata(0, {"type":"Modifier", "info":mod})
+			mod_item.set_meta("filter_button", %Filter_EffectsAndModifiers)
 			mod_item.visible = %Filter_EffectsAndModifiers.button_pressed
 
 		# Settings
@@ -173,18 +189,18 @@ func load_modules_tree() -> void:
 			settings_item.set_icon(0, get_theme_icon("PluginScript", "EditorIcons"))
 			settings_item.set_text(0, module_item.get_text(0) + " Settings")
 			settings_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
-			settings_item.set_metadata(0, {'type':'Settings', 'info':settings})
-			settings_item.set_meta('filter_button', %Filter_Settings)
+			settings_item.set_metadata(0, {"type":"Settings", "info":settings})
+			settings_item.set_meta("filter_button", %Filter_Settings)
 			settings_item.visible = %Filter_Settings.button_pressed
 
 		# Editors
 		for editor in i._get_editors():
 			var editor_item: TreeItem = %Tree.create_item(module_item)
 			editor_item.set_icon(0, get_theme_icon("ConfirmationDialog", "EditorIcons"))
-			editor_item.set_text(0, editor.get_file().trim_suffix('.tscn').capitalize())
+			editor_item.set_text(0, editor.get_file().trim_suffix(".tscn").capitalize())
 			editor_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
-			editor_item.set_metadata(0, {'type':'Editor', 'info':editor})
-			editor_item.set_meta('filter_button', %Filter_Editors)
+			editor_item.set_metadata(0, {"type":"Editor", "info":editor})
+			editor_item.set_meta("filter_button", %Filter_Editors)
 			editor_item.visible = %Filter_Editors.button_pressed
 
 		module_item.collapsed = %Collapse.button_pressed
@@ -194,15 +210,15 @@ func load_modules_tree() -> void:
 
 
 func _on_tree_button_clicked(item:TreeItem, _column:int, id:int, _mouse_button_index:int) -> void:
-	match item.get_metadata(0)['type']:
-		'Module':
+	match item.get_metadata(0)["type"]:
+		"Module":
 			item.collapsed = false
 			%Tree.set_selected(item.get_child(id), 0)
-		'Event':
+		"Event":
 			# Visibility item clicked
 			if id == 0:
 				var meta: Dictionary= item.get_metadata(0)
-				if meta['hidden']:
+				if meta["hidden"]:
 					item.set_button(0, 0, get_theme_icon("GuiVisibilityVisible", "EditorIcons"))
 					item.get_parent().set_button_color(0, item.get_index(), item.get_icon_modulate(0))
 					if item == %Tree.get_selected():
@@ -214,9 +230,9 @@ func _on_tree_button_clicked(item:TreeItem, _column:int, id:int, _mouse_button_i
 					item.get_parent().set_button_color(0, item.get_index(), color)
 					if item == %Tree.get_selected():
 						%VisibilityToggle.button_pressed = false
-				meta['hidden'] = !meta['hidden']
+				meta["hidden"] = !meta["hidden"]
 				item.set_metadata(0, meta)
-				change_event_visibility(meta['event'], !meta['hidden'])
+				change_event_visibility(meta["event"], not meta["hidden"])
 
 
 func _on_tree_item_selected() -> void:
@@ -229,63 +245,77 @@ func _on_tree_item_selected() -> void:
 	%Icon.texture = null
 	%ExternalLink.hide()
 	%VisibilityToggle.hide()
+	%ShowInFileSystem.disabled = false
+	%Open.disabled = false
 
 	if metadata is Dictionary:
 		match metadata.type:
-			'Event':
+			"Event":
 				%GeneralInfo.text = "Events can be used in timelines and do all kinds of things. They often interact with subsystems and dialogic nodes."
 
-				load_event_settings(metadata.event)
 				if %EventDefaults.get_child_count():
 					%EventDefaultsPanel.show()
+				load_event_settings(metadata.event)
 
 				if metadata.event.help_page_path:
 					%ExternalLink.show()
-					%ExternalLink.set_meta('url', metadata.event.help_page_path)
+					%ExternalLink.set_meta("url", metadata.event.help_page_path)
 				%Icon.texture = metadata.event._get_icon()
-				if !metadata.event.disable_editor_button:
+				if not metadata.event.disable_editor_button:
 					%VisibilityToggle.show()
-					%VisibilityToggle.button_pressed = !metadata.event.event_name in DialogicUtil.get_editor_setting('hidden_event_buttons', [])
+					%VisibilityToggle.button_pressed = !metadata.event.event_name in DialogicUtil.get_editor_setting("hidden_event_buttons", [])
 					if %VisibilityToggle.button_pressed:
 						%VisibilityToggle.icon = get_theme_icon("GuiVisibilityVisible", "EditorIcons")
 					else:
 						%VisibilityToggle.icon = get_theme_icon("GuiVisibilityHidden", "EditorIcons")
+
 			# -------------------------------------------------
-			'Subsystem':
+			"Subsystem":
 				%GeneralInfo.text = "Subsystems hold specialized functionality. They mostly manage communication between events and dialogic nodes. Often they provide handy methods that can be accessed by the user like this: Dialogic.Subsystem.a_method()."
 			# -------------------------------------------------
-			'Effect':
+			"Effect":
 				%GeneralInfo.text = "Text effects can be used in text events. They will be executed once reached and can take a single argument."
+				%ShowInFileSystem.disabled = true
+				%Open.disabled = true
 			# -------------------------------------------------
-			'Modifier':
+			"Modifier":
 				%GeneralInfo.text = "Modifiers can modify text from text events before it is shown."
+				%ShowInFileSystem.disabled = true
+				%Open.disabled = true
 			# -------------------------------------------------
-			'Style':
+			"Style":
 				%GeneralInfo.text = "Style presets can be activated and modified in the Styles editor. They provide the design of the dialog interface in your game."
 			# -------------------------------------------------
-			'Editor':
+			"Editor":
 				%GeneralInfo.text = "Editors provide a user interface for editing dialogic data."
 			# -------------------------------------------------
-			'Settings':
+			"Settings":
 				%GeneralInfo.text = "Settings pages provide settings that are usually used by subsystems, events and dialogic nodes."
+			"Module":
+				%GeneralInfo.text = ""
+				%Open.disabled = true
 			# -------------------------------------------------
 			_:
 				%GeneralInfo.text = ""
-
+				%ShowInFileSystem.disabled = true
+				%Open.disabled = true
+	if %Open.disabled == false:
+		%Open.icon = get_theme_icon("CodeHighlighter", "EditorIcons") if get_element_path().ends_with(".gd") else get_theme_icon("PackedScene", "EditorIcons")
+	%Documentation.disabled = not get_element_path().ends_with(".gd")
 
 func _on_external_link_pressed() -> void:
-	if %ExternalLink.has_meta('url'):
-		OS.shell_open(%ExternalLink.get_meta('url'))
+	if %ExternalLink.has_meta("url"):
+		OS.shell_open(%ExternalLink.get_meta("url"))
 
 
 func change_event_visibility(event:DialogicEvent, visibility:bool) -> void:
 	if event:
-		var list: Array= DialogicUtil.get_editor_setting('hidden_event_buttons', [])
+		var list: Array= DialogicUtil.get_editor_setting("hidden_event_buttons", [])
 		if visibility:
 			list.erase(event.event_name)
 		else:
 			list.append(event.event_name)
-		DialogicUtil.set_editor_setting('hidden_event_buttons', list)
+		DialogicUtil.set_editor_setting("hidden_event_buttons", list)
 		force_event_button_list_update()
 
 
@@ -304,24 +334,86 @@ func _on_visibility_toggle_toggled(button_pressed:bool) -> void:
 		%Tree.get_selected().get_parent().set_button_color(0, %Tree.get_selected().get_index(), color)
 
 
-
 func force_event_button_list_update() -> void:
-	find_parent('EditorsManager').editors['Timeline'].node.get_node('%VisualEditor').load_event_buttons()
+	find_parent("EditorsManager").editors["Timeline"].node.get_node("%VisualEditor").load_event_buttons()
 
+
+func _on_show_in_file_system_pressed() -> void:
+	EditorInterface.get_file_system_dock().navigate_to_path(get_element_path())
+
+
+func _on_documentation_pressed() -> void:
+	EditorInterface.set_main_screen_editor("Script")
+	var msg = get_element_path()
+	#print(msg)
+	var dir := EditorInterface.get_resource_filesystem().get_filesystem_path(msg.get_base_dir())
+	var the_class_name := dir.get_file_script_class_name(dir.find_file_index(msg.get_file()))
+	#print(the_class_name)
+	if the_class_name:
+		EditorInterface.get_script_editor().goto_help("class_name:"+the_class_name)
+		return
+	#if msg.contains("/"):
+		#msg='"'+msg.replace("res://","").replace('"',"").replace("'","")+'"'
+	#msg='class'+'_name:'+msg.replace('class'+'_name:',"")
+	##print(msg)
+	#EditorInterface.get_script_editor().get_current_editor().go_to_help.emit(msg)
+	#print('class_name:"'+get_element_path().trim_prefix("res://")+'"')
+	EditorInterface.get_script_editor().goto_help('class_name:"'+get_element_path().trim_prefix("res://")+'"')
+
+
+func _on_open_pressed() -> void:
+	var path := get_element_path()
+	if path.ends_with(".gd"):
+		EditorInterface.set_main_screen_editor("Script")
+		EditorInterface.edit_script(load(path), 1, 1)
+	elif path.ends_with(".tscn"):
+		EditorInterface.open_scene_from_path(path)
+		await get_tree().process_frame
+		EditorInterface.set_main_screen_editor("2D")
+
+
+func get_element_path() -> String:
+	var selected_item: TreeItem = %Tree.get_selected()
+	var metadata: Variant = selected_item.get_metadata(0)
+	if metadata is Dictionary:
+		match metadata.type:
+			"Module":
+				return metadata.info.this_folder
+			"Subsystem":
+				return metadata.info.script
+			"Event":
+				return metadata.event.script.resource_path
+			"Style":
+				return metadata.info.path
+			"Settings":
+				return metadata.info
+	return ""
+
+#region EVENT DEFAULT SETTINGS
 ################################################################################
-##						EVENT DEFAULT SETTINGS
-################################################################################
+
+var customization_editor_info := {}
+
 func load_event_settings(event:DialogicEvent) -> void:
 	for child in %EventDefaults.get_children():
+		child.get_parent().remove_child(child)
 		child.queue_free()
 
-	var event_default_overrides: Dictionary = ProjectSettings.get_setting('dialogic/event_default_overrides', {})
+	customization_editor_info.clear()
+
+	var event_default_overrides: Dictionary = ProjectSettings.get_setting("dialogic/event_default_overrides", {})
 
 	var params := event.get_shortcode_parameters()
+	var property_list := event.get_property_list()
 	for prop in params:
-		var current_value: Variant = params[prop].default
-		if event_default_overrides.get(event.event_name, {}).has(params[prop].property):
-			current_value = event_default_overrides.get(event.event_name, {}).get(params[prop].property)
+		var orig_value : Variant = params[prop].default
+		var current_value: Variant = orig_value
+		var prop_name: String = params[prop].property
+
+		if event_default_overrides.get(event.event_name, {}).has(prop_name):
+			current_value = event_default_overrides.get(event.event_name, {}).get(prop_name)
+
+		customization_editor_info[prop_name] = {"orig":orig_value, "current":current_value}
 
 		# Label
 		var label := Label.new()
@@ -329,113 +421,67 @@ func load_event_settings(event:DialogicEvent) -> void:
 		%EventDefaults.add_child(label)
 
 		var reset := Button.new()
-		reset.icon = get_theme_icon("Clear", "EditorIcons")
 		reset.flat = true
-
+		reset.icon = get_theme_icon("Reload", "EditorIcons")
+		reset.tooltip_text = "Remove customization"
+		reset.pressed.connect(_on_export_override_reset.bind(prop_name))
+		reset.disabled = typeof(current_value) == typeof(orig_value) and current_value == orig_value
+		customization_editor_info[prop_name]["reset"] = reset
 		%EventDefaults.add_child(reset)
 
 		# Editing field
-		var editor_node: Node = null
-		match typeof(event.get(params[prop].property)):
-			TYPE_STRING:
-				editor_node = LineEdit.new()
-				editor_node.custom_minimum_size.x = 150
-				editor_node.text = str(current_value)
-				editor_node.text_changed.connect(_on_event_default_string_submitted.bind(params[prop].property))
-			TYPE_INT, TYPE_FLOAT:
-				if params[prop].has('suggestions'):
-					editor_node = OptionButton.new()
-					for i in params[prop].suggestions.call():
-						editor_node.add_item(i, int(params[prop].suggestions.call()[i].value))
-					editor_node.select(int(current_value))
-					editor_node.item_selected.connect(_on_event_default_option_selected.bind(editor_node, params[prop].property))
-				else:
-					editor_node = SpinBox.new()
-
-					editor_node.allow_greater = true
-					editor_node.allow_lesser = true
-					if typeof(event.get(params[prop].property)) == TYPE_INT:
-						editor_node.step = 1
-					else:
-						editor_node.step = 0.001
-
-					editor_node.value = float(current_value)
-					editor_node.value_changed.connect(_on_event_default_number_changed.bind(params[prop].property))
-
-			TYPE_VECTOR2:
-				editor_node = load("res://addons/dialogic/Editor/Events/Fields/field_vector2.tscn").instantiate()
-				editor_node.set_value(current_value)
-				editor_node.property_name = params[prop].property
-				editor_node.value_changed.connect(_on_event_default_value_changed)
-
-			TYPE_BOOL:
-				editor_node = CheckBox.new()
-				editor_node.button_pressed = bool(current_value)
-				editor_node.toggled.connect(_on_event_default_bool_toggled.bind(params[prop].property))
-
-			TYPE_ARRAY:
-				editor_node = load("res://addons/dialogic/Editor/Events/Fields/field_array.tscn").instantiate()
-				editor_node.set_value(current_value)
-				editor_node.property_name = params[prop].property
-				editor_node.value_changed.connect(_on_event_default_value_changed)
-
-			TYPE_DICTIONARY:
-				editor_node = load("res://addons/dialogic/Editor/Events/Fields/field_dictionary.tscn").instantiate()
-				editor_node.set_value(current_value)
-				editor_node.property_name = params[prop].property
-				editor_node.value_changed.connect(_on_event_default_value_changed)
+		var editor_node: Node = DialogicUtil.setup_script_property_edit_node(
+			property_list.filter(func(x): return x.name == prop_name)[0], current_value, set_event_default_override)
+		editor_node.size_flags_horizontal = SIZE_EXPAND_FILL
+		customization_editor_info[prop_name]["node"] = editor_node
 		%EventDefaults.add_child(editor_node)
-		reset.pressed.connect(reset_event_default_override.bind(prop, editor_node, params[prop].default))
+
+	%EventDefaultsPanel.visible = %EventDefaults.get_child_count() > 0
 
 
 func set_event_default_override(prop:String, value:Variant) -> void:
-	var event_default_overrides: Dictionary = ProjectSettings.get_setting('dialogic/event_default_overrides', {})
+	value = str_to_var(value)
+	var event_default_overrides: Dictionary = ProjectSettings.get_setting("dialogic/event_default_overrides", {})
 	var event: DialogicEvent = %Tree.get_selected().get_metadata(0).event
 
 	if not event_default_overrides.has(event.event_name):
 		event_default_overrides[event.event_name] = {}
 
-	event_default_overrides[event.event_name][prop] = value
+	if value == customization_editor_info[prop].orig:
+		event_default_overrides[event.event_name].erase(prop)
+		customization_editor_info[prop].reset.disabled = true
+	else:
+		event_default_overrides[event.event_name][prop] = value
+		customization_editor_info[prop].reset.disabled = false
 
-	ProjectSettings.set_setting('dialogic/event_default_overrides', event_default_overrides)
+	ProjectSettings.set_setting("dialogic/event_default_overrides", event_default_overrides)
 
 
-func reset_event_default_override(prop:String, node:Node, default:Variant) -> void:
-	var event_default_overrides: Dictionary = ProjectSettings.get_setting('dialogic/event_default_overrides', {})
+func _on_export_override_reset(property_name:String) -> void:
+	var event_default_overrides: Dictionary = ProjectSettings.get_setting("dialogic/event_default_overrides", {})
 	var event: DialogicEvent = %Tree.get_selected().get_metadata(0).event
+	if event.event_name in event_default_overrides:
+		event_default_overrides[event.event_name].erase(property_name)
+		#current_style.remove_layer_setting(current_layer_id, property_name)
+		print(customization_editor_info.keys())
+		customization_editor_info[property_name]["reset"].disabled = true
+		set_customization_value(property_name, customization_editor_info[property_name]["orig"])
 
-	if not event_default_overrides.has(event.event_name):
-		return
 
-	event_default_overrides[event.event_name].erase(prop)
-
-	ProjectSettings.set_setting('dialogic/event_default_overrides', event_default_overrides)
-
+func set_customization_value(property_name:String, value:Variant) -> void:
+	var node: Node = customization_editor_info[property_name]["node"]
 	if node is CheckBox:
-		node.button_pressed = default
+		node.button_pressed = value
 	elif node is LineEdit:
-		node.text = default
-	elif node.has_method('set_value'):
-		node.set_value(default)
+		node.text = value
+	elif node.has_method("set_value"):
+		node.set_value(value)
 	elif node is ColorPickerButton:
-		node.color = default
+		node.color = value
 	elif node is OptionButton:
-		node.select(default)
+		node.select(value)
 	elif node is SpinBox:
-		node.value = default
+		node.value = value
 
 
-func _on_event_default_string_submitted(text:String, prop:String) -> void:
-	set_event_default_override(prop, text)
-
-func _on_event_default_option_selected(index:int, option_button:OptionButton, prop:String) -> void:
-	set_event_default_override(prop, option_button.get_item_id(index))
-
-func _on_event_default_number_changed(value:float, prop:String) -> void:
-	set_event_default_override(prop, value)
-
-func _on_event_default_value_changed(prop:String, value:Variant) -> void:
-	set_event_default_override(prop, value)
-
-func _on_event_default_bool_toggled(value:bool, prop:String) -> void:
-	set_event_default_override(prop, value)
+#endregion

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd
@@ -263,7 +263,7 @@ func _on_tree_item_selected() -> void:
 				%Icon.texture = metadata.event._get_icon()
 				if not metadata.event.disable_editor_button:
 					%VisibilityToggle.show()
-					%VisibilityToggle.button_pressed = !metadata.event.event_name in DialogicUtil.get_editor_setting("hidden_event_buttons", [])
+					%VisibilityToggle.button_pressed = !metadata.event.event_name in DialogicUtil.get_editor_setting("hidden_event_buttons", DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
 					if %VisibilityToggle.button_pressed:
 						%VisibilityToggle.icon = get_theme_icon("GuiVisibilityVisible", "EditorIcons")
 					else:
@@ -310,7 +310,7 @@ func _on_external_link_pressed() -> void:
 
 func change_event_visibility(event:DialogicEvent, visibility:bool) -> void:
 	if event:
-		var list: Array= DialogicUtil.get_editor_setting("hidden_event_buttons", [])
+		var list: Array= DialogicUtil.get_editor_setting("hidden_event_buttons", DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
 		if visibility:
 			list.erase(event.event_name)
 		else:

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://o7ljiritpgap"]
+[gd_scene format=3 uid="uid://o7ljiritpgap"]
 
 [ext_resource type="Script" uid="uid://bcu347pvraog6" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd" id="1_l2hk0"]
 
@@ -39,7 +39,7 @@ border_width_right = 2
 border_width_bottom = 2
 corner_detail = 1
 
-[node name="ModuleManagement" type="HSplitContainer"]
+[node name="ModuleManagement" type="HSplitContainer" unique_id=538174781]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -53,25 +53,25 @@ short_info = "Here you can manage modules:
 - change event defaults
 - hide events from the event list"
 
-[node name="Overview" type="VBoxContainer" parent="."]
+[node name="Overview" type="VBoxContainer" parent="." unique_id=584770025]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Overview"]
+[node name="ScrollContainer" type="ScrollContainer" parent="Overview" unique_id=2065308431]
 layout_mode = 2
 size_flags_horizontal = 3
 follow_focus = true
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 0
 
-[node name="HBox" type="HBoxContainer" parent="Overview/ScrollContainer"]
+[node name="HBox" type="HBoxContainer" parent="Overview/ScrollContainer" unique_id=308601580]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 8
 alignment = 2
 
-[node name="Filter_Events" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_Events" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1770970323]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Events"
@@ -81,7 +81,7 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Filter_Subsystems" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_Subsystems" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=899699063]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Subsystems"
@@ -91,7 +91,7 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Filter_EffectsAndModifiers" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_EffectsAndModifiers" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1831330531]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Text Effects and Modifiers"
@@ -101,7 +101,7 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Filter_Styles" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_Styles" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=442872763]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Preset Style Scenes"
@@ -111,7 +111,7 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Filter_Settings" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_Settings" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=788315383]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Settings Pages"
@@ -120,7 +120,7 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Filter_Editors" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Filter_Editors" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=2115117454]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Editors"
@@ -129,32 +129,33 @@ text = "0"
 flat = true
 icon_alignment = 2
 
-[node name="Search" type="LineEdit" parent="Overview/ScrollContainer/HBox"]
+[node name="Search" type="LineEdit" parent="Overview/ScrollContainer/HBox" unique_id=1749645592]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
 placeholder_text = "Search"
 clear_button_enabled = true
 
-[node name="Refresh" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Refresh" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1919233634]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Refresh"
 
-[node name="Collapse" type="Button" parent="Overview/ScrollContainer/HBox"]
+[node name="Collapse" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1713654816]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Collapse All"
 toggle_mode = true
 
-[node name="Tree" type="Tree" parent="Overview"]
+[node name="Tree" type="Tree" parent="Overview" unique_id=2002333500]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
+theme_type_variation = &"TreeSecondary"
 allow_reselect = true
 hide_root = true
 
-[node name="Scroll" type="ScrollContainer" parent="."]
+[node name="Scroll" type="ScrollContainer" parent="." unique_id=280174295]
 show_behind_parent = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -163,32 +164,32 @@ size_flags_stretch_ratio = 0.75
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 0
 
-[node name="Settings" type="VBoxContainer" parent="Scroll"]
+[node name="Settings" type="VBoxContainer" parent="Scroll" unique_id=770304559]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="HBox" type="HBoxContainer" parent="Scroll/Settings"]
+[node name="HBox" type="HBoxContainer" parent="Scroll/Settings" unique_id=1522881579]
 layout_mode = 2
 
-[node name="Icon" type="TextureRect" parent="Scroll/Settings/HBox"]
+[node name="Icon" type="TextureRect" parent="Scroll/Settings/HBox" unique_id=26017225]
 unique_name_in_owner = true
 layout_mode = 2
 expand_mode = 3
 
-[node name="Title" type="Label" parent="Scroll/Settings/HBox"]
+[node name="Title" type="Label" parent="Scroll/Settings/HBox" unique_id=1323694018]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"DialogicSubTitle"
 
-[node name="ExternalLink" type="Button" parent="Scroll/Settings/HBox"]
+[node name="ExternalLink" type="Button" parent="Scroll/Settings/HBox" unique_id=488553913]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 icon = SubResource("ImageTexture_lce2m")
 flat = true
 
-[node name="VisibilityToggle" type="Button" parent="Scroll/Settings/HBox"]
+[node name="VisibilityToggle" type="Button" parent="Scroll/Settings/HBox" unique_id=1399656633]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
@@ -197,25 +198,25 @@ button_pressed = true
 icon = SubResource("ImageTexture_137g7")
 flat = true
 
-[node name="EventDefaultsPanel" type="PanelContainer" parent="Scroll/Settings"]
+[node name="EventDefaultsPanel" type="PanelContainer" parent="Scroll/Settings" unique_id=1538662659]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_315cl")
 
-[node name="VBox" type="VBoxContainer" parent="Scroll/Settings/EventDefaultsPanel"]
+[node name="VBox" type="VBoxContainer" parent="Scroll/Settings/EventDefaultsPanel" unique_id=909920434]
 layout_mode = 2
 
-[node name="Title" type="Label" parent="Scroll/Settings/EventDefaultsPanel/VBox"]
+[node name="Title" type="Label" parent="Scroll/Settings/EventDefaultsPanel/VBox" unique_id=404311626]
 layout_mode = 2
 text = "Edit event defaults:"
 
-[node name="EventDefaults" type="GridContainer" parent="Scroll/Settings/EventDefaultsPanel/VBox"]
+[node name="EventDefaults" type="GridContainer" parent="Scroll/Settings/EventDefaultsPanel/VBox" unique_id=1002365879]
 unique_name_in_owner = true
 layout_mode = 2
 columns = 3
 
-[node name="GeneralInfo" type="Label" parent="Scroll/Settings"]
+[node name="GeneralInfo" type="Label" parent="Scroll/Settings" unique_id=15394927]
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"DialogicHintText2"

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
@@ -185,6 +185,7 @@ text = "Audio"
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
+tooltip_text = "Toggle Event Button Visibility"
 theme_type_variation = &"FlatButton"
 toggle_mode = true
 button_pressed = true

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.tscn
@@ -2,18 +2,6 @@
 
 [ext_resource type="Script" uid="uid://bcu347pvraog6" path="res://addons/dialogic/Editor/Settings/CoreSettingsPages/settings_modules.gd" id="1_l2hk0"]
 
-[sub_resource type="Image" id="Image_1yyxk"]
-data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
-
-[sub_resource type="ImageTexture" id="ImageTexture_lce2m"]
-image = SubResource("Image_1yyxk")
-
 [sub_resource type="Image" id="Image_bclq7"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
@@ -26,18 +14,17 @@ data = {
 [sub_resource type="ImageTexture" id="ImageTexture_137g7"]
 image = SubResource("Image_bclq7")
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_315cl"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-bg_color = Color(1, 0.365, 0.365, 1)
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-corner_detail = 1
+[sub_resource type="Image" id="Image_1yyxk"]
+data = {
+"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"format": "RGBA8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id="ImageTexture_lce2m"]
+image = SubResource("Image_1yyxk")
 
 [node name="ModuleManagement" type="HSplitContainer" unique_id=538174781]
 anchors_preset = 15
@@ -65,74 +52,83 @@ follow_focus = true
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 0
 
-[node name="HBox" type="HBoxContainer" parent="Overview/ScrollContainer" unique_id=308601580]
+[node name="HBox" type="HFlowContainer" parent="Overview/ScrollContainer" unique_id=641853081]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 8
 alignment = 2
 
-[node name="Filter_Events" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1770970323]
+[node name="Filters" type="HBoxContainer" parent="Overview/ScrollContainer/HBox" unique_id=812935428]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="Filter_Events" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=1770970323]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Events"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
 button_pressed = true
-text = "0"
-flat = true
+text = "27"
 icon_alignment = 2
+metadata/counter = 27
 
-[node name="Filter_Subsystems" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=899699063]
+[node name="Filter_Subsystems" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=899699063]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Subsystems"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
 button_pressed = true
-text = "0"
-flat = true
+text = "19"
 icon_alignment = 2
+metadata/counter = 19
 
-[node name="Filter_EffectsAndModifiers" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=1831330531]
+[node name="Filter_EffectsAndModifiers" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=1831330531]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Text Effects and Modifiers"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
-button_pressed = true
-text = "0"
-flat = true
+text = "15"
 icon_alignment = 2
+metadata/counter = 15
 
-[node name="Filter_Styles" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=442872763]
+[node name="Filter_Styles" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=442872763]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Preset Style Scenes"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
-button_pressed = true
-text = "0"
-flat = true
+text = "15"
 icon_alignment = 2
+metadata/counter = 15
 
-[node name="Filter_Settings" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=788315383]
+[node name="Filter_Settings" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=788315383]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Settings Pages"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
-text = "0"
-flat = true
+text = "6"
 icon_alignment = 2
+metadata/counter = 6
 
-[node name="Filter_Editors" type="Button" parent="Overview/ScrollContainer/HBox" unique_id=2115117454]
+[node name="Filter_Editors" type="Button" parent="Overview/ScrollContainer/HBox/Filters" unique_id=2115117454]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Include Editors"
+theme_type_variation = &"FlatButton"
 toggle_mode = true
-text = "0"
-flat = true
+text = "3"
 icon_alignment = 2
+metadata/counter = 3
 
 [node name="Search" type="LineEdit" parent="Overview/ScrollContainer/HBox" unique_id=1749645592]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(100, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 placeholder_text = "Search"
 clear_button_enabled = true
 
@@ -146,6 +142,7 @@ unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Collapse All"
 toggle_mode = true
+button_pressed = true
 
 [node name="Tree" type="Tree" parent="Overview" unique_id=2002333500]
 unique_name_in_owner = true
@@ -180,41 +177,64 @@ expand_mode = 3
 [node name="Title" type="Label" parent="Scroll/Settings/HBox" unique_id=1323694018]
 unique_name_in_owner = true
 layout_mode = 2
+size_flags_horizontal = 3
 theme_type_variation = &"DialogicSubTitle"
-
-[node name="ExternalLink" type="Button" parent="Scroll/Settings/HBox" unique_id=488553913]
-unique_name_in_owner = true
-visible = false
-layout_mode = 2
-icon = SubResource("ImageTexture_lce2m")
-flat = true
+text = "Audio"
 
 [node name="VisibilityToggle" type="Button" parent="Scroll/Settings/HBox" unique_id=1399656633]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
+theme_type_variation = &"FlatButton"
 toggle_mode = true
 button_pressed = true
 icon = SubResource("ImageTexture_137g7")
-flat = true
+
+[node name="ExternalLink" type="Button" parent="Scroll/Settings/HBox" unique_id=488553913]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_type_variation = &"FlatButton"
+icon = SubResource("ImageTexture_lce2m")
+
+[node name="Documentation" type="Button" parent="Scroll/Settings/HBox" unique_id=2144591126]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Show in FileSystem"
+theme_type_variation = &"FlatButton"
+
+[node name="ShowInFileSystem" type="Button" parent="Scroll/Settings/HBox" unique_id=327123463]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Show in FileSystem"
+theme_type_variation = &"FlatButton"
+
+[node name="Open" type="Button" parent="Scroll/Settings/HBox" unique_id=153524768]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Open"
+theme_type_variation = &"FlatButton"
 
 [node name="EventDefaultsPanel" type="PanelContainer" parent="Scroll/Settings" unique_id=1538662659]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_315cl")
 
 [node name="VBox" type="VBoxContainer" parent="Scroll/Settings/EventDefaultsPanel" unique_id=909920434]
 layout_mode = 2
 
 [node name="Title" type="Label" parent="Scroll/Settings/EventDefaultsPanel/VBox" unique_id=404311626]
 layout_mode = 2
-text = "Edit event defaults:"
+text = "Event Defaults:"
 
 [node name="EventDefaults" type="GridContainer" parent="Scroll/Settings/EventDefaultsPanel/VBox" unique_id=1002365879]
 unique_name_in_owner = true
 layout_mode = 2
 columns = 3
+
+[node name="HSeparator" type="HSeparator" parent="Scroll/Settings/EventDefaultsPanel/VBox" unique_id=2034226101]
+clip_contents = true
+layout_mode = 2
 
 [node name="GeneralInfo" type="Label" parent="Scroll/Settings" unique_id=15394927]
 unique_name_in_owner = true
@@ -222,16 +242,19 @@ layout_mode = 2
 theme_type_variation = &"DialogicHintText2"
 autowrap_mode = 3
 
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Events" to="." method="filters_updated"]
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Subsystems" to="." method="filters_updated"]
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_EffectsAndModifiers" to="." method="filters_updated"]
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Styles" to="." method="filters_updated"]
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Settings" to="." method="filters_updated"]
-[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Editors" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_Events" to="." method="_on_filter_toggled" flags=18]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_Subsystems" to="." method="_on_filter_toggled" flags=18]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_EffectsAndModifiers" to="." method="_on_filter_toggled" flags=18]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_Styles" to="." method="_on_filter_toggled" flags=18]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_Settings" to="." method="_on_filter_toggled" flags=18]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filters/Filter_Editors" to="." method="_on_filter_toggled" flags=18]
 [connection signal="text_changed" from="Overview/ScrollContainer/HBox/Search" to="." method="_on_search_text_changed"]
 [connection signal="pressed" from="Overview/ScrollContainer/HBox/Refresh" to="." method="_on_refresh_pressed"]
 [connection signal="toggled" from="Overview/ScrollContainer/HBox/Collapse" to="." method="_on_collapse_toggled"]
 [connection signal="button_clicked" from="Overview/Tree" to="." method="_on_tree_button_clicked"]
 [connection signal="item_selected" from="Overview/Tree" to="." method="_on_tree_item_selected"]
-[connection signal="pressed" from="Scroll/Settings/HBox/ExternalLink" to="." method="_on_external_link_pressed"]
 [connection signal="toggled" from="Scroll/Settings/HBox/VisibilityToggle" to="." method="_on_visibility_toggle_toggled"]
+[connection signal="pressed" from="Scroll/Settings/HBox/ExternalLink" to="." method="_on_external_link_pressed"]
+[connection signal="pressed" from="Scroll/Settings/HBox/Documentation" to="." method="_on_documentation_pressed"]
+[connection signal="pressed" from="Scroll/Settings/HBox/ShowInFileSystem" to="." method="_on_show_in_file_system_pressed"]
+[connection signal="pressed" from="Scroll/Settings/HBox/Open" to="." method="_on_open_pressed"]

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd
@@ -73,7 +73,7 @@ func request_code_completion(force:bool, text:CodeEdit, mode:=Modes.FULL_HIGHLIG
 
 	# make sure shortcode event references are loaded
 	if mode == Modes.FULL_HIGHLIGHTING:
-		var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', [])
+		var hidden_events: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
 		if shortcode_events.is_empty():
 			for event in DialogicResourceUtil.get_event_cache():
 				if event.get_shortcode() != 'default_shortcode':

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/TimelineArea.gd
@@ -67,7 +67,7 @@ func _process(_delta:float) -> void:
 				drag_to_position = child.get_index()
 				queue_redraw()
 				return
-	
+
 	if get_global_rect().has_point(get_global_mouse_position()):
 		if %Timeline.get_child_count():
 			var last_child := %Timeline.get_child(-1)

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1017,6 +1017,7 @@ func _on_event_popup_menu_id_pressed(id:int) -> void:
 	elif id == 3:
 		EditorInterface.set_main_screen_editor('Script')
 		EditorInterface.edit_script(item.resource.get_script(), 1, 1)
+
 	elif id == 4 or id == 5:
 		if id == 4:
 			offset_blocks_by_index(selected_items, -1)

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -208,12 +208,9 @@ func load_event_buttons() -> void:
 
 	# Clear previous event buttons
 	for child in %RightSidebar.get_child(0).get_children():
-
 		if child is FlowContainer:
-
 			for button in child.get_children():
 				button.queue_free()
-
 
 	for child in %RightSidebar.get_child(0).get_children():
 		child.get_parent().remove_child(child)
@@ -223,7 +220,7 @@ func load_event_buttons() -> void:
 	var button_scene := load("res://addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.tscn")
 
 	var scripts := DialogicResourceUtil.get_event_cache()
-	var hidden_buttons: Array = DialogicUtil.get_editor_setting('hidden_event_buttons', [])
+	var hidden_buttons: Array = DialogicUtil.get_editor_setting("hidden_event_buttons", DialogicUtil.SETTING_HIDDEN_BUTTONS_DEFAULT)
 	var sections := {}
 
 	for event_script in scripts:
@@ -251,7 +248,7 @@ func load_event_buttons() -> void:
 
 		button.button_up.connect(_add_event_button_pressed.bind(event_resource))
 
-		if !event_resource.event_category in sections:
+		if not event_resource.event_category in sections:
 			var section := VBoxContainer.new()
 			section.name = event_resource.event_category
 
@@ -278,13 +275,14 @@ func load_event_buttons() -> void:
 			sections[event_resource.event_category].move_child(button, button.get_index()-1)
 
 	# Sort event sections
-	var sections_order: Array = DialogicUtil.get_editor_setting('event_section_order',
-			['Main', 'Flow', 'Logic', 'Audio', 'Visual','Other', 'Helper'])
+	var sections_order: Array = DialogicUtil.get_editor_setting("event_section_order",
+			DialogicUtil.SETTING_BUTTON_SECTION_ORDER)
 
-	sections_order.reverse()
+	var i := 0
 	for section_name in sections_order:
 		if %RightSidebar.get_child(0).has_node(section_name):
-			%RightSidebar.get_child(0).move_child(%RightSidebar.get_child(0).get_node(section_name), 0)
+			%RightSidebar.get_child(0).move_child(%RightSidebar.get_child(0).get_node(section_name), i)
+			i += 1
 
 	# Resize RightSidebar
 	%RightSidebar.custom_minimum_size.x = 50 * DialogicUtil.get_editor_scale()

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://ysqbusmy0qma"]
+[gd_scene format=3 uid="uid://ysqbusmy0qma"]
 
 [ext_resource type="Script" uid="uid://cvgok7bxva5e2" path="res://addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd" id="1_8smxc"]
 [ext_resource type="Theme" uid="uid://cqst728xxipcw" path="res://addons/dialogic/Editor/Theme/MainTheme.tres" id="2_x0fhp"]
@@ -8,35 +8,7 @@
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_phyjj"]
 content_margin_top = 10.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_6gqu8"]
-bg_color = Color(0, 0, 0, 1)
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jujwh"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-bg_color = Color(1, 0.365, 0.365, 1)
-draw_center = false
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-corner_detail = 1
-
-[sub_resource type="Image" id="Image_3temo"]
-data = {
-"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
-"format": "RGBA8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
-
-[sub_resource type="ImageTexture" id="ImageTexture_xe7d2"]
-image = SubResource("Image_3temo")
-
-[node name="TimelineVisualEditor" type="MarginContainer"]
+[node name="TimelineVisualEditor" type="MarginContainer" unique_id=1827236598]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -47,13 +19,13 @@ theme_override_constants/margin_right = 5
 theme_override_constants/margin_bottom = 5
 script = ExtResource("1_8smxc")
 
-[node name="View" type="HSplitContainer" parent="."]
+[node name="View" type="HSplitContainer" parent="." unique_id=1893392013]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme = ExtResource("2_x0fhp")
 
-[node name="TimelineArea" type="ScrollContainer" parent="View"]
+[node name="TimelineArea" type="ScrollContainer" parent="View" unique_id=1257416940]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -61,51 +33,25 @@ size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_phyjj")
 script = ExtResource("3_sap1x")
 
-[node name="Timeline" type="VBoxContainer" parent="View/TimelineArea"]
+[node name="Timeline" type="VBoxContainer" parent="View/TimelineArea" unique_id=1887371894]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="EventPopupMenu" type="PopupMenu" parent="View/TimelineArea"]
+[node name="EventPopupMenu" type="PopupMenu" parent="View/TimelineArea" unique_id=1937370098]
 unique_name_in_owner = true
 size = Vector2i(165, 124)
-theme_override_styles/panel = SubResource("StyleBoxFlat_6gqu8")
-theme_override_styles/hover = SubResource("StyleBoxFlat_jujwh")
-item_count = 9
-item_0/text = "Duplicate"
-item_0/icon = SubResource("ImageTexture_xe7d2")
-item_1/id = -1
-item_1/separator = true
-item_2/text = "Documentation"
-item_2/icon = SubResource("ImageTexture_xe7d2")
-item_2/id = 2
-item_3/text = "Open Code"
-item_3/icon = SubResource("ImageTexture_xe7d2")
-item_3/id = 3
-item_4/id = -1
-item_4/separator = true
-item_5/text = "Move up"
-item_5/icon = SubResource("ImageTexture_xe7d2")
-item_5/id = 5
-item_6/text = "Move down"
-item_6/icon = SubResource("ImageTexture_xe7d2")
-item_6/id = 6
-item_7/id = -1
-item_7/separator = true
-item_8/text = "Delete"
-item_8/icon = SubResource("ImageTexture_xe7d2")
-item_8/id = 8
 script = ExtResource("4_ugiq6")
 
-[node name="RightSidebar" type="ScrollContainer" parent="View"]
+[node name="RightSidebar" type="ScrollContainer" parent="View" unique_id=269152096]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 size_flags_stretch_ratio = 0.2
 horizontal_scroll_mode = 0
 
-[node name="EventContainer" type="VBoxContainer" parent="View/RightSidebar"]
+[node name="EventContainer" type="VBoxContainer" parent="View/RightSidebar" unique_id=151696986]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/addons/dialogic/Modules/Audio/event_audio.gd
+++ b/addons/dialogic/Modules/Audio/event_audio.gd
@@ -8,13 +8,13 @@ extends DialogicEvent
 ### Settings
 
 ## The file to play. If empty, the previous audio will be faded out.
-var file_path := "":
+@export var file_path := "":
 	set(value):
 		if file_path != value:
 			file_path = value
 			ui_update_needed.emit()
 ## The channel name to use. If none given plays as a One-Shot SFX.
-var channel_name := "":
+@export var channel_name := "":
 	set(value):
 		if channel_name != channel_name_regex.sub(value, '', true):
 			channel_name = channel_name_regex.sub(value, '', true)
@@ -27,15 +27,15 @@ var channel_name := "":
 				ui_update_needed.emit()
 
 ## The length of the fade. If 0 it's an instant change.
-var fade_length: float = 0.0
+@export var fade_length: float = 0.0
 ## The volume in decibel.
-var volume: float = 0.0
+@export var volume: float = 0.0
 ## The audio bus the audio will be played on.
-var audio_bus := ""
+@export var audio_bus := ""
 ## If true, the audio will loop, otherwise only play once.
-var loop := true
+@export var loop := true
 ## Sync starting time with different channel (if playing audio on that channel)
-var sync_channel := ""
+@export var sync_channel := ""
 
 ## Helpers. Set automatically
 var set_fade_length := false

--- a/addons/dialogic/Modules/Background/event_background.gd
+++ b/addons/dialogic/Modules/Background/event_background.gd
@@ -10,16 +10,16 @@ extends DialogicEvent
 ## This scene supports images and fading.
 ## If you set it to a scene path, then that scene will be instanced.
 ## Learn more about custom backgrounds in the Subsystem_Background.gd docs.
-var scene := ""
+@export var scene := ""
 ## The argument that is passed to the background scene.
 ## For the default scene it's the path to the image to show.
-var argument := ""
+@export var argument := ""
 ## The time the fade animation will take. Leave at 0 for instant change.
-var fade: float = 0.0
+@export var fade: float = 0.0
 ## Name of the transition to use.
-var transition := ""
+@export var transition := ""
 ## If `true` will wait for the duration of the transition before continuing.
-var await_transition := false
+@export var await_transition := false
 
 ## Helpers for visual editor
 enum ArgumentTypes {IMAGE, COLOR, STRING}

--- a/addons/dialogic/Modules/Call/event_call.gd
+++ b/addons/dialogic/Modules/Call/event_call.gd
@@ -7,16 +7,16 @@ extends DialogicEvent
 ### Settings
 
 ## The name of the autoload to call the method on.
-var autoload_name := ""
+@export var autoload_name := ""
 ## The name of the method to call on the given autoload.
-var method := "":
+@export var method := "":
 	set(value):
 		method = value
 		if Engine.is_editor_hint():
 			update_argument_info()
 			check_arguments_and_update_warning()
 ## A list of arguments to give to the call.
-var arguments := []:
+@export var arguments := []:
 	set(value):
 		arguments = value
 		if Engine.is_editor_hint():

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -8,36 +8,36 @@ enum Actions {JOIN, LEAVE, UPDATE}
 ### Settings
 
 ## The type of action of this event (JOIN/LEAVE/UPDATE). See [Actions].
-var action :=  Actions.JOIN
+@export var action :=  Actions.JOIN
 ## The character that will join/leave/update.
-var character: DialogicCharacter = null
+@export var character: DialogicCharacter = null
 ## For Join/Update, this will be the portrait of the character that is shown.
 ## Not used on Leave.
 ## If empty, the default portrait will be used.
-var portrait := ""
+@export var portrait := ""
 ## The index of the position this character should move to
-var transform := "center"
+@export var transform := "center"
 
 ## Name of the animation script (extending DialogicAnimation).
 ## On Join/Leave empty (default) will fallback to the animations set in the settings.
 ## On Update empty will mean no animation.
-var animation_name := ""
+@export var animation_name := ""
 ## Length of the animation.
-var animation_length: float = 0.5
+@export var animation_length: float = 0.5
 ## How often the animation is repeated. Only for Update events.
-var animation_repeats: int = 1
+@export var animation_repeats: int = 1
 ## If true, the events waits for the animation to finish before the next event starts.
-var animation_wait := false
+@export var animation_wait := false
 
 ## The fade animation to use. If left empty, the default cross-fade animation AND time will be used.
-var fade_animation := ""
-var fade_length := 0.5
+@export var fade_animation := ""
+@export var fade_length := 0.5
 
 ## For Update only. If bigger then 0, the portrait will tween to the
 ## new position (if changed) in this time (in seconds).
-var transform_time: float = 0.0
-var transform_ease := Tween.EaseType.EASE_IN_OUT
-var transform_trans := Tween.TransitionType.TRANS_SINE
+@export var transform_time: float = 0.0
+@export var transform_ease := Tween.EaseType.EASE_IN_OUT
+@export var transform_trans := Tween.TransitionType.TRANS_SINE
 
 var ease_options := [
 		{'label': 'In', 	 'value': Tween.EASE_IN},
@@ -62,11 +62,11 @@ var trans_options := [
 		]
 
 ## The z_index that the portrait should have.
-var z_index: int = 0
+@export var z_index: int = 0
 ## If true, the portrait will be set to mirrored.
-var mirrored := false
+@export var mirrored := false
 ## If set, will be passed to the portrait scene.
-var extra_data := ""
+@export var extra_data := ""
 
 
 ### Helpers

--- a/addons/dialogic/Modules/Choice/event_choice.gd
+++ b/addons/dialogic/Modules/Choice/event_choice.gd
@@ -9,17 +9,17 @@ enum ElseActions {HIDE=0, DISABLE=1, DEFAULT=2}
 
 ### Settings
 ## The text that is displayed on the choice button.
-var text := ""
+@export var text := ""
 ## If not empty this condition will determine if this choice is active.
-var condition := ""
+@export var condition := ""
 ## Determines what happens if  [condition] is false. Default will use the action set in the settings.
-var else_action := ElseActions.DEFAULT
+@export var else_action := ElseActions.DEFAULT
 ## The text that is displayed if [condition] is false and [else_action] is Disable.
 ## If empty [text] will be used for disabled button as well.
-var disabled_text := ""
+@export var disabled_text := ""
 ## A dictionary that can be filled with arbitrary information
 ## This can then be interpreted by a custom choice layer
-var extra_data := {}
+@export var extra_data := {}
 
 
 ## UI helper

--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -5,15 +5,15 @@ extends DialogicEvent
 ## Event that clears audio & visuals (not variables).
 ## Useful to make sure the scene is clear for a completely new thing.
 
-var time := 1.0
-var step_by_step := true
+@export var time := 1.0
+@export var step_by_step := true
 
-var clear_textbox := true
-var clear_portraits := true
-var clear_style := true
-var clear_music := true
-var clear_portrait_positions := true
-var clear_background := true
+@export var clear_textbox := true
+@export var clear_portraits := true
+@export var clear_style := true
+@export var clear_music := true
+@export var clear_portrait_positions := true
+@export var clear_background := true
 
 #region EXECUTE
 ################################################################################

--- a/addons/dialogic/Modules/Comment/event_comment.gd
+++ b/addons/dialogic/Modules/Comment/event_comment.gd
@@ -27,8 +27,9 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Comment"
 	event_description = "Has no effect on gameplay, but can help organize your timeline."
+	event_sorting_index = 10
 	set_default_color('Color9')
-	event_category = "Helpers"
+	event_category = "Other"
 	event_sorting_index = 0
 
 #endregion

--- a/addons/dialogic/Modules/Comment/event_comment.gd
+++ b/addons/dialogic/Modules/Comment/event_comment.gd
@@ -8,7 +8,7 @@ extends DialogicEvent
 ### Settings
 
 ## Content of the comment.
-var text := ""
+@export var text := ""
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/Condition/event_condition.gd
+++ b/addons/dialogic/Modules/Condition/event_condition.gd
@@ -9,9 +9,9 @@ enum ConditionTypes {IF, ELIF, ELSE}
 ### Settings
 
 ## Condition type (see [ConditionTypes]). Defaults to if.
-var condition_type := ConditionTypes.IF
+@export var condition_type := ConditionTypes.IF
 ## The condition as a string. Will be executed as an Expression.
-var condition := ""
+@export var condition := ""
 
 
 #region EXECUTE
@@ -89,6 +89,14 @@ func is_valid_event(string:String) -> bool:
 	if string.strip_edges() in ['if', 'elif', 'else'] or (string.strip_edges().begins_with('if ') or string.strip_edges().begins_with('elif ') or string.strip_edges().begins_with('else')):
 		return true
 	return false
+
+
+## Only here to allow setting defaults in the module settings
+func get_shortcode_parameters() -> Dictionary:
+	return {
+		#param_name 	: property_info
+		"condition" 	: {"property": "condition", 			"default": ""},
+	}
 
 #endregion
 

--- a/addons/dialogic/Modules/History/event_history.gd
+++ b/addons/dialogic/Modules/History/event_history.gd
@@ -9,7 +9,7 @@ enum Actions {CLEAR, PAUSE, RESUME}
 ### Settings
 
 ## The type of action: Clear, Pause or Resume
-var action := Actions.PAUSE
+@export var action := Actions.PAUSE
 
 
 #region EXECUTION

--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -8,9 +8,9 @@ extends DialogicEvent
 ### Settings
 
 ## The timeline to jump to, if null then it's the current one. This setting should be a dialogic timeline resource.
-var timeline: DialogicTimeline
-## If not empty, the event will try to find a Label event with this set as name. Empty by default..
-var label_name := ""
+@export var timeline: DialogicTimeline
+## If not empty, the event will try to find a Label event with this set as name. Otherwise the given timeline will start from the beginning.
+@export var label_name := ""
 
 
 ### Helpers

--- a/addons/dialogic/Modules/Jump/event_label.gd
+++ b/addons/dialogic/Modules/Jump/event_label.gd
@@ -8,8 +8,10 @@ extends DialogicEvent
 ### Settings
 
 ## Used to identify the label. Duplicate names in a timeline will mean it always chooses the first.
-var name := ""
-var display_name := ""
+@export var name := ""
+## Translatable property you could use in game.
+## Will be passed to [signal Dialogic.Jump.passed_label] signal and the last one can be retreived with [method Dialogic.Jump.get_last_label_name].
+@export var display_name := ""
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/Save/event_save.gd
+++ b/addons/dialogic/Modules/Save/event_save.gd
@@ -9,7 +9,7 @@ extends DialogicEvent
 
 ## The name of the slot to save to. Learn more in the saving subsystem.
 ## If empty, the event will attempt to save to the latest slot, and otherwise use the default.
-var slot_name := ""
+@export var slot_name := ""
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/Settings/event_setting.gd
+++ b/addons/dialogic/Modules/Settings/event_setting.gd
@@ -16,7 +16,7 @@ enum SettingValueType {
 }
 
 ## The name of the setting to save to.
-var name := ""
+@export var name := ""
 var _value_type := 0 :
 	get:
 		return _value_type
@@ -30,9 +30,9 @@ var _value_type := 0 :
 					value = 0
 			ui_update_needed.emit()
 
-var value: Variant = ""
+@export var value: Variant = ""
 
-var mode := Modes.SET
+@export var mode := Modes.SET
 
 ## Used to suppress _value_type from overwriting value with a default value when the type changes
 ## This is only used when initializing the event_variable.

--- a/addons/dialogic/Modules/Settings/event_setting.gd
+++ b/addons/dialogic/Modules/Settings/event_setting.gd
@@ -71,8 +71,9 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Setting"
 	event_description = "Advanced: Changes a setting from the Settings subsystem."
+	event_sorting_index = 15
 	set_default_color('Color9')
-	event_category = "Helpers"
+	event_category = "Other"
 	event_sorting_index = 2
 
 

--- a/addons/dialogic/Modules/Signal/event_signal.gd
+++ b/addons/dialogic/Modules/Signal/event_signal.gd
@@ -9,10 +9,11 @@ extends DialogicEvent
 ### Settings
 
 enum ArgumentTypes {STRING, DICTIONARY}
-var argument_type := ArgumentTypes.STRING
-
+## The type of argument to be given with the signal.
+@export var argument_type := ArgumentTypes.STRING
 ## The argument that will be provided with the signal.
-var argument: Variant = ""
+@export var argument: Variant = ""
+
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/Style/event_style.gd
+++ b/addons/dialogic/Modules/Style/event_style.gd
@@ -8,7 +8,7 @@ extends DialogicEvent
 ### Settings
 
 ## The name of the style to change to. Can be set on the DialogicNode_Style.
-var style_name := ""
+@export var style_name := ""
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/StyleEditor/style_editor.tscn
+++ b/addons/dialogic/Modules/StyleEditor/style_editor.tscn
@@ -18,7 +18,7 @@ corner_radius_top_right = 10
 corner_radius_bottom_right = 10
 corner_radius_bottom_left = 10
 
-[sub_resource type="Image" id="Image_i40ox"]
+[sub_resource type="Image" id="Image_3rxjh"]
 data = {
 "data": PackedByteArray(0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255),
 "format": "RGBA8",
@@ -28,7 +28,7 @@ data = {
 }
 
 [sub_resource type="ImageTexture" id="ImageTexture_yr3tj"]
-image = SubResource("Image_i40ox")
+image = SubResource("Image_3rxjh")
 
 [node name="StyleEditor" type="HSplitContainer" unique_id=1865892929]
 anchors_preset = 15

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -382,7 +382,6 @@ func load_layout_scene_customization(custom_scene_path:String, overrides:Diction
 				current_subgroup_name = ""
 
 			&"SUBGROUP":
-
 				# add separator
 				if current_subgroup_name:
 					current_grid.add_child(HSeparator.new())

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -11,14 +11,14 @@ extends DialogicEvent
 ## This is the content of the text event.
 ## It is supposed to be displayed by a DialogicNode_DialogText node.
 ## That means you can use bbcode, but also some custom commands.
-var text := ""
+@export var text := ""
 ## If this is not null, the given character (as a resource) will be associated with this event.
 ## The DialogicNode_NameLabel will show the characters display_name. If a typing sound is setup,
 ## it will play.
-var character: DialogicCharacter = null
+@export var character: DialogicCharacter = null
 ## If a character is set, this setting can change the portrait of that character.
 ## If a runtime-character is created, the portrait can instead be a color (hex or color name).
-var portrait := ""
+@export var portrait := ""
 
 ### Helpers
 

--- a/addons/dialogic/Modules/TextInput/event_text_input.gd
+++ b/addons/dialogic/Modules/TextInput/event_text_input.gd
@@ -8,15 +8,15 @@ extends DialogicEvent
 ### Settings
 
 ## The promt to be shown.
-var text := "Please enter some text:"
+@export var text := "Please enter some text:"
 ## The name/path of the variable to set.
-var variable := ""
+@export var variable := ""
 ## The placeholder text to show in the line edit.
-var placeholder := ""
+@export var placeholder := ""
 ## The value that should be in the line edit by default.
-var default := ""
+@export var default := ""
 ## If true, the player can continue if nothing is entered.
-var allow_empty := false
+@export var allow_empty := false
 
 
 #region EXECUTION

--- a/addons/dialogic/Modules/Variable/event_variable.gd
+++ b/addons/dialogic/Modules/Variable/event_variable.gd
@@ -18,7 +18,7 @@ enum VarValueType {
 ## Settings
 
 ## Name/Path of the variable that should be changed.
-var name := "":
+@export var name := "":
 	set(_value):
 		name = _value
 		if Engine.is_editor_hint() and not value:
@@ -33,7 +33,7 @@ var name := "":
 		update_editor_warning()
 
 ## The operation to perform.
-var operation := Operations.SET:
+@export var operation := Operations.SET:
 	set(value):
 		operation = value
 		if not (operation == Operations.SET or operation == Operations.ADD) and _value_type == VarValueType.STRING:
@@ -42,8 +42,8 @@ var operation := Operations.SET:
 		update_editor_warning()
 
 ## The value that is used. Can be a variable as well.
-var value: Variant = ""
-var _value_type := 0 :
+@export var value: Variant = ""
+@export var _value_type := VarValueType.STRING :
 	set(_value):
 		_value_type = _value
 		if not _suppress_default_value:
@@ -60,8 +60,8 @@ var _value_type := 0 :
 		update_editor_warning()
 
 ## If true, a random number between [random_min] and [random_max] is used instead of [value].
-var random_min: int = 0
-var random_max: int = 100
+@export var random_min: int = 0
+@export var random_max: int = 100
 
 ## Used to suppress _value_type from overwriting value with a default value when the type changes
 ## This is only used when initializing the event_variable.
@@ -228,6 +228,19 @@ func from_text(string:String) -> void:
 
 func is_valid_event(string:String) -> bool:
 	return string.begins_with('set')
+
+
+## Only here to allow setting defaults in the module settings
+func get_shortcode_parameters() -> Dictionary:
+	return {
+		#param_name 	: property_info
+		"name" 			: {"property": "name", 					"default": ""},
+		"operation" 	: {"property": "operation",				"default": Operations.SET},
+		"value" 		: {"property": "value",					"default": ""},
+		"random_min" 	: {"property": "random_min", 			"default": 0},
+		"random_max" 	: {"property": "random_max", 			"default": 100},
+
+	}
 
 #endregion
 

--- a/addons/dialogic/Modules/Voice/event_voice.gd
+++ b/addons/dialogic/Modules/Voice/event_voice.gd
@@ -8,15 +8,15 @@ extends DialogicEvent
 ### Settings
 
 ## The path to the sound file.
-var file_path := "":
+@export_file var file_path := "":
 	set(value):
 		if file_path != value:
 			file_path = value
 			ui_update_needed.emit()
 ## The volume the sound will be played at.
-var volume: float = 0
+@export var volume: float = 0
 ## The audio bus to play the sound on.
-var audio_bus := "Master"
+@export var audio_bus := "Master"
 
 
 #region EXECUTE

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -8,11 +8,11 @@ extends DialogicEvent
 ### Settings
 
 ## The time in seconds that the event will stop before continuing.
-var time: float = 1.0
+@export var time: float = 1.0
 ## If true the text box will be hidden while the event waits.
-var hide_text := true
+@export var hide_text := true
 ## If true the wait can be skipped with user input
-var skippable := false
+@export var skippable := false
 
 var _tween: Tween
 

--- a/addons/dialogic/Modules/WaitInput/event_wait_input.gd
+++ b/addons/dialogic/Modules/WaitInput/event_wait_input.gd
@@ -4,7 +4,7 @@ extends DialogicEvent
 
 ## Event that waits for input before continuing.
 
-var hide_textbox := true
+@export var hide_textbox := true
 
 
 #region EXECUTE


### PR DESCRIPTION
# Event Color Settings
You can now see which events use a color by hovering the color button.

# Sorting of Event Button Sections & Hide some by default
Not the biggest fan of adding settings defaults to the DialogicUtil, might move this somewhere else later, but need to think about how to best do defaults for these things...

For now this hides the Save, Setting and History events and fixes the sorting of sections.

# Module Settings UI
- Shift Clicking a Filter button will solo it
- Changes icons for subsystems
- Change how Event Defaults UI is created (use same system as styles and portrait scenes)
To do so this @exports most major event settings. This is a bit of an invaisve change, but I cannot see a downside to this, it probably will just help someone for an obscure use-case and not do any harm anywhere else. In theory, especially with @export_custom we might actually be able to bypass a bunch of our own code, but tbh it would probably decrease the readability a lot, so no for now.

- Makes Reset logic the same as in style editor
- Adds Open Documentation, Show in Filesystem and Open (Script/Scene) buttons
