### PR TITLE
Assign button sounds to the correct audio bus

### DIFF
--- a/addons/dialogic/Modules/Choice/node_button_sound.gd
+++ b/addons/dialogic/Modules/Choice/node_button_sound.gd
@@ -14,6 +14,9 @@ extends AudioStreamPlayer
 func _ready() -> void:
 	add_to_group('dialogic_button_sound')
 	_connect_all_buttons()
+	if bus == "Master":
+		bus = ProjectSettings.get_setting("dialogic/audio/type_sound_bus", "Master")
+
 
 #basic play sound
 func play_sound(sound) -> void:


### PR DESCRIPTION
Currently Button Sounds are played through the default (master) audio bus. Button Sounds play the typing sound when hovering over a dialog option. This PR assigns the bus to the same user setting as Type Sound (in `/Modules/Text/node_type_sound.gd`).

This fix was for my personal project where I noticed that muting the sound-effects audio bus did not stop the hover typing sounds in dialog options.

I'm not sure why the assignment to the bus needs to be guarded with `if bus == 'Master'`, but this is what was done in `node_type_sound.gd`.