### PR TITLE
Fix for when calling start in physics process

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -334,16 +334,14 @@ func clear(clear_flags := ClearFlags.FULL_CLEAR) -> void:
 			if subsystem is DialogicSubsystem:
 				(subsystem as DialogicSubsystem)._clear_state(clear_flags)
 
-	var timeline := current_timeline
-
-	current_timeline = null
 	current_event_idx = -1
 	current_timeline_events = []
 	current_state = States.IDLE
 
 	# Resetting variables
-	if timeline:
-		await timeline.clean()
+	if current_timeline:
+		await current_timeline.clean()
+	current_timeline = null
 
 
 ## Cleanup after previous event (if any).


### PR DESCRIPTION
I'm working on a game in Godot 4.6.stable and had just added Dialogic into my project. I'm using it alongside LimboAI and created a `BTAction` for starting a timeline:

```
extends BTAction

@export var timeline_name: String = "timeline"

func _tick(_delta: float) -> Status:
  if Dialogic.current_timeline == null:
    Dialogic.start(timeline_name)
    scene_root.get_viewport().set_input_as_handled()
    return Status.SUCCESS
  else:
    var timeline_str: String = str(Dialogic.current_timeline)
    var name_start: String = "[DialogicTimeline:"
    timeline_str = timeline_str.substr(name_start.length(), timeline_str.length() - name_start.length() - 1)
    return Status.SUCCESS if timeline_str == timeline_name else Status.FAILURE
 ```
 
I found it had an issue where the timeline would not start up again after the first time. When debugging the issue, I found that `current_timeline` was set to my timeline and `current_status` was set to animating, but nothing was showing. It seemed as though Dialogic was setting the `current_timeline` before it was ready to go again. Based on this I looked for where `current_timeline` was being set to null and found the `clear` function in `DialogicGameHandler` and adjusted the code so that `current_timeline` was set to null after the `clean` function. This fixed the issue for me.

I started to make a minimal reproduction of this issue to share in this pull request. I made two, one with the fix and one without, but as I was making them I noticed the issue does not happen from the `_process` function but the `_physics_process` function. This also is the default used function in LimboAI so that makes sense.

I don't know if the fix I made does not interact negatively with other systems as I've only started trying out Dialogic, so please let me know if any changes are needed or if this fix is just not feasible. I'm really liking it though so far, thank you very much for creating this!

[dialogic-minimal-fail.zip](https://github.com/user-attachments/files/25784521/dialogic-minimal-fail.zip)
[dialogic-minimal-success.zip](https://github.com/user-attachments/files/25784522/dialogic-minimal-success.zip)