### PR TITLE
Objectdb debbuger snapshot null error fix

### DIFF
--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -178,6 +178,7 @@ func _set(property, value) -> bool:
 ## Allows to get dialogic built-in variables
 func _get(property):
 	property = str(property)
+	if not dialogic: return
 	if property in var_storage.keys():
 		if typeof(var_storage[property]) == TYPE_DICTIONARY:
 			return VariableFolder.new(var_storage[property], property, self)


### PR DESCRIPTION
In Godot 4.6 using ObjectDB profiler snapshot causing error by trying to access null variable
<img width="1239" height="887" alt="Screenshot_102" src="https://github.com/user-attachments/assets/1adfa1bc-1af4-4326-9d4a-66994a406e38" />
