### PR TITLE
Fixes and More

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -548,6 +548,8 @@ func report_name_change(item: TreeItem) -> void:
 			if s_item.get_metadata(0).has('group') or !s_item.has_meta('new'):
 				report_name_change(s_item)
 	else:
+		if item.has_meta("new"):
+			return
 		if item.get_meta('previous_name') == %PortraitTree.get_full_item_name(item):
 			return
 		editors_manager.reference_manager.add_portrait_ref_change(

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -3,16 +3,16 @@ extends Tree
 
 ## Tree that displays the portrait list as a hirarchy
 
-var editor := find_parent('Character Editor')
+var editor := find_parent("Character Editor")
 var current_group_nodes := {}
 
 
 func _ready() -> void:
 	if owner.get_parent() is SubViewport:
 		return
-	$PortraitRightClickMenu.set_item_icon(0, get_theme_icon('Rename', 'EditorIcons'))
-	$PortraitRightClickMenu.set_item_icon(1, get_theme_icon('Duplicate', 'EditorIcons'))
-	$PortraitRightClickMenu.set_item_icon(2, get_theme_icon('Remove', 'EditorIcons'))
+	$PortraitRightClickMenu.set_item_icon(0, get_theme_icon("Rename", "EditorIcons"))
+	$PortraitRightClickMenu.set_item_icon(1, get_theme_icon("Duplicate", "EditorIcons"))
+	$PortraitRightClickMenu.set_item_icon(2, get_theme_icon("Remove", "EditorIcons"))
 	$PortraitRightClickMenu.set_item_icon(4, get_theme_icon("Favorites", "EditorIcons"))
 
 
@@ -27,11 +27,11 @@ func add_portrait_item(portrait_name: String, portrait_data: Dictionary, parent_
 	item.set_text(0, portrait_name)
 	item.set_metadata(0, portrait_data)
 	if previous_name.is_empty():
-		item.set_meta('previous_name', get_full_item_name(item))
+		item.set_meta("previous_name", get_full_item_name(item))
 	else:
-		item.set_meta('previous_name', previous_name)
+		item.set_meta("previous_name", previous_name)
 	if portrait_name == editor.current_resource.default_portrait:
-		item.add_button(0, get_theme_icon('Favorites', 'EditorIcons'), 2, true, 'Default')
+		item.add_button(0, get_theme_icon("Favorites", "EditorIcons"), 2, true, "Default")
 	return item
 
 
@@ -39,11 +39,11 @@ func add_portrait_group(goup_name := "Group", parent_item: TreeItem = get_root()
 	var item: TreeItem = %PortraitTree.create_item(parent_item)
 	item.set_icon(0, get_theme_icon("Folder", "EditorIcons"))
 	item.set_text(0, goup_name)
-	item.set_metadata(0, {'group':true})
+	item.set_metadata(0, {"group":true})
 	if previous_name.is_empty():
-		item.set_meta('previous_name', get_full_item_name(item))
+		item.set_meta("previous_name", get_full_item_name(item))
 	else:
-		item.set_meta('previous_name', previous_name)
+		item.set_meta("previous_name", previous_name)
 	update_left_item_margin(true)
 	return item
 
@@ -62,9 +62,9 @@ func create_necessary_group_items(path: String) -> TreeItem:
 	var last_item := get_root()
 	var item_path := ""
 
-	for i in Array(path.split('/')).slice(0, -1):
+	for i in Array(path.split("/")).slice(0, -1):
 		item_path += "/"+i
-		item_path = item_path.trim_prefix('/')
+		item_path = item_path.trim_prefix("/")
 		if current_group_nodes.has(item_path+"/"+i):
 			last_item = current_group_nodes[item_path+"/"+i]
 		else:
@@ -74,9 +74,9 @@ func create_necessary_group_items(path: String) -> TreeItem:
 	return last_item
 
 
-func _on_item_mouse_selected(pos: Vector2, mouse_button_index: int) -> void:
+func _on_item_mouse_selected(_pos: Vector2, mouse_button_index: int) -> void:
 	if mouse_button_index == MOUSE_BUTTON_RIGHT:
-		$PortraitRightClickMenu.set_item_disabled(1, get_selected().get_metadata(0).has('group'))
+		$PortraitRightClickMenu.set_item_disabled(1, get_selected().get_metadata(0).has("group"))
 		$PortraitRightClickMenu.popup_on_parent(Rect2(get_global_mouse_position(),Vector2()))
 
 
@@ -99,14 +99,14 @@ func _get_drag_data(at_position: Vector2) -> Variant:
 	drop_mode_flags = DROP_MODE_INBETWEEN
 	var preview := Label.new()
 	preview.text = "     "+drag_item.get_text(0)
-	preview.add_theme_stylebox_override('normal', get_theme_stylebox("Background", "EditorStyles"))
+	preview.add_theme_stylebox_override("normal", get_theme_stylebox("Background", "EditorStyles"))
 	set_drag_preview(preview)
 
 	return drag_item
 
 
 func _can_drop_data(_at_position: Vector2, data: Variant) -> bool:
-	if typeof(data) == TYPE_DICTIONARY and 'files' in data.keys():
+	if typeof(data) == TYPE_DICTIONARY and "files" in data.keys():
 		return true
 	return data is TreeItem
 
@@ -131,12 +131,12 @@ func _drop_data(at_position: Vector2, item: Variant) -> void:
 	if to_item:
 		parent = to_item.get_parent()
 
-	if to_item and to_item.get_metadata(0).has('group') and drop_section == 1:
+	if to_item and to_item.get_metadata(0).has("group") and drop_section == 1:
 		parent = to_item
 
 	var new_item := copy_branch_or_item(item, parent)
 
-	if to_item and !to_item.get_metadata(0).has('group') and drop_section == 1:
+	if to_item and !to_item.get_metadata(0).has("group") and drop_section == 1:
 		new_item.move_after(to_item)
 
 	if drop_section == -1:
@@ -149,10 +149,13 @@ func _drop_data(at_position: Vector2, item: Variant) -> void:
 
 func copy_branch_or_item(item: TreeItem, new_parent: TreeItem) -> TreeItem:
 	var new_item: TreeItem = null
-	if item.get_metadata(0).has('group'):
-		new_item = add_portrait_group(item.get_text(0), new_parent, item.get_meta('previous_name'))
+	if item.get_metadata(0).has("group"):
+		new_item = add_portrait_group(item.get_text(0), new_parent, item.get_meta("previous_name"))
 	else:
-		new_item = add_portrait_item(item.get_text(0), item.get_metadata(0), new_parent, item.get_meta('previous_name'))
+		new_item = add_portrait_item(item.get_text(0), item.get_metadata(0), new_parent, item.get_meta("previous_name"))
+
+	if item.has_meta("new"):
+		new_item.set_meta("new", true)
 
 	for child in item.get_children():
 		copy_branch_or_item(child, new_item)

--- a/addons/dialogic/Editor/Common/reference_manager.gd
+++ b/addons/dialogic/Editor/Common/reference_manager.gd
@@ -6,8 +6,11 @@ func _ready() -> void:
 	if get_parent() is SubViewport:
 		return
 
-	add_theme_stylebox_override("panel", get_theme_stylebox("Background", "EditorStyles"))
+	add_theme_stylebox_override("panel", get_theme_stylebox("Background", "EditorStyles").duplicate())
+	get_theme_stylebox("panel").set_content_margin_all(10)
 	$Tabs/Close.icon = get_theme_icon("Close", "EditorIcons")
+
+	%HelpButton.icon = get_theme_icon("ExternalLink", "EditorIcons")
 
 	for tab in $Tabs/Tabs.get_children():
 		tab.add_theme_color_override("font_selected_color", get_theme_color("accent_color", "Editor"))
@@ -36,3 +39,7 @@ func open() -> void:
 
 func _on_close_pressed() -> void:
 	get_parent()._on_close_requested()
+
+
+func _on_help_button_pressed() -> void:
+	OS.shell_open("https://docs.dialogic.pro/reference-manager.html")

--- a/addons/dialogic/Editor/Common/reference_manager.tscn
+++ b/addons/dialogic/Editor/Common/reference_manager.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://c7lmt5cp7bxcm"]
+[gd_scene format=3 uid="uid://c7lmt5cp7bxcm"]
 
 [ext_resource type="Script" uid="uid://dugy11ebty3yq" path="res://addons/dialogic/Editor/Common/reference_manager.gd" id="1_3t531"]
 [ext_resource type="Script" uid="uid://nrhtjk2rgmgk" path="res://addons/dialogic/Editor/Common/broken_reference_manager.gd" id="1_agmg4"]
@@ -310,12 +310,13 @@ layout_mode = 2
 size_flags_horizontal = 4
 text = "Close"
 
-[node name="HelpButton" type="LinkButton" parent="." unique_id=242293099]
+[node name="HelpButton" type="Button" parent="." unique_id=840546210]
+unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
-text = "Documentation"
-uri = "https://docs.dialogic.pro/reference-manager.html"
+theme_type_variation = &"FlatButton"
+text = "Online Docs"
 
 [connection signal="pressed" from="Tabs/BrokenReferences/ChangesList/VBox/HBoxContainer/AddButton" to="Tabs/BrokenReferences" method="_on_add_button_pressed"]
 [connection signal="item_selected" from="Tabs/BrokenReferences/ChangesList/VBox/ReplacementEditPanel/VBox/HBoxContainer3/Type" to="Tabs/BrokenReferences/ChangesList/VBox/ReplacementEditPanel" method="_on_type_item_selected"]
@@ -329,3 +330,4 @@ uri = "https://docs.dialogic.pro/reference-manager.html"
 [connection signal="button_clicked" from="Tabs/UniqueIdentifiers/VBox/IdentifierTable" to="Tabs/UniqueIdentifiers" method="_on_identifier_table_button_clicked"]
 [connection signal="item_edited" from="Tabs/UniqueIdentifiers/VBox/IdentifierTable" to="Tabs/UniqueIdentifiers" method="_on_identifier_table_item_edited"]
 [connection signal="pressed" from="Tabs/Close" to="." method="_on_close_pressed"]
+[connection signal="pressed" from="HelpButton" to="." method="_on_help_button_pressed"]

--- a/addons/dialogic/Editor/Common/side_bar.tscn
+++ b/addons/dialogic/Editor/Common/side_bar.tscn
@@ -98,7 +98,6 @@ placeholder_text = "Filter Resources"
 caret_blink = true
 caret_blink_interval = 0.5
 
-
 [node name="RightTools" type="HBoxContainer" parent="VBoxPrimary/Margin/MainVSplit/VBox/Tools/HBox" unique_id=803895286]
 unique_name_in_owner = true
 layout_mode = 2
@@ -107,6 +106,7 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Resource List Options"
+theme_type_variation = &"FlatMenuButton"
 flat = false
 
 [node name="ResourceTree" type="Tree" parent="VBoxPrimary/Margin/MainVSplit/VBox" unique_id=47398120]

--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -159,10 +159,11 @@ func _hide_sidebar() -> void:
 
 func _on_editors_resource_opened(_resource: Resource) -> void:
 	%ContentListSection.hide()
+
 	update_resource_list()
 
 
-func _on_editors_editor_changed(_previous: DialogicEditor, current: DialogicEditor) -> void:
+func _on_editors_editor_changed(_previous: DialogicEditor, _current: DialogicEditor) -> void:
 	update_resource_list()
 	%ContentListSection.hide()
 	update_content_list()
@@ -509,7 +510,7 @@ func update_content_list() -> void:
 		%ContentListSection.hide()
 		return
 
-	var current_labels := DialogicResourceUtil.get_label_cache().get(current_resource.get_identifier(), [])
+	var current_labels: Array = DialogicResourceUtil.get_label_cache().get(current_resource.get_identifier(), [])
 	if current_labels.is_empty():
 		%ContentListSection.hide()
 		return
@@ -603,7 +604,7 @@ func _on_main_v_split_dragged(offset: int) -> void:
 	DialogicUtil.set_editor_setting("sidebar_v_split", offset)
 
 
-func _on_resource_tree_empty_clicked(click_position: Vector2, mouse_button_index: int) -> void:
+func _on_resource_tree_empty_clicked(_click_position: Vector2, mouse_button_index: int) -> void:
 	if mouse_button_index == MOUSE_BUTTON_RIGHT:
 		%RightClickNoItemMenu.popup_on_parent(Rect2(get_global_mouse_position(), Vector2()))
 

--- a/addons/dialogic/Editor/HomePage/home_page.tscn
+++ b/addons/dialogic/Editor/HomePage/home_page.tscn
@@ -292,7 +292,7 @@ layout_mode = 2
 layout_mode = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_es88k")
 bbcode_enabled = true
-text = "[center]Welcome to dialogic, a plugin that lets you easily create stories and dialogs for your game!
+text = "[center]Welcome to Dialogic, a plugin that lets you easily create stories and dialogs for your game!
 
 If you are new, start by creating a timeline or character!"
 fit_content = true

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -181,8 +181,12 @@ func color_region(dict:Dictionary, color:Color, line:String, start:String, end:S
 	if end.is_empty():
 		region_regex.compile(r"(?<!\\)"+start+".*")
 	else:
-		r"(?<!\\){([^{}]|({[^}]*}))*}"
-		region_regex.compile(r"(?<!\\)"+start+"([^"+start+end+"]|("+start+"[^"+end+"]*"+end+"))*"+end)
+		if start != end:
+			r"(?<!\\){([^{}]|({[^}]*}))*}" # example for { }
+			region_regex.compile(r"(?<!\\)"+start+"([^"+start+end+"]|("+start+"[^"+end+"]*"+end+"))*"+end)
+		else:
+			r"(?<!\\)'([^'])*'" # example for ' '
+			region_regex.compile(r"(?<!\\)"+start+"([^"+end+"])*"+end)
 	if to <= from:
 		to = len(line)-1
 	for region in region_regex.search_all(line.substr(from, to-from+2)):

--- a/addons/dialogic/Editor/editors_manager.gd
+++ b/addons/dialogic/Editor/editors_manager.gd
@@ -22,7 +22,6 @@ var current_editor: DialogicEditor = null
 var previous_editor: DialogicEditor = null
 var editors := {}
 var supported_file_extensions := []
-var used_resources_cache: Array = []
 enum ButtonPlacement {TOOLBAR_MAIN, SIDEBAR_LEFT_OF_FILTER, SIDEBAR_RIGHT_OF_FILTER}
 
 
@@ -61,8 +60,6 @@ func _ready() -> void:
 	await get_tree().process_frame
 
 	load_saved_state()
-	used_resources_cache = DialogicUtil.get_editor_setting('last_resources', [])
-	sidebar.update_resource_list(used_resources_cache)
 
 	EditorInterface.get_file_system_dock().files_moved.connect(_on_file_moved)
 	EditorInterface.get_file_system_dock().file_removed.connect(_on_file_removed)
@@ -79,15 +76,15 @@ func _add_editor(path:String) -> void:
 
 ## Call to register an editor/tab that edits a resource with a custom ending.
 func register_resource_editor(resource_extension:String, editor:DialogicEditor) -> void:
-	editors[editor.name] = {'node':editor, 'buttons':[], 'extension': resource_extension}
+	editors[editor.name] = {"node":editor, "buttons":[], "extension": resource_extension}
 	supported_file_extensions.append(resource_extension)
 	editor.resource_saved.connect(_on_resource_saved.bind(editor))
 	editor.resource_unsaved.connect(_on_resource_unsaved.bind(editor))
 
 
-## Call to register an editor/tab that doesn't edit a resource
+## Call to register an editor/tab that doesn"t edit a resource
 func register_simple_editor(editor:DialogicEditor) -> void:
-	editors[editor.name] = {'node': editor,  'buttons':[]}
+	editors[editor.name] = {"node": editor,  "buttons":[]}
 
 
 ## Call to add a button.
@@ -98,9 +95,9 @@ func add_button(icon:Texture, label:String, tooltip:String, editor:DialogicEdito
 			button = toolbar.add_button(icon, label, tooltip, placement)
 		ButtonPlacement.SIDEBAR_LEFT_OF_FILTER, ButtonPlacement.SIDEBAR_RIGHT_OF_FILTER:
 			button = sidebar.add_button(icon, label, tooltip, placement)
-	
+
 	if editor != null:
-		editors[editor.name]['buttons'].append(button)
+		editors[editor.name]["buttons"].append(button)
 	return button
 
 
@@ -119,25 +116,21 @@ func _on_editors_tab_changed(tab:int) -> void:
 
 func edit_resource(resource:Resource, save_previous:bool = true, silent:= false) -> void:
 	if not resource:
-		# The resource doesn't exists, show an error
+		# The resource doesn"t exists, show an error
 		print("[Dialogic] The resource you are trying to edit doesn't exist any more.")
 		return
 
 	if current_editor and save_previous:
 		current_editor._save()
 
-	if !resource.resource_path in used_resources_cache:
-		used_resources_cache.append(resource.resource_path)
-		sidebar.update_resource_list(used_resources_cache)
-
 	## Open the correct editor
 	var extension: String = resource.resource_path.get_extension()
 	for editor in editors.values():
-		if editor.get('extension', '') == extension:
-			editor['node']._open_resource(resource)
-			if !silent:
-				open_editor(editor['node'], false)
-	if !silent:
+		if editor.get("extension", "") == extension:
+			editor["node"]._open_resource(resource)
+			if not silent:
+				open_editor(editor["node"], false)
+	if not silent:
 		resource_opened.emit(resource)
 
 
@@ -168,14 +161,6 @@ func open_editor(editor:DialogicEditor, save_previous: bool = true, extra_info:V
 	editor.show()
 	tabbar.current_tab = editor.get_index()
 
-	if editor.current_resource:
-		var text: String = editor.current_resource.resource_path.get_file()
-		if editor.current_resource_state == DialogicEditor.ResourceStates.UNSAVED:
-			text += "(*)"
-
-	## This makes custom button editor-specific
-	## I think it's better without.
-
 	save_current_state()
 	editor_changed.emit(previous_editor, current_editor)
 
@@ -190,22 +175,22 @@ func clear_editor(editor:DialogicEditor, save:bool = false) -> void:
 
 ## Shows a file selector. Calls [accept_callable] once accepted
 func show_add_resource_dialog(accept_callable:Callable, filter:String = "*", title = "New resource", default_name = "new_character", mode = EditorFileDialog.FILE_MODE_SAVE_FILE) -> void:
-	find_parent('EditorView').godot_file_dialog(
+	find_parent("EditorView").godot_file_dialog(
 		_on_add_resource_dialog_accepted.bind(accept_callable),
 		filter,
 		mode,
 		title,
 		default_name,
 		true,
-		"Do not use \"'()!;:/\\*# in character or timeline names!"
+		"Do not use '\"()!;:/\\*# in character or timeline names!"
 	)
 
 
 func _on_add_resource_dialog_accepted(path:String, callable:Callable) -> void:
-	var file_name: String = path.get_file().trim_suffix('.'+path.get_extension())
-	for i in ['#','&','+',';','(',')','!','*','*','"',"'",'%', '$', ':','.',',']:
-		file_name = file_name.replace(i, '')
-	callable.call(path.trim_suffix(path.get_file()).path_join(file_name)+'.'+path.get_extension())
+	var file_name: String = path.get_file().trim_suffix("."+path.get_extension())
+	for i in ["#","&","+",";","(",")","!","*","*",""",""","%", "$", ":",".",","]:
+		file_name = file_name.replace(i, "")
+	callable.call(path.trim_suffix(path.get_file()).path_join(file_name)+"."+path.get_extension())
 
 
 ## Called by the plugin.gd script on CTRL+S or Debug Game start
@@ -215,44 +200,44 @@ func save_current_resource() -> void:
 
 
 ## Change the resource state
-func _on_resource_saved(editor:DialogicEditor):
+func _on_resource_saved(_editor:DialogicEditor):
 	sidebar.set_unsaved_indicator(true)
 
 
 ## Change the resource state
-func _on_resource_unsaved(editor:DialogicEditor):
+func _on_resource_unsaved(_editor:DialogicEditor):
 	sidebar.set_unsaved_indicator(false)
 
 
 ## Tries opening the last resource
 func load_saved_state() -> void:
-	var current_resources: Dictionary = DialogicUtil.get_editor_setting('current_resources', {})
+	var current_resources: Dictionary = DialogicUtil.get_editor_setting("current_resources", {})
 	for editor in current_resources.keys():
-		editors[editor]['node']._open_resource(load(current_resources[editor]))
+		editors[editor]["node"]._open_resource(load(current_resources[editor]))
 
-	var current_editor: String = DialogicUtil.get_editor_setting('current_editor', 'HomePage')
-	open_editor(editors[current_editor]['node'])
+	var loaded_current_editor: String = DialogicUtil.get_editor_setting("current_editor", "HomePage")
+	open_editor(editors[loaded_current_editor]["node"])
 
 
 func save_current_state() -> void:
-	DialogicUtil.set_editor_setting('current_editor', current_editor.name)
+	DialogicUtil.set_editor_setting("current_editor", current_editor.name)
 	var current_resources: Dictionary = {}
 	for editor in editors.values():
-		if editor['node'].current_resource != null:
-			current_resources[editor['node'].name] = editor['node'].current_resource.resource_path
-	DialogicUtil.set_editor_setting('current_resources', current_resources)
+		if editor["node"].current_resource != null:
+			current_resources[editor["node"].name] = editor["node"].current_resource.resource_path
+	DialogicUtil.set_editor_setting("current_resources", current_resources)
 
 
 func _on_file_moved(old_name:String, new_name:String) -> void:
-	if !old_name.get_extension() in supported_file_extensions:
+	if not old_name.get_extension() in supported_file_extensions:
 		return
 
-	used_resources_cache = DialogicUtil.get_editor_setting('last_resources', [])
-	if old_name in used_resources_cache:
-		used_resources_cache.insert(used_resources_cache.find(old_name), new_name)
-		used_resources_cache.erase(old_name)
+	var used_resources_list = DialogicUtil.get_editor_setting("last_resources", [])
+	if old_name in used_resources_list:
+		used_resources_list.insert(used_resources_list.find(old_name), new_name)
+		used_resources_list.erase(old_name)
 
-	sidebar.update_resource_list(used_resources_cache)
+	sidebar.update_resource_list(used_resources_list)
 
 	for editor in editors:
 		if editors[editor].node.current_resource != null and editors[editor].node.current_resource.resource_path == old_name:
@@ -263,7 +248,7 @@ func _on_file_moved(old_name:String, new_name:String) -> void:
 
 
 func _on_file_removed(file_name:String) -> void:
-	var current_resources: Dictionary = DialogicUtil.get_editor_setting('current_resources', {})
+	var current_resources: Dictionary = DialogicUtil.get_editor_setting("current_resources", {})
 	for editor_name in current_resources:
 		if current_resources[editor_name] == file_name:
 			clear_editor(editors[editor_name].node, false)
@@ -272,14 +257,9 @@ func _on_file_removed(file_name:String) -> void:
 
 
 
-################################################################################
-## 						HELPERS
+#region HELPERS
 ################################################################################
 
 
 func get_current_editor() -> DialogicEditor:
 	return current_editor
-
-
-func _exit_tree() -> void:
-	DialogicUtil.set_editor_setting('last_resources', used_resources_cache)

--- a/addons/dialogic/Modules/Call/event_call.gd
+++ b/addons/dialogic/Modules/Call/event_call.gd
@@ -22,7 +22,10 @@ extends DialogicEvent
 		if Engine.is_editor_hint():
 			check_arguments_and_update_warning()
 
-var _current_method_arg_hints := {'a':null, 'm':null, 'info':{}}
+var _current_method_arg_hints := {"a":null, "m":null, "info":{}}
+
+var regex := RegEx.create_from_string(r"do (?<autoload>[^\(]*)\.((?<method>[^.(]*)(\((?<arguments>.*)\))?)?")
+var split_args_regex := RegEx.create_from_string(r"(,|^)(\s)*(?<arg>([^[\"'\],]+)|(\[[^\]]*\])|(\"[^\"]*\")|('[^']*'))(\s)*(?=,|$)")
 
 
 #region EXECUTION
@@ -31,8 +34,8 @@ var _current_method_arg_hints := {'a':null, 'm':null, 'info':{}}
 func _execute() -> void:
 	var object: Object = null
 	var obj_path := autoload_name
-	var autoload: Node = dialogic.get_node('/root/'+obj_path.get_slice('.', 0))
-	obj_path = obj_path.trim_prefix(obj_path.get_slice('.', 0)+'.')
+	var autoload: Node = dialogic.get_node("/root/"+obj_path.get_slice(".", 0))
+	obj_path = obj_path.trim_prefix(obj_path.get_slice(".", 0)+".")
 	object = autoload
 	if object:
 		while obj_path:
@@ -40,7 +43,7 @@ func _execute() -> void:
 				object = object.get(obj_path.get_slice(".", 0))
 			else:
 				break
-			obj_path = obj_path.trim_prefix(obj_path.get_slice('.', 0)+'.')
+			obj_path = obj_path.trim_prefix(obj_path.get_slice(".", 0)+".")
 
 	if object == null:
 		printerr("[Dialogic] Call event failed: Unable to find autoload '",autoload_name,"'")
@@ -50,8 +53,8 @@ func _execute() -> void:
 	if object.has_method(method):
 		var args := []
 		for arg in arguments:
-			if arg is String and arg.begins_with('@'):
-				args.append(dialogic.Expressions.execute_string(arg.trim_prefix('@')))
+			if arg is String and arg.begins_with("@"):
+				args.append(dialogic.Expressions.execute_string(arg.trim_prefix("@")))
 			else:
 				args.append(arg)
 		dialogic.current_state = dialogic.States.WAITING
@@ -71,7 +74,7 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Call"
 	event_description = "Calls a method on an autoload script or scene."
-	set_default_color('Color6')
+	set_default_color("Color6")
 	event_category = "Logic"
 	event_sorting_index = 10
 
@@ -86,37 +89,39 @@ func to_text() -> String:
 	if autoload_name:
 		result += autoload_name
 		if method:
-			result += '.'+method
+			result += "."+method
 			if arguments.is_empty():
-				result += '()'
+				result += "()"
 			else:
-				result += '('
+				result += "("
 				for i in arguments:
-					if i is String and i.begins_with('@'):
-						result += i.trim_prefix('@')
+					if i is String and i.begins_with("@"):
+						result += i.trim_prefix("@")
 					else:
 						result += var_to_str(i)
-					result += ', '
-				result = result.trim_suffix(', ')+')'
+					result += ", "
+				result = result.trim_suffix(", ")+")"
 	return result
 
 
 func from_text(string:String) -> void:
-	var result := RegEx.create_from_string(r"do (?<autoload>[^\(]*)\.((?<method>[^.(]*)(\((?<arguments>.*)\))?)?").search(string.strip_edges())
+	var result := regex.search(string.strip_edges())
 	if result:
-		autoload_name = result.get_string('autoload')
-		method = result.get_string('method')
-		if result.get_string('arguments').is_empty():
+		autoload_name = result.get_string("autoload")
+		method = result.get_string("method")
+		if result.get_string("arguments").is_empty():
 			arguments = []
 		else:
 			var arr := []
-			for i in result.get_string('arguments').split(','):
-				i = i.strip_edges()
-				if str_to_var(i) != null:
-					arr.append(str_to_var(i))
+			for arg_result in split_args_regex.search_all(result.get_string("arguments")):
+				var arg := arg_result.get_string("arg").strip_edges()
+				if arg.is_empty():
+					continue
+				if str_to_var(arg) != null:
+					arr.append(str_to_var(arg))
 				else:
 					# Mark this as a complex expression
-					arr.append("@"+i)
+					arr.append("@"+arg)
 			arguments = arr
 
 
@@ -141,15 +146,15 @@ func get_shortcode_parameters() -> Dictionary:
 ################################################################################
 
 func build_event_editor() -> void:
-	add_header_edit('autoload_name', ValueType.DYNAMIC_OPTIONS, {'left_text':'On autoload',
-		'empty_text':'Autoload',
-		'suggestions_func': DialogicUtil.get_autoload_suggestions,
-		'editor_icon':["Node", "EditorIcons"]})
-	add_header_edit('method', ValueType.DYNAMIC_OPTIONS, {'left_text':'call',
-		'empty_text':'Method',
-		'suggestions_func': get_method_suggestions,
-		'editor_icon':["Callable", "EditorIcons"]}, 'autoload_name')
-	add_body_edit('arguments', ValueType.ARRAY, {'left_text':'Arguments:'}, 'not autoload_name.is_empty() and not method.is_empty()')
+	add_header_edit("autoload_name", ValueType.DYNAMIC_OPTIONS, {"left_text":"On autoload",
+		"empty_text":"Autoload",
+		"suggestions_func": DialogicUtil.get_autoload_suggestions,
+		"editor_icon":["Node", "EditorIcons"]})
+	add_header_edit("method", ValueType.DYNAMIC_OPTIONS, {"left_text":"call",
+		"empty_text":"Method",
+		"suggestions_func": get_method_suggestions,
+		"editor_icon":["Callable", "EditorIcons"]}, "autoload_name")
+	add_body_edit("arguments", ValueType.ARRAY, {"left_text":"Arguments:"}, "not autoload_name.is_empty() and not method.is_empty()")
 
 
 func get_method_suggestions(filter:="") -> Dictionary:
@@ -158,13 +163,13 @@ func get_method_suggestions(filter:="") -> Dictionary:
 
 func update_argument_info() -> void:
 	if autoload_name and method and not _current_method_arg_hints.is_empty() and (_current_method_arg_hints.a == autoload_name and _current_method_arg_hints.m == method):
-		if !ResourceLoader.exists(ProjectSettings.get_setting('autoload/'+autoload_name, '').trim_prefix('*')):
+		if !ResourceLoader.exists(ProjectSettings.get_setting("autoload/"+autoload_name, "").trim_prefix("*")):
 			_current_method_arg_hints = {}
 			return
-		var script: Script = load(ProjectSettings.get_setting('autoload/'+autoload_name, '').trim_prefix('*'))
+		var script: Script = load(ProjectSettings.get_setting("autoload/"+autoload_name, "").trim_prefix("*"))
 		for m in script.get_script_method_list():
 			if m.name == method:
-				_current_method_arg_hints = {'a':autoload_name, 'm':method, 'info':m}
+				_current_method_arg_hints = {"a":autoload_name, "m":method, "info":m}
 				break
 
 
@@ -180,7 +185,7 @@ func check_arguments_and_update_warning() -> void:
 			continue
 		if _current_method_arg_hints.info.args[idx].type != 0:
 			if _current_method_arg_hints.info.args[idx].type != typeof(arg):
-				if arg is String and arg.begins_with('@'):
+				if arg is String and arg.begins_with("@"):
 					continue
 				var expected_type: String = ""
 				match _current_method_arg_hints.info.args[idx].type:
@@ -190,7 +195,7 @@ func check_arguments_and_update_warning() -> void:
 					TYPE_INT: 		expected_type = "int"
 					_: 				expected_type = "something else"
 
-				ui_update_warning.emit('Argument '+ str(idx+1)+ ' ('+_current_method_arg_hints.info.args[idx].name+') has the wrong type (method expects '+expected_type+')!')
+				ui_update_warning.emit("Argument "+ str(idx+1)+ " ("+_current_method_arg_hints.info.args[idx].name+") has the wrong type (method expects "+expected_type+")!")
 				return
 
 	if len(arguments) < len(_current_method_arg_hints.info.args)-len(_current_method_arg_hints.info.default_args):
@@ -211,21 +216,21 @@ func _get_code_completion(CodeCompletionHelper:Node, TextNode:TextEdit, line:Str
 	var autoloads := DialogicUtil.get_autoload_suggestions()
 	var line_until_caret: String = CodeCompletionHelper.get_line_untill_caret(line)
 
-	if line.count(' ') == 1 and not '.' in line:
+	if line.count(" ") == 1 and not "." in line:
 		for i in autoloads:
-			TextNode.add_code_completion_option(CodeEdit.KIND_MEMBER, i, i+'.', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), TextNode.get_theme_icon("Node", "EditorIcons"))
+			TextNode.add_code_completion_option(CodeEdit.KIND_MEMBER, i, i+".", event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), TextNode.get_theme_icon("Node", "EditorIcons"))
 
 	elif (line_until_caret.ends_with(".") or symbol == "."):
 		var some_autoload := line_until_caret.split(" ")[-1].split(".")[0]
 		if some_autoload in autoloads:
 			var methods := DialogicUtil.get_autoload_method_suggestions("", some_autoload)
 			for i in methods.keys():
-				TextNode.add_code_completion_option(CodeEdit.KIND_MEMBER, i, i+'(', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), TextNode.get_theme_icon("MemberMethod", "EditorIcons"))
+				TextNode.add_code_completion_option(CodeEdit.KIND_MEMBER, i, i+"(", event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), TextNode.get_theme_icon("MemberMethod", "EditorIcons"))
 
 
 
 func _get_start_code_completion(_CodeCompletionHelper:Node, TextNode:TextEdit) -> void:
-	TextNode.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'do', 'do ', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), _get_icon())
+	TextNode.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, "do", "do ", event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.3), _get_icon())
 
 #endregion
 
