### PR TITLE
Fix scale/position issue while changing portrait during transition

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -179,7 +179,7 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 		if not portrait_node.is_inside_tree():
 			character_node.add_child(portrait_node)
 
-		_update_portrait_transform(portrait_node)
+		_update_portrait_transform(portrait_node, 0.0, not info["same_scene"])
 
 		## Handle Cross-Animating
 		if previous_portrait and previous_portrait != portrait_node:
@@ -223,7 +223,7 @@ func _update_character_transform(character_node:Node, time := 0.0) -> void:
 		_update_portrait_transform(child, time)
 
 
-func _update_portrait_transform(portrait_node: Node, time:float = 0.0) -> void:
+func _update_portrait_transform(portrait_node: Node, time:float = 0.0, is_new_node: bool = false) -> void:
 	var character_node: Node = portrait_node.get_parent()
 
 	var character: DialogicCharacter = character_node.get_meta('character')
@@ -255,6 +255,14 @@ func _update_portrait_transform(portrait_node: Node, time:float = 0.0) -> void:
 		tween.tween_method(DialogicUtil.multitween.bind(character_node, "position", "base"), character_node.position, transform.position, time)
 		tween.tween_property(portrait_node, 'position',character.offset + portrait_info.get('offset', Vector2()), time)
 		tween.tween_property(portrait_node, 'scale', transform.size, time)
+		if is_new_node:
+			# New portrait nodes start with default position/scale (Vector2(0,0) / Vector2(1,1)).
+			# Tweening from those defaults causes visual artifacts, so set them immediately.
+			portrait_node.position = character.offset + portrait_info.get('offset', Vector2())
+			portrait_node.scale = transform.size
+		else:
+			tween.tween_property(portrait_node, 'position',character.offset + portrait_info.get('offset', Vector2()), time)
+			tween.tween_property(portrait_node, 'scale', transform.size, time)
 
 
 ## Animates the node with the given animation.


### PR DESCRIPTION
## Fix portrait glitch when changing portrait scene during a move

I ran into a visual bug where changing a character's portrait to a different scene (different `.tscn`) while the character is mid-move causes the portrait to zoom in and jump to the wrong position before snapping back to normal.

### What's happening

When `_update_portrait_transform()` picks up a running `move_tween`, it tweens the portrait node's `position` and `scale` over the remaining move time. That's fine for an existing node that already has correct values — but when a new portrait scene was just instantiated, those properties start at Godot defaults (`Vector2(0,0)` and `Vector2(1,1)`), so you get a tween from nonsense values to the correct ones.

### Repro

```
update Character right [length="1.0" wait="true" move_time="1.0"]
Character (different_portrait_scene): some text
```

The character will appear huge and mispositioned during the transition.

### The proposed fix

I added an `is_new_node` parameter to `_update_portrait_transform()`. When it's a new node and a move tween is active, position and scale get set immediately instead of tweened. The actual character move still tweens normally.

`_change_portrait()` passes `not info["same_scene"]` so this only kicks in when a brand new portrait node was created — same-scene expression swaps are unaffected.

The parameter defaults to `false`, so the other two call sites (`_update_character_transform` and `_move_character`) don't need any changes.
