### PR TITLE
Next indicator no longer blocks mouse clicks

### DIFF
--- a/addons/dialogic/Example Assets/Fonts/Roboto-Bold.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Bold.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Example Assets/Fonts/Roboto-Italic.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Italic.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Example Assets/Fonts/Roboto-Regular.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Regular.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.tscn
@@ -3,10 +3,10 @@
 [ext_resource type="Script" uid="uid://bl43m5qw8pso3" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.gd" id="1_bpydr"]
 [ext_resource type="Script" uid="uid://bfc03rn8slceu" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/animations.gd" id="2_xy7a2"]
 [ext_resource type="Script" uid="uid://drhfq6rmdeuri" path="res://addons/dialogic/Modules/Text/node_dialog_text.gd" id="3_4634k"]
+[ext_resource type="StyleBox" uid="uid://dkv1pl1c1dq6" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_default_panel.tres" id="3_ssa84"]
 [ext_resource type="Script" uid="uid://dpv2dfiv5dhmr" path="res://addons/dialogic/Modules/Text/node_type_sound.gd" id="4_ma5mw"]
 [ext_resource type="Script" uid="uid://dve1vwse2peji" path="res://addons/dialogic/Modules/Text/node_next_indicator.gd" id="5_40a50"]
 [ext_resource type="Script" uid="uid://bklme8oymw6h7" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/autoadvance_indicator.gd" id="6_07xym"]
-[ext_resource type="StyleBox" uid="uid://dkv1pl1c1dq6" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_default_panel.tres" id="3_ssa84"]
 [ext_resource type="Texture2D" uid="uid://b0rpqfg4fhebk" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/next.svg" id="6_uch03"]
 [ext_resource type="Script" uid="uid://bak74s0kcr0ao" path="res://addons/dialogic/Modules/Text/node_name_label.gd" id="7_bi7sh"]
 [ext_resource type="StyleBox" uid="uid://m7gyepkysu83" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_name_label_panel.tres" id="9_yg8ig"]
@@ -219,7 +219,7 @@ name_label_box_modulate = Color(0, 0, 0, 1)
 [node name="Animations" type="AnimationPlayer" parent="."]
 unique_name_in_owner = true
 libraries = {
-"": SubResource("AnimationLibrary_c14kh")
+&"": SubResource("AnimationLibrary_c14kh")
 }
 autoplay = "RESET"
 script = ExtResource("2_xy7a2")
@@ -278,12 +278,11 @@ unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
 theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/bold_italics_font_size = 15
+theme_override_font_sizes/italics_font_size = 15
 theme_override_font_sizes/normal_font_size = 15
 theme_override_font_sizes/bold_font_size = 15
-theme_override_font_sizes/italics_font_size = 15
-theme_override_font_sizes/bold_italics_font_size = 15
 bbcode_enabled = true
-text = "Some default text"
 visible_characters_behavior = 1
 script = ExtResource("3_4634k")
 textbox_root = NodePath("..")
@@ -298,7 +297,6 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
 size_flags_vertical = 8
-mouse_filter = 2
 script = ExtResource("5_40a50")
 show_on_questions = true
 texture = ExtResource("6_uch03")

--- a/addons/dialogic/Modules/Text/node_next_indicator.gd
+++ b/addons/dialogic/Modules/Text/node_next_indicator.gd
@@ -44,7 +44,7 @@ var tween: Tween
 
 func _ready() -> void:
 	add_to_group('dialogic_next_indicator')
-
+	gui_input.connect(_on_gui_input)
 	# Creating TextureRect if missing
 	if not texture_rect:
 		var icon := TextureRect.new()
@@ -61,6 +61,9 @@ func _ready() -> void:
 	hide()
 	visibility_changed.connect(_on_visibility_changed)
 
+
+func _on_gui_input(event: InputEvent) -> void:
+	Dialogic.Inputs.handle_node_gui_input(event)
 
 func _on_visibility_changed() -> void:
 	if visible:


### PR DESCRIPTION
Clicking on the next indicator will now count as a regular click, no matter where it is.