@@ -234,13 +239,13 @@ func _get_start_code_completion(_CodeCompletionHelper:Node, TextNode:TextEdit) -
 ################################################################################
 
 func _get_syntax_highlighting(Highlighter:SyntaxHighlighter, dict:Dictionary, line:String) -> Dictionary:
-	dict[line.find('do')] = {"color":event_color.lerp(Highlighter.normal_color, 0.3)}
-	dict[line.find('do')+2] = {"color":event_color.lerp(Highlighter.normal_color, 0.5)}
+	dict[line.find("do")] = {"color":event_color.lerp(Highlighter.normal_color, 0.3)}
+	dict[line.find("do")+2] = {"color":event_color.lerp(Highlighter.normal_color, 0.5)}
 
-	Highlighter.color_region(dict, Highlighter.normal_color, line, '(', ')')
+	Highlighter.color_region(dict, Highlighter.normal_color, line, "(", ")")
 	Highlighter.color_region(dict, Highlighter.string_color, line, '"', '"')
-	Highlighter.color_word(dict, Highlighter.boolean_operator_color, line, 'true')
-	Highlighter.color_word(dict, Highlighter.boolean_operator_color, line, 'false')
+	Highlighter.color_word(dict, Highlighter.boolean_operator_color, line, "true")
+	Highlighter.color_word(dict, Highlighter.boolean_operator_color, line, "false")
 	return dict
 
 #endregion

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd
@@ -40,6 +40,7 @@ func _ready() -> void:
 
 	%ReferenceInfo.get_node('Label').add_theme_color_override('font_color', get_theme_color("warning_color", "Editor"))
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
+	%Documentation.icon = get_theme_icon("ExternalLink", "EditorIcons")
 
 #region RENAMING
 
