### PR TITLE
Support and Hooks for custom subsystems

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -66,9 +66,6 @@ var paused := false:
 ## By default this timeline only contains a clear event.
 var dialog_ending_timeline: DialogicTimeline
 
-## Flag to identify if current timeline is network enabled
-var is_mp_timeline : bool = false
-
 ## Emitted when [member paused] changes to `true`.
 signal dialogic_paused
 ## Emitted when [member paused] changes to `false`.
@@ -168,15 +165,6 @@ func _ready() -> void:
 
 #region TIMELINE & EVENT HANDLING
 ################################################################################
-@rpc("any_peer", "call_local")
-# This allows Dialogic to be easily multiplayer compatible
-# 	as its an RPC call, we have to use a string
-
-
-func start_mp(timeline : String) -> void:
-	is_mp_timeline = true
-	start(timeline)
-
 
 ## Method to start a timeline AND ensure that a layout scene is present.
 ## For argument info, checkout [method start_timeline].

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
@@ -2,7 +2,7 @@
 extends DialogicSettingsPage
 
 ## Settings tab that holds genreal dialogic settings.
-const DIALOGIC_RESERVED_WORDS = ["Animations", "Audio", "Background", "Choice", "Expressoins", "Glossary", "History", "Jump", "PortraitContainers", "Portrait", "Save", "Styles", "Text", "TextInput", "Voice", "VAR"]
+var DIALOGIC_RESERVED_WORDS : Array[String] = []
 
 func _get_title() -> String:
 	return "General"
@@ -26,6 +26,11 @@ func _ready() -> void:
 
 	# Extension creator
 	%ExtensionCreator.hide()
+	
+	# Grab subsystems that exist for later use
+	for prop in Dialogic.get_script().get_script_property_list():
+		if prop.class_name == 'Node':
+			DIALOGIC_RESERVED_WORDS.push_back(prop.name)
 
 
 func _refresh() -> void:

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
@@ -2,7 +2,7 @@
 extends DialogicSettingsPage
 
 ## Settings tab that holds genreal dialogic settings.
-
+const DIALOGIC_RESERVED_WORDS = ["Animations", "Audio", "Background", "Choice", "Expressoins", "Glossary", "History", "Jump", "PortraitContainers", "Portrait", "Save", "Styles", "Text", "TextInput", "Voice", "VAR"]
 
 func _get_title() -> String:
 	return "General"
@@ -22,6 +22,7 @@ func _ready() -> void:
 	%ExtensionsFolderPicker.value_changed.connect(_on_ExtensionsFolder_value_changed)
 	%PhysicsTimerButton.toggled.connect(_on_physics_timer_button_toggled)
 
+	%NameEdit.text_changed.connect(_on_name_edit_changed)
 
 	# Extension creator
 	%ExtensionCreator.hide()
@@ -66,7 +67,7 @@ func _on_create_extension_button_pressed() -> void:
 func _on_submit_extension_button_pressed() -> void:
 	if %NameEdit.text.is_empty():
 		return
-
+	
 	var extensions_folder: String = ProjectSettings.get_setting('dialogic/extensions_folder', 'res://addons/dialogic_additions')
 
 	extensions_folder = extensions_folder.path_join(%NameEdit.text.to_pascal_case())
@@ -175,3 +176,13 @@ func force_event_button_list_reload() -> void:
 
 func _on_reload_pressed() -> void:
 	DialogicUtil._update_autoload_subsystem_access()
+
+
+func _on_name_edit_changed(new_text: String) -> void:
+		if new_text in DIALOGIC_RESERVED_WORDS:
+			%WarningMessage.text = str("[color=yellow]Warning: Extension ",new_text," is the same as an existing subsystem. \
+			If you do not intend to override the base subsystem, choose a new name.")
+			%WarningMessage.visible = true
+		else:
+			%WarningMessage.visible = false
+			

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.gd
@@ -28,9 +28,9 @@ func _ready() -> void:
 	%ExtensionCreator.hide()
 	
 	# Grab subsystems that exist for later use
-	for prop in Dialogic.get_script().get_script_property_list():
-		if prop.class_name == 'Node':
-			DIALOGIC_RESERVED_WORDS.push_back(prop.name)
+	for indexer in DialogicUtil.get_indexers():
+		for sub in indexer._get_subsystems():
+			DIALOGIC_RESERVED_WORDS.append(sub.name)
 
 
 func _refresh() -> void:

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_general.tscn
@@ -76,6 +76,7 @@ selected = 0
 fit_to_longest_item = false
 item_count = 3
 popup/item_0/text = "Delete Layout Node"
+popup/item_0/id = 0
 popup/item_1/text = "Hide Layout Node"
 popup/item_1/id = 1
 popup/item_2/text = "Keep Layout Node"
@@ -188,6 +189,7 @@ layout_mode = 2
 selected = 0
 item_count = 4
 popup/item_0/text = "Event only"
