### PR TITLE
Fix background subsystem changed emit with invalid argument field

### DIFF
--- a/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
@@ -70,7 +70,7 @@ func update_background(new_scene := "", new_argument := "", fade_time := 0.0, tr
 	else:
 		background_holder = get_tree().get_first_node_in_group('dialogic_background_holders')
 
-	var info := {'scene':new_scene, 'argument':new_scene, 'fade_time':fade_time, 'same_scene':false}
+	var info := {'scene':new_scene, 'argument':new_argument, 'fade_time':fade_time, 'same_scene':false}
 	if background_holder == null:
 		background_changed.emit(info)
 		return


### PR DESCRIPTION
Regression #2695

I'm using a custom implementation for the background holder, which is connected to `background_changed` event. Everything worked fine in the `alpha-19` release, but there is a bug in the master branch: `background_changed` signal emit data with invalid `argument` field.  