### PR TITLE
Fix infinite loop after jumping to non-existent label

### DIFF
--- a/addons/dialogic/Modules/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Modules/Jump/subsystem_jump.gd
@@ -76,7 +76,8 @@ func jump_to_label(label:String) -> void:
 		idx += 1
 		var event: Variant = dialogic.current_timeline.get_event(idx)
 		if not event:
-			idx = dialogic.current_event_idx
+			printerr("[Dialogic] Label '%s' not found for jump in timeline '%s'." % [label, dialogic.current_timeline.get_identifier()])
+			idx = dialogic.current_event_idx + 1
 			break
 		if event is DialogicLabelEvent and event.name == label:
 			break


### PR DESCRIPTION
When a label for `Jump Event` was not found `Godot Engine` silently freezes, because `Dialogic` enters an infinite loop. 

This happens because `Dialogic` fails to find the label and rolls back to the previous step before the `Jump Event` and executes it again, causing an infinite loop. 

To fix this, I propose printing an error and continue execution from current index, not previous. 


