### PR TITLE
fixed 'Not all code paths return a value.' error for godot 4.7

### DIFF
--- a/addons/dialogic/Modules/Text/node_name_label.gd
+++ b/addons/dialogic/Modules/Text/node_name_label.gd
@@ -23,3 +23,5 @@ func _set(property, what):
 		else:
 			name_label_root.show()
 		return true
+	else:
+		return false

--- a/addons/dialogic/Modules/Text/node_name_label.gd
+++ b/addons/dialogic/Modules/Text/node_name_label.gd
@@ -23,5 +23,4 @@ func _set(property, what):
 		else:
 			name_label_root.show()
 		return true
-	else:
-		return false
+	return false

--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -183,8 +183,7 @@ func _get(property):
 			return VariableFolder.new(var_storage[property], property, self)
 		else:
 			return DialogicUtil.logical_convert(var_storage[property])
-	else:
-		return null
+	return null
 
 
 func folders() -> Array:
@@ -246,8 +245,7 @@ class VariableFolder:
 				return VariableFolder.new(data[property], path+"."+property, outside)
 			else:
 				return DialogicUtil.logical_convert(data[property])
-		else:
-			return null
+		return null
 
 
 	func _set(property:StringName, value:Variant) -> bool:

--- a/addons/dialogic/Modules/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Modules/Variable/subsystem_variables.gd
@@ -183,6 +183,8 @@ func _get(property):
 			return VariableFolder.new(var_storage[property], property, self)
 		else:
 			return DialogicUtil.logical_convert(var_storage[property])
+	else:
+		return null
 
 
 func folders() -> Array:
@@ -244,6 +246,8 @@ class VariableFolder:
 				return VariableFolder.new(data[property], path+"."+property, outside)
 			else:
 				return DialogicUtil.logical_convert(data[property])
+		else:
+			return null
 
 
 	func _set(property:StringName, value:Variant) -> bool:


### PR DESCRIPTION
the new godot versions now requires returning in all circumstances instead of having the interpreter figure it out by itself, so this just has them return what they wouldve returned automatically in previous versions and should also work with said previous versions as no new features are used