@@ -63,3 +64,7 @@ func _on_reference_manager_pressed() -> void:
 
 func _on_search_text_changed(new_text: String) -> void:
 	%Tree.filter(new_text)
+
+
+func _on_documentation_pressed() -> void:
+	OS.shell_open("https://docs.dialogic.pro/variables.html")

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
@@ -1,13 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://6tdle4y5o03o"]
+[gd_scene format=3 uid="uid://6tdle4y5o03o"]
 
 [ext_resource type="Script" uid="uid://d1yoykg323a5p" path="res://addons/dialogic/Modules/Variable/variables_editor/variables_editor.gd" id="2"]
 [ext_resource type="Script" uid="uid://deduielq1r0r" path="res://addons/dialogic/Modules/Variable/variables_editor/variable_tree.gd" id="2_1i17i"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1bhct"]
-content_margin_left = 6.0
-content_margin_top = 6.0
-content_margin_right = 6.0
-content_margin_bottom = 6.0
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
 bg_color = Color(0.337, 0.62, 1, 0.2)
 border_width_left = 2
 border_width_top = 2
@@ -52,38 +52,45 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+split_offsets = PackedInt32Array(12)
+split_offset = 12
 script = ExtResource("2")
 
-[node name="Editor" type="VBoxContainer" parent="." unique_id=1875027373]
+[node name="PanelContainer" type="PanelContainer" parent="." unique_id=1972038904]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_type_variation = &"DialogicPanelA"
+
+[node name="Editor" type="VBoxContainer" parent="PanelContainer" unique_id=1875027373]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="HBox" type="HBoxContainer" parent="Editor" unique_id=522266499]
+[node name="HBox" type="HBoxContainer" parent="PanelContainer/Editor" unique_id=522266499]
 layout_mode = 2
 