+popup/item_0/id = 0
 popup/item_1/text = "Event+Subsystem"
 popup/item_1/id = 1
 popup/item_2/text = "Subsystem only"
@@ -199,6 +201,14 @@ popup/item_3/id = 3
 unique_name_in_owner = true
 layout_mode = 2
 text = "Create"
+
+[node name="WarningMessage" type="RichTextLabel" parent="HBoxContainer6/ExtensionsPanel/VBox/ExtensionCreator"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+bbcode_enabled = true
+text = "[color=yellow]Warning: Extension <name> is the same as an existing subsystem. If you do not intend to override the base subsystem, choose a new name."
+fit_content = true
 
 [node name="HSeparator2" type="HSeparator" parent="."]
 layout_mode = 2

--- a/addons/dialogic/Example Assets/Fonts/Roboto-Bold.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Bold.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Example Assets/Fonts/Roboto-Italic.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Italic.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Example Assets/Fonts/Roboto-Regular.ttf.import
+++ b/addons/dialogic/Example Assets/Fonts/Roboto-Regular.ttf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.tscn
@@ -3,10 +3,10 @@
 [ext_resource type="Script" uid="uid://bl43m5qw8pso3" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.gd" id="1_bpydr"]
 [ext_resource type="Script" uid="uid://bfc03rn8slceu" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/animations.gd" id="2_xy7a2"]
 [ext_resource type="Script" uid="uid://drhfq6rmdeuri" path="res://addons/dialogic/Modules/Text/node_dialog_text.gd" id="3_4634k"]
+[ext_resource type="StyleBox" uid="uid://dkv1pl1c1dq6" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_default_panel.tres" id="3_ssa84"]
 [ext_resource type="Script" uid="uid://dpv2dfiv5dhmr" path="res://addons/dialogic/Modules/Text/node_type_sound.gd" id="4_ma5mw"]
 [ext_resource type="Script" uid="uid://dve1vwse2peji" path="res://addons/dialogic/Modules/Text/node_next_indicator.gd" id="5_40a50"]
 [ext_resource type="Script" uid="uid://bklme8oymw6h7" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/autoadvance_indicator.gd" id="6_07xym"]
-[ext_resource type="StyleBox" uid="uid://dkv1pl1c1dq6" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_default_panel.tres" id="3_ssa84"]
 [ext_resource type="Texture2D" uid="uid://b0rpqfg4fhebk" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/next.svg" id="6_uch03"]
 [ext_resource type="Script" uid="uid://bak74s0kcr0ao" path="res://addons/dialogic/Modules/Text/node_name_label.gd" id="7_bi7sh"]
 [ext_resource type="StyleBox" uid="uid://m7gyepkysu83" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_name_label_panel.tres" id="9_yg8ig"]
@@ -219,7 +219,7 @@ name_label_box_modulate = Color(0, 0, 0, 1)
 [node name="Animations" type="AnimationPlayer" parent="."]
 unique_name_in_owner = true
 libraries = {
-"": SubResource("AnimationLibrary_c14kh")
+&"": SubResource("AnimationLibrary_c14kh")
 }
 autoplay = "RESET"
 script = ExtResource("2_xy7a2")
@@ -278,12 +278,11 @@ unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
 theme_override_colors/default_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/bold_italics_font_size = 15
+theme_override_font_sizes/italics_font_size = 15
 theme_override_font_sizes/normal_font_size = 15
 theme_override_font_sizes/bold_font_size = 15
-theme_override_font_sizes/italics_font_size = 15
-theme_override_font_sizes/bold_italics_font_size = 15
 bbcode_enabled = true
-text = "Some default text"
 visible_characters_behavior = 1
 script = ExtResource("3_4634k")
 textbox_root = NodePath("..")


### PR DESCRIPTION
Three additions all related to some Multiplayer work I'm dealing with, but have other broad applications as well

1.  Adds the ability to override base Subsystems with custom extensions 
2.  A warning if you accidentally name an extension a 'reserved' word
3.  Adds an RPC enabled hook to the Dialogic Game handler and a flag to identify it has been called 

So 1 and 2 are actual bugs that most people just haven't run into yet. Previous to this if you named your extension a 'reserved' subsystem, it would make a random name for the node, which could very well break your extension if you weren't ready for it. The warning is there to avoid that situation, but now if you DO have a naming conflict, it'll assume you're doing it on purpose and override the subsystem. This allows you to extend subsystems with custom functionality quickly and easily without messing with the subsystem code in the slightest!

3, by itself, just allows people to start a dialogic timeline for all or some connected peers if called properly (_Dialogic.start_mp.rpc(<timeline name>)_ ). With that in place you could use my multiplayer extension or build your own very easily. Since normal _Dialogic.start_ allows for Variants as an argument, we can't just make that RPC aware, we need to enforce primitives, so for combability a separate function is needed.

This one definitely needs a bit of review. The code is simple but it may need some supporting changes in other subsystems to be used cleanly, such as error messages concerning already connected signals, but I wanted it up and out there right now.