### PR TITLE
Support indent as stored property to better create timelines from code

### DIFF
--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -47,7 +47,8 @@ var event_node_as_text := ""
 var event_node_ready := false
 ## How many empty lines are before this event
 var empty_lines_above: int = 0
-
+## The level of indent in this event
+var indent: int = 0
 
 ### Editor UI Properties ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ## The description that is displayed in the editor tooltip.
@@ -310,9 +311,9 @@ func get_shortcode_parameters() -> Dictionary:
 func to_text() -> String:
 	var shortcode := store_to_shortcode_parameters()
 	if shortcode:
-		return "[" + self.get_shortcode() + " " + store_to_shortcode_parameters() + "]"
+		return " ".repeat(indent) + "[" + self.get_shortcode() + " " + store_to_shortcode_parameters() + "]"
 	else:
-		return "[" + self.get_shortcode() + "]"
+		return " ".repeat(indent) + "[" + self.get_shortcode() + "]"
 
 
 ## Loads the variables from the string stored by [method to_text].
@@ -382,6 +383,8 @@ func value_to_string(value: Variant, suggestions := Callable()) -> String:
 
 
 func load_from_shortcode_parameters(string:String) -> void:
+	indent = len(string) - len(string.strip_edges(true, false))
+
 	var data: Dictionary = parse_shortcode_parameters(string)
 	var params: Dictionary = get_shortcode_parameters()
 	for parameter in params.keys():


### PR DESCRIPTION
This stores the indent level as a property in each event object, supports serialization and deserialization with the indent level. When creating timelines via code something like this is now possible (code may not be correct, I'm using C# in my project so this is based on the example in the docs):
```gdscript
var events : Array = []

var text_event = DialogicTextEvent.new()
text_event.text = "Hey, was this made in code?"
text_event.character = load("res://characters/Emilio.dch")

var ch1 = DialogicChoiceEvent.new()
ch1.text = "Yes"

var sig = DialogicSignalEvent.new()
sig.indent = 1
sig.argument = "yes"

var ch2 = DialogicChoiceEvent.new()
ch2.text = "No"

var end = DialogicEndEvent.new()
end.indent = 1

events = [
  text_event,
  ch1,
  sig,
  ch2,
  end
]

var timeline : DialogicTimeline = DialogicTimeline.new()
timeline.events = events
# if your events are already resources, you need to add this:
timeline.events_processed = true
Dialogic.start(timeline)
```

This is equivalent to the following string timeline:
```
emilio: Hey, was this made in code?
- Yes
	[signal arg="yes"]
- No
	[end_timeline]
```