-[node name="Title" type="Label" parent="Editor/HBox" unique_id=2042431687]
+[node name="Title" type="Label" parent="PanelContainer/Editor/HBox" unique_id=2042431687]
 layout_mode = 2
 theme_type_variation = &"DialogicSubTitle"
 text = "Variables"
 
-[node name="Search" type="LineEdit" parent="Editor/HBox" unique_id=2112236003]
+[node name="Search" type="LineEdit" parent="PanelContainer/Editor" unique_id=2112236003]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-placeholder_text = "Filter"
+placeholder_text = "Filter Variables"
 
-[node name="Tree" type="Tree" parent="Editor" unique_id=913318958]
+[node name="Tree" type="Tree" parent="PanelContainer/Editor" unique_id=913318958]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
-theme_type_variation = &"DialogicPanelB"
+theme_type_variation = &"TreeSecondary"
 theme_override_constants/button_margin = 4
 theme_override_constants/draw_guides = 1
 columns = 3
 column_titles_visible = true
 script = ExtResource("2_1i17i")
 
-[node name="ChangeTypePopup" type="PanelContainer" parent="Editor/Tree" unique_id=782708767]
+[node name="ChangeTypePopup" type="PanelContainer" parent="PanelContainer/Editor/Tree" unique_id=782708767]
 unique_name_in_owner = true
 visible = false
 self_modulate = Color(0.1021275, 0.1021275, 0.1021275, 1)
