### PR TITLE
Fix Wait Event not pausing when Dialogic is paused

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -148,6 +148,9 @@ var VAR := preload("res://addons/dialogic/Modules/Variable/subsystem_variables.g
 var Voice := preload("res://addons/dialogic/Modules/Voice/subsystem_voice.gd").new():
 	get: return get_subsystem("Voice")
 
+var Wait := preload("res://addons/dialogic/Modules/Wait/subsystem_wait.gd").new():
+	get: return get_subsystem("Wait")
+
 #endregion
 
 

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -22,9 +22,9 @@ func _execute() -> void:
 	dialogic.Wait.update_wait(time, hide_text, skippable, _on_finish)
 
 
-func _on_finish(tween: Tween) -> void:
-	if is_instance_valid(tween):
-		tween.kill()
+func _on_finish(timer: Timer) -> void:
+	if is_instance_valid(timer):
+		timer.queue_free()
 
 	if skippable:
 		dialogic.Inputs.dialogic_action.disconnect(_on_finish)

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -19,15 +19,7 @@ extends DialogicEvent
 ################################################################################
 
 func _execute() -> void:
-	dialogic.Wait.update_wait(time, hide_text, skippable, _on_finish)
-
-
-func _on_finish(timer: Timer) -> void:
-	if is_instance_valid(timer):
-		timer.queue_free()
-
-	if skippable:
-		dialogic.Inputs.dialogic_action.disconnect(_on_finish)
+	await dialogic.Wait.update_wait(time, hide_text, skippable)
 
 	if dialogic.Animations.is_animating():
 		dialogic.Animations.stop_animation()

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -14,37 +14,17 @@ extends DialogicEvent
 ## If true the wait can be skipped with user input
 @export var skippable := false
 
-var _tween: Tween
-
 
 #region EXECUTE
 ################################################################################
 
 func _execute() -> void:
-	var final_wait_time := time
-
-	if dialogic.Inputs.auto_skip.enabled:
-		var time_per_event: float = dialogic.Inputs.auto_skip.time_per_event
-		final_wait_time = min(time, time_per_event)
-
-	dialogic.current_state = dialogic.States.WAITING
-
-	if hide_text and dialogic.has_subsystem("Text"):
-		dialogic.Text.update_dialog_text('', true)
-		dialogic.Text.hide_textbox()
-
-	_tween = dialogic.get_tree().create_tween()
-	if DialogicUtil.is_physics_timer():
-		_tween.set_process_mode(Tween.TWEEN_PROCESS_PHYSICS)
-	_tween.tween_callback(_on_finish).set_delay(final_wait_time)
-
-	if skippable:
-		dialogic.Inputs.dialogic_action.connect(_on_finish)
+	dialogic.Wait.update_wait(time, hide_text, skippable, _on_finish)
 
 
-func _on_finish() -> void:
-	if is_instance_valid(_tween):
-		_tween.kill()
+func _on_finish(tween: Tween) -> void:
+	if is_instance_valid(tween):
+		tween.kill()
 
 	if skippable:
 		dialogic.Inputs.dialogic_action.disconnect(_on_finish)

--- a/addons/dialogic/Modules/Wait/index.gd
+++ b/addons/dialogic/Modules/Wait/index.gd
@@ -4,3 +4,7 @@ extends DialogicIndexer
 
 func _get_events() -> Array:
 	return [this_folder.path_join('event_wait.gd')]
+
+
+func _get_subsystems() -> Array:
+	return [{'name':'Wait', 'script':this_folder.path_join('subsystem_wait.gd')}]

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -1,0 +1,52 @@
+extends DialogicSubsystem
+
+## Subsystem that manages wait events.
+
+var _tween: Tween
+
+
+#region STATE
+####################################################################################################
+
+func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
+	if is_instance_valid(_tween):
+		_tween.kill()
+
+
+func pause() -> void:
+	if is_instance_valid(_tween):
+		_tween.pause()
+
+
+func resume() -> void:
+	if is_instance_valid(_tween):
+		_tween.play()
+
+#endregion
+
+
+#region MAIN METHODS
+####################################################################################################
+
+func update_wait(time: float, hide_text: bool, skippable: bool, callback: Callable) -> void:
+	var final_wait_time := time
+
+	if dialogic.Inputs.auto_skip.enabled:
+		var time_per_event: float = dialogic.Inputs.auto_skip.time_per_event
+		final_wait_time = min(time, time_per_event)
+
+	dialogic.current_state = dialogic.States.WAITING
+
+	if hide_text and dialogic.has_subsystem("Text"):
+		dialogic.Text.update_dialog_text('', true)
+		dialogic.Text.hide_textbox()
+
+	_tween = dialogic.get_tree().create_tween()
+	if DialogicUtil.is_physics_timer():
+		_tween.set_process_mode(Tween.TWEEN_PROCESS_PHYSICS)
+	_tween.tween_callback(callback.bind(_tween)).set_delay(final_wait_time)
+
+	if skippable:
+		dialogic.Inputs.dialogic_action.connect(callback.bind(_tween))
+
+#endregion

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -2,25 +2,24 @@ extends DialogicSubsystem
 
 ## Subsystem that manages wait events.
 
-var _timer: Timer
+signal timeout
+
+var _timer: Timer = Timer.new()
 
 
 #region STATE
 ####################################################################################################
 
 func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
-	if is_instance_valid(_timer):
-		_timer.queue_free()
+	_timer.stop()
 
 
 func pause() -> void:
-	if is_instance_valid(_timer):
-		_timer.paused = true
+	_timer.paused = true
 
 
 func resume() -> void:
-	if is_instance_valid(_timer):
-		_timer.paused = false
+	_timer.paused = false
 
 #endregion
 
@@ -28,7 +27,15 @@ func resume() -> void:
 #region MAIN METHODS
 ####################################################################################################
 
-func update_wait(time: float, hide_text: bool, skippable: bool, callback: Callable) -> void:
+func _ready() -> void:
+	_timer.one_shot = true
+	if DialogicUtil.is_physics_timer():
+		_timer.process_callback = Timer.TIMER_PROCESS_PHYSICS
+	add_child(_timer)
+	_timer.timeout.connect(timeout.emit)
+
+
+func update_wait(time: float, hide_text: bool, skippable: bool) -> void:
 	var final_wait_time := time
 
 	if dialogic.Inputs.auto_skip.enabled:
@@ -41,15 +48,15 @@ func update_wait(time: float, hide_text: bool, skippable: bool, callback: Callab
 		dialogic.Text.update_dialog_text('', true)
 		dialogic.Text.hide_textbox()
 
-	_timer = Timer.new()
-	_timer.one_shot = true
-	if DialogicUtil.is_physics_timer():
-		_timer.process_callback = Timer.TIMER_PROCESS_PHYSICS
-	add_child(_timer)
 	_timer.start(final_wait_time)
-	_timer.timeout.connect(callback.bind(_timer))
 
 	if skippable:
-		dialogic.Inputs.dialogic_action.connect(callback.bind(_timer))
+		dialogic.Inputs.dialogic_action.connect(timeout.emit)
+
+	await timeout
+	_timer.stop()
+
+	if skippable:
+		dialogic.Inputs.dialogic_action.disconnect(timeout.emit)
 
 #endregion

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -2,25 +2,25 @@ extends DialogicSubsystem
 
 ## Subsystem that manages wait events.
 
-var _tween: Tween
+var _timer: Timer
 
 
 #region STATE
 ####################################################################################################
 
 func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
-	if is_instance_valid(_tween):
-		_tween.kill()
+	if is_instance_valid(_timer):
+		_timer.queue_free()
 
 
 func pause() -> void:
-	if is_instance_valid(_tween):
-		_tween.pause()
+	if is_instance_valid(_timer):
+		_timer.paused = true
 
 
 func resume() -> void:
-	if is_instance_valid(_tween):
-		_tween.play()
+	if is_instance_valid(_timer):
+		_timer.paused = false
 
 #endregion
 
@@ -41,12 +41,15 @@ func update_wait(time: float, hide_text: bool, skippable: bool, callback: Callab
 		dialogic.Text.update_dialog_text('', true)
 		dialogic.Text.hide_textbox()
 
-	_tween = dialogic.get_tree().create_tween()
+	_timer = Timer.new()
+	_timer.one_shot = true
 	if DialogicUtil.is_physics_timer():
-		_tween.set_process_mode(Tween.TWEEN_PROCESS_PHYSICS)
-	_tween.tween_callback(callback.bind(_tween)).set_delay(final_wait_time)
+		_timer.process_callback = Timer.TIMER_PROCESS_PHYSICS
+	add_child(_timer)
+	_timer.start(final_wait_time)
+	_timer.timeout.connect(callback.bind(_timer))
 
 	if skippable:
-		dialogic.Inputs.dialogic_action.connect(callback.bind(_tween))
+		dialogic.Inputs.dialogic_action.connect(callback.bind(_timer))
 
 #endregion

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd.uid
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd.uid
@@ -1,0 +1,1 @@
+uid://db2kljpe5lv1x


### PR DESCRIPTION
As discussed on Discord, the Wait event did not pause when Dialogic was paused, as it did not use a subsystem. This PR moves the active part of the Wait event to a subsystem so it can hook into the `pause()` and `resume()` functions.