@@ -95,62 +102,63 @@ offset_bottom = 190.0
 theme = SubResource("Theme_17j6i")
 theme_override_styles/panel = SubResource("StyleBoxFlat_ncgqs")
 
-[node name="HBox" type="HBoxContainer" parent="Editor/Tree/ChangeTypePopup" unique_id=133785951]
+[node name="HBox" type="HBoxContainer" parent="PanelContainer/Editor/Tree/ChangeTypePopup" unique_id=133785951]
 layout_mode = 2
 
-[node name="String" type="Button" parent="Editor/Tree/ChangeTypePopup/HBox" unique_id=592609856]
+[node name="String" type="Button" parent="PanelContainer/Editor/Tree/ChangeTypePopup/HBox" unique_id=592609856]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 tooltip_text = "String (Any text)"
 toggle_mode = true
 icon_alignment = 1
 
-[node name="Float" type="Button" parent="Editor/Tree/ChangeTypePopup/HBox" unique_id=304875364]
+[node name="Float" type="Button" parent="PanelContainer/Editor/Tree/ChangeTypePopup/HBox" unique_id=304875364]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 tooltip_text = "Float (Number with Decimals)"
 toggle_mode = true
 icon_alignment = 1
 
-[node name="Int" type="Button" parent="Editor/Tree/ChangeTypePopup/HBox" unique_id=1830794936]
+[node name="Int" type="Button" parent="PanelContainer/Editor/Tree/ChangeTypePopup/HBox" unique_id=1830794936]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 tooltip_text = "Int (Integer)"
 toggle_mode = true
 icon_alignment = 1
 
-[node name="Bool" type="Button" parent="Editor/Tree/ChangeTypePopup/HBox" unique_id=586558133]
+[node name="Bool" type="Button" parent="PanelContainer/Editor/Tree/ChangeTypePopup/HBox" unique_id=586558133]
 custom_minimum_size = Vector2(30, 30)
 layout_mode = 2
 tooltip_text = "Bool (True/False flag)"
 toggle_mode = true
 icon_alignment = 1
 
-[node name="RightClickMenu" type="PopupMenu" parent="Editor/Tree" unique_id=567109241]
+[node name="RightClickMenu" type="PopupMenu" parent="PanelContainer/Editor/Tree" unique_id=567109241]
 unique_name_in_owner = true
 size = Vector2i(67, 35)
 item_count = 1
 item_0/text = "Copy"
 item_0/id = 0
 
-[node name="ReferenceInfo" type="HBoxContainer" parent="Editor" unique_id=307117089]
+[node name="ReferenceInfo" type="HBoxContainer" parent="PanelContainer/Editor" unique_id=307117089]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Editor/ReferenceInfo" unique_id=1059085735]
+[node name="Label" type="Label" parent="PanelContainer/Editor/ReferenceInfo" unique_id=1059085735]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_color = Color(0.83, 0.78, 0.62, 1)
 text = "You've made some changes to existing variables! Use the reference manager to check if something broke."
 autowrap_mode = 3
 
-[node name="ReferenceManager" type="Button" parent="Editor/ReferenceInfo" unique_id=1766978997]
+[node name="ReferenceManager" type="Button" parent="PanelContainer/Editor/ReferenceInfo" unique_id=1766978997]
 layout_mode = 2
 text = "Reference Manager"
 
 [node name="Info" type="VBoxContainer" parent="." unique_id=227696553]
 layout_mode = 2
 size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.7
 
 [node name="HBox" type="HBoxContainer" parent="Info" unique_id=362730822]
 layout_mode = 2
@@ -161,19 +169,37 @@ size_flags_horizontal = 3
 theme_type_variation = &"DialogicSection"
 text = "How to use variables"
 
-[node name="Documentation" type="LinkButton" parent="Info/HBox" unique_id=965398298]
+[node name="Documentation" type="Button" parent="Info/HBox" unique_id=754140705]
+unique_name_in_owner = true
 layout_mode = 2
+theme_type_variation = &"FlatButton"
 text = "Read the Docs"
-uri = "https://docs.dialogic.pro/variables.html"
 
 [node name="RichTextLabel" type="RichTextLabel" parent="Info" unique_id=2046774878]
 layout_mode = 2
-text = "Variables are good way to keep track of all kinds of things during your game. Dialogic has an easy-to-use and beginner friendly variable system built in. However Dialogic allows to use outside variables (of Autoload Singletons) just as easily. You can also access the Dialogic variables from outside scripts."
+theme_override_constants/text_highlight_h_padding = 3
+theme_override_constants/text_highlight_v_padding = 1
+bbcode_enabled = true
+text = "Variables are a good way to keep track of all kinds of things during your game: The player name, their health or the state of the world, their relationships, quests, etc. 
+
+Setup the variables and their defaults in this editor and then change them during timelines with the [b]Set Variable[/b] event.
+
+You can use variables in conditions on the [b]Condition[/b] and [b]Choice[/b] events or as expressions in texts: 
+[color=web_gray][code]Hi I'm [color=turquoise]{PlayerName}[/color].[/code][/color]
+
+If you need to access a variables value from a script, you can do so like this:
+[color=web_gray][code]print([color=goldenrod]Dialogic[/color].[color=olive_drab]VAR[/color].[color=turquoise]MyVariable[/color])
+[color=goldenrod]Dialogic[/color].[color=olive_drab]VAR[/color].[color=turquoise]AnotherVariable[/color] = 42[/code][/color]
+
+You can create variable groups with [img]res://addons/dialogic/Editor/Images/Pieces/add-folder.svg[/img]. To access a variable in a group use it's \"path\" like so: 
+[code][color=web_gray][color=turquoise]{MyGroup.MyVariable}[/color] # in some text
+[code]print([color=goldenrod]Dialogic[/color].[color=olive_drab]VAR[/color].[color=turquoise]MyGroup[/color].[color=turquoise]MyVariable[/color])[/code] # in a script[/color][/code]"
 fit_content = true
 
-[connection signal="text_changed" from="Editor/HBox/Search" to="." method="_on_search_text_changed"]
-[connection signal="button_clicked" from="Editor/Tree" to="Editor/Tree" method="_on_button_clicked"]
-[connection signal="gui_input" from="Editor/Tree" to="Editor/Tree" method="_on_gui_input"]
-[connection signal="item_edited" from="Editor/Tree" to="Editor/Tree" method="_on_item_edited"]
-[connection signal="id_pressed" from="Editor/Tree/RightClickMenu" to="Editor/Tree" method="_on_right_click_menu_id_pressed"]
-[connection signal="pressed" from="Editor/ReferenceInfo/ReferenceManager" to="." method="_on_reference_manager_pressed"]
+[connection signal="text_changed" from="PanelContainer/Editor/Search" to="." method="_on_search_text_changed"]
+[connection signal="button_clicked" from="PanelContainer/Editor/Tree" to="PanelContainer/Editor/Tree" method="_on_button_clicked"]
+[connection signal="gui_input" from="PanelContainer/Editor/Tree" to="PanelContainer/Editor/Tree" method="_on_gui_input"]
+[connection signal="item_edited" from="PanelContainer/Editor/Tree" to="PanelContainer/Editor/Tree" method="_on_item_edited"]
+[connection signal="id_pressed" from="PanelContainer/Editor/Tree/RightClickMenu" to="PanelContainer/Editor/Tree" method="_on_right_click_menu_id_pressed"]
+[connection signal="pressed" from="PanelContainer/Editor/ReferenceInfo/ReferenceManager" to="." method="_on_reference_manager_pressed"]
+[connection signal="pressed" from="Info/HBox/Documentation" to="." method="_on_documentation_pressed"]

--- a/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
+++ b/addons/dialogic/Modules/Variable/variables_editor/variables_editor.tscn
@@ -173,10 +173,11 @@ text = "How to use variables"
 unique_name_in_owner = true
 layout_mode = 2
 theme_type_variation = &"FlatButton"
-text = "Read the Docs"
+text = "Online Docs"
 
 [node name="RichTextLabel" type="RichTextLabel" parent="Info" unique_id=2046774878]
 layout_mode = 2
+size_flags_vertical = 3
 theme_override_constants/text_highlight_h_padding = 3
 theme_override_constants/text_highlight_v_padding = 1
 bbcode_enabled = true
@@ -194,7 +195,6 @@ If you need to access a variables value from a script, you can do so like this:
 You can create variable groups with [img]res://addons/dialogic/Editor/Images/Pieces/add-folder.svg[/img]. To access a variable in a group use it's \"path\" like so: 
 [code][color=web_gray][color=turquoise]{MyGroup.MyVariable}[/color] # in some text
 [code]print([color=goldenrod]Dialogic[/color].[color=olive_drab]VAR[/color].[color=turquoise]MyGroup[/color].[color=turquoise]MyVariable[/color])[/code] # in a script[/color][/code]"
-fit_content = true
 
 [connection signal="text_changed" from="PanelContainer/Editor/Search" to="." method="_on_search_text_changed"]
 [connection signal="button_clicked" from="PanelContainer/Editor/Tree" to="PanelContainer/Editor/Tree" method="_on_button_clicked"]


### PR DESCRIPTION
Includes various small UI changes as well as:


## Cleanup on resource list logic
Both the sidebar and the editors manager where trying to keep track of the resource list, which made it go out of sync all the time, thus the list resetting when you just cleared it or removed a character. Much better now, it's mostly handled by the sidebar now, only few things (as when files are moved) are handled by the editors manager, which writes directly to the setting now instead of holding a local copy.

## Fix for not warning when moving new portraits
If you added a new portrait and moved it into a group you'd get the "references changed warning". Not anymore.

## Improve parsing of call event
This now allows the use of `,` commas in array or string arguments in the call event. However arrays are only supported in the text editor, as the visual editor cannot display them and will cut them out if it encounters them.

Also slightly improve syntax highlighting logic for regions with equal start and end sign (aka strings).
