### PR TITLE
Alpha 20 Preparations

### DIFF
--- a/addons/dialogic/Core/DialogicGameHandler.gd
+++ b/addons/dialogic/Core/DialogicGameHandler.gd
@@ -22,7 +22,7 @@ enum States {
 enum ClearFlags {
 	FULL_CLEAR = 0, 		## Clears all subsystems
 	KEEP_VARIABLES = 1, 	## Clears all subsystems and info except for variables
-	TIMELINE_INFO_ONLY = 2	## Doesn't clear subsystems but current timeline and index
+	TIMELINE_INFO_ONLY = 2 	## Doesn't clear subsystems but current timeline and index
 	}
 
 ## Reference to the currently executed timeline.
@@ -469,14 +469,14 @@ func get_subsystem(subsystem_name:String) -> DialogicSubsystem:
 ## Adds a subsystem node with the given [param subsystem_name] and [param script_path].
 func add_subsystem(subsystem_name:String, script_path:String) -> DialogicSubsystem:
 	var existing_subsystem_node = get_node_or_null(subsystem_name)
-	
+
 	# If two Subsystem have the same name, we override the existing one with the new one
 	if is_instance_valid(existing_subsystem_node):
 		existing_subsystem_node.set_script(load(script_path))
 		existing_subsystem_node.dialogic = self
 		existing_subsystem_node._ready()
 		return existing_subsystem_node
-	
+
 	var node: Node = Node.new()
 	node.name = subsystem_name
 	node.set_script(load(script_path))

--- a/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/CoreSettingsPages/settings_translation.gd
@@ -376,6 +376,7 @@ func update_csv_files() -> void:
 
 	%StatusMessage.text = status_message.format(status_message_args)
 	ProjectSettings.set_setting(_USED_LOCALES_SETTING, _unique_locales)
+	ProjectSettings.save()
 
 
 ## Iterates over all character resource files and creates or updates CSV files

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -105,10 +105,12 @@ func _gui_input(event):
 		"Ctrl+Shift+D", "Ctrl+D":
 			duplicate_lines()
 
-		"Ctrl+F6" when OS.get_name() != "macOS": # Play from here
+		"Ctrl+Shift+F6" when OS.get_name() != "macOS": # Play from here
 			play_from_here()
+			get_viewport().set_input_as_handled()
 		"Ctrl+Shift+B" when OS.get_name() == "macOS": # Play from here
 			play_from_here()
+			get_viewport().set_input_as_handled()
 		"Enter":
 			if get_code_completion_options():
 				return

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -1042,6 +1042,7 @@ func play_from_here(index:=-1) -> void:
 			index = selected_items[0].get_index()
 	timeline_editor.play_timeline(index)
 
+
 func _on_right_sidebar_resized() -> void:
 	var _scale := DialogicUtil.get_editor_scale()
 
@@ -1152,10 +1153,13 @@ func _input(event:InputEvent) -> void:
 			_add_event_button_pressed(DialogicLabelEvent.new(), true)
 			get_viewport().set_input_as_handled()
 
-		"Ctrl+F6" when OS.get_name() != "macOS":  # Play from here
+		"Ctrl+Shift+F6" when OS.get_name() != "macOS":  # Play from here
 			play_from_here()
+			get_viewport().set_input_as_handled()
+
 		"Ctrl+Shift+B" when OS.get_name() == "macOS":  # Play from here
 			play_from_here()
+			get_viewport().set_input_as_handled()
 
 	## Some shortcuts should be disabled when writing text.
 	var focus_owner: Control = get_viewport().gui_get_focus_owner()

--- a/addons/dialogic/Editor/TimelineEditor/shortcut_popup.gd
+++ b/addons/dialogic/Editor/TimelineEditor/shortcut_popup.gd
@@ -19,9 +19,9 @@ var shortcuts := [
 	{"shortcut":"Ctrl+F", 			"text":"Search"},
 	{"shortcut":"Ctrl+R", 			"text":"Replace"},
 	{},
-	{"shortcut":"Ctrl+F5", 			"text":"Play timeline", "platform":"-macOS"},
+	{"shortcut":"Ctrl+F6", 			"text":"Play timeline", "platform":"-macOS"},
 	{"shortcut":"Ctrl+B", 			"text":"Play timeline", "platform":"macOS"},
-	{"shortcut":"Ctrl+F6", 			"text":"Play timeline from here", "platform":"-macOS"},
+	{"shortcut":"Ctrl+Shift+F6", 	"text":"Play timeline from here", "platform":"-macOS"},
 	{"shortcut":"Ctrl+Shift+B", 	"text":"Play timeline from here", "platform":"macOS"},
 
 	{},

--- a/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
+++ b/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
@@ -4,7 +4,7 @@ func _ready() -> void:
 	print("[Dialogic] Testing scene was started.")
 	if not ProjectSettings.get_setting('internationalization/locale/test', "").is_empty():
 		print("Testing locale is: ", ProjectSettings.get_setting('internationalization/locale/test'))
-	$PauseIndictator.hide()
+	%PauseIndictator.hide()
 
 	var scene: Node = DialogicUtil.autoload().Styles.load_style(DialogicUtil.get_editor_setting('current_test_style', ''))
 	if not scene is CanvasLayer:
@@ -32,7 +32,7 @@ func receive_text_signal(argument:String) -> void:
 func _input(event:InputEvent) -> void:
 	if event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
 		DialogicUtil.autoload().paused = !DialogicUtil.autoload().paused
-		$PauseIndictator.visible = DialogicUtil.autoload().paused
+		%PauseIndictator.visible = DialogicUtil.autoload().paused
 
 	if (event is InputEventMouseButton
 	and event.is_pressed()

--- a/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.tscn
@@ -1,8 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://ud18ke1g2nw4"]
+[gd_scene format=3 uid="uid://ud18ke1g2nw4"]
 
 [ext_resource type="Script" uid="uid://cbq0n68r4pwu7" path="res://addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd" id="1_bamud"]
 
-[node name="TestTimelineScene" type="Control"]
+[node name="TestTimelineScene" type="Control" unique_id=1948298457]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -11,8 +11,11 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_bamud")
 
-[node name="PauseIndictator" type="Label" parent="."]
-layout_mode = 1
+[node name="OverlayUI" type="CanvasLayer" parent="." unique_id=1508099505]
+layer = 99
+
+[node name="PauseIndictator" type="Label" parent="OverlayUI" unique_id=1521879484]
+unique_name_in_owner = true
 anchors_preset = 1
 anchor_left = 1.0
 anchor_right = 1.0

--- a/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Modules/Background/subsystem_backgrounds.gd
@@ -213,7 +213,7 @@ func add_background_node(new_scene:PackedScene, parent:DialogicNode_BackgroundHo
 
 ## Whether a background is set.
 func has_background() -> bool:
-	return not scene.is_empty() or argument.is_empty()
+	return not (scene.is_empty() and argument.is_empty())
 
 
 func get_background_node() -> DialogicBackground:

--- a/addons/dialogic/Modules/Character/DefaultAnimations/bounce_in_out.gd
+++ b/addons/dialogic/Modules/Character/DefaultAnimations/bounce_in_out.gd
@@ -25,7 +25,7 @@ func animate() -> void:
 
 	(tween.tween_property(node, "scale", end_scale, time)
 		.set_trans(Tween.TRANS_SPRING)
-		.set_ease(Tween.EASE_OUT))
+		.set_ease(Tween.EASE_IN if is_reversed else Tween.EASE_OUT))
 	tween.tween_property(node, modulation_property + ":a", end_modulate_alpha, time)
 
 	await tween.finished

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -252,7 +252,7 @@ func _on_choice_selected(choice_info := {}) -> void:
 		return
 
 	if dialogic.has_subsystem('History'):
-		var all_choices: Array = last_question_info['choices'].map(func(x): return x["text"])
+		var all_choices: Array = last_question_info['choices']
 		if dialogic.has_subsystem('VAR'):
 			dialogic.History.store_simple_history_entry(dialogic.VAR.parse_variables(choice_info.text), "Choice", {'all_choices': all_choices})
 		else:

--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -15,6 +15,10 @@ extends DialogicEvent
 @export var clear_portrait_positions := true
 @export var clear_background := true
 
+## If true Dialogic will not actually switch the style if this is the last
+## event in a timeline, which is very common and unnecessarily resource intensive.
+var auto_avoid_style_change := true
+
 #region EXECUTE
 ################################################################################
 
@@ -26,14 +30,14 @@ func _execute() -> void:
 		final_time = min(time, time_per_event)
 
 	if clear_textbox and dialogic.has_subsystem("Text") and dialogic.Text.is_textbox_visible():
-		dialogic.Text.update_dialog_text('')
+		dialogic.Text.update_dialog_text("", true)
 		if step_by_step:
 			await dialogic.Text.hide_textbox(final_time == 0)
 		else:
 			dialogic.Text.hide_textbox(final_time == 0)
 		dialogic.current_state = dialogic.States.IDLE
 
-	if clear_portraits and dialogic.has_subsystem('Portraits') and len(dialogic.Portraits.get_joined_characters()) != 0:
+	if clear_portraits and dialogic.has_subsystem("Portraits") and len(dialogic.Portraits.get_joined_characters()) != 0:
 		if final_time == 0:
 			dialogic.Portraits.leave_all_characters("Instant", final_time, step_by_step)
 		else:
@@ -41,19 +45,22 @@ func _execute() -> void:
 		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
 	if clear_background and dialogic.has_subsystem('Backgrounds') and dialogic.Backgrounds.has_background():
-		dialogic.Backgrounds.update_background('', '', final_time)
+		dialogic.Backgrounds.update_background("", "", final_time)
 		if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
-	if clear_music and dialogic.has_subsystem('Audio'):
+	if clear_music and dialogic.has_subsystem("Audio"):
 		dialogic.Audio.stop_all_one_shot_sounds()
 		if dialogic.Audio.is_any_channel_playing():
 			dialogic.Audio.stop_all_channels(final_time)
 			if step_by_step: await dialogic.get_tree().create_timer(final_time).timeout
 
-	if clear_style and dialogic.has_subsystem('Styles'):
-		dialogic.Styles.change_style()
+	if clear_style and dialogic.has_subsystem("Styles"):
+		if auto_avoid_style_change and Dialogic.current_event_idx == Dialogic.current_timeline_events.size()-1:
+			pass
+		else:
+			dialogic.Styles.change_style()
 
-	if clear_portrait_positions and dialogic.has_subsystem('Portraits'):
+	if clear_portrait_positions and dialogic.has_subsystem("Portraits"):
 		dialogic.PortraitContainers.reset_all_containers()
 
 	if not step_by_step:
@@ -70,7 +77,7 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Clear"
 	event_description = "Clears current state like text, background, portraits, style or audio."
-	set_default_color('Color9')
+	set_default_color("Color9")
 	event_category = "Other"
 	event_sorting_index = 2
 

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_History/history_layer.gd
@@ -122,13 +122,15 @@ func show_history() -> void:
 			"Choice":
 				var choices_text: String = ""
 				if show_all_choices:
-					for i : String in info['all_choices']:
-						if i.ends_with('#disabled'):
-							choices_text += "-  [i]("+i.trim_suffix('#disabled')+")[/i]\n"
-						elif i == info['text']:
-							choices_text += "-> [b]"+i+"[/b]\n"
+					for i:Dictionary in info['all_choices']:
+						if not i.visible:
+							continue
+						if i.disabled:
+							choices_text += "-  [i]("+i.text+")[/i]\n"
+						elif i.text == info['text']:
+							choices_text += "-> [b]"+i.text+"[/b]\n"
 						else:
-							choices_text += "-> "+i+"\n"
+							choices_text += "-> "+i.text+"\n"
 				else:
 					choices_text += "- [b]"+info['text']+"[/b]\n"
 				history_item.call(&'load_info', choices_text)

--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -17,7 +17,7 @@ func _ready() -> void:
 
 
 func _clear_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
-	style = ""
+	pass
 	base_style = ""
 
 

--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -33,6 +33,9 @@ var speed_counter: float = 0
 
 
 func _ready() -> void:
+	if Engine.is_editor_hint():
+		return
+
 	# add to necessary
 	add_to_group('dialogic_dialog_text')
 	meta_hover_ended.connect(_on_meta_hover_ended)
@@ -44,13 +47,16 @@ func _ready() -> void:
 	if textbox_root == null:
 		textbox_root = self
 
+	if start_hidden:
+		textbox_root.hide()
+
 	text = ""
 
 	var custom_bbcode_effects: Array = ProjectSettings.get_setting("dialogic/text/custom_bbcode_effects", "").split(",", false)
 	for i in custom_bbcode_effects:
 		var x: Resource = load(i.strip_edges())
 		if x is RichTextEffect:
-			custom_effects.append(x)
+			custom_effects.append(x.duplicate())
 
 
 ## This is called by the [subsytem Text] to set text and play the reveal animation according to [member active_speed].
@@ -166,7 +172,7 @@ func on_gui_input(event:InputEvent) -> void:
 
 
 func custom_fx_update() -> void:
-	for effect in custom_effects:
+	for effect:RichTextEffect in custom_effects:
 		if "visible_characters" in effect:
 			effect.visible_characters = visible_characters
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -251,8 +251,6 @@ func show_textbox(instant:=false, identifier:=active_textbox) -> void:
 ## Instant skips the signal and thus possible animations
 func hide_textbox(instant:=false, identifier:=active_textbox) -> void:
 	var emitted := instant
-	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
-		name_label.text = ""
 	if not emitted and not get_textboxes(identifier).is_empty() and get_textboxes(identifier)[0].textbox_root.visible:
 		animation_textbox_hide.emit()
 		if dialogic.Animations.is_animating():

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -45,7 +45,6 @@ func update_wait(time: float, hide_text: bool, skippable: bool) -> void:
 	dialogic.current_state = dialogic.States.WAITING
 
 	if hide_text and dialogic.has_subsystem("Text"):
-		dialogic.Text.update_dialog_text("", true)
 		dialogic.Text.hide_textbox()
 
 	_timer.start(final_wait_time)

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -10,15 +10,15 @@ var _timer: Timer = Timer.new()
 #region STATE
 ####################################################################################################
 
-func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
+func _clear_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
 	_timer.stop()
 
 
-func pause() -> void:
+func _pause() -> void:
 	_timer.paused = true
 
 
-func resume() -> void:
+func _resume() -> void:
 	_timer.paused = false
 
 #endregion
@@ -45,7 +45,7 @@ func update_wait(time: float, hide_text: bool, skippable: bool) -> void:
 	dialogic.current_state = dialogic.States.WAITING
 
 	if hide_text and dialogic.has_subsystem("Text"):
-		dialogic.Text.update_dialog_text('', true)
+		dialogic.Text.update_dialog_text("", true)
 		dialogic.Text.hide_textbox()
 
 	_timer.start(final_wait_time)
@@ -58,5 +58,4 @@ func update_wait(time: float, hide_text: bool, skippable: bool) -> void:
 
 	if skippable:
 		dialogic.Inputs.dialogic_action.disconnect(timeout.emit)
-
 #endregion

--- a/addons/dialogic/Modules/Wait/subsystem_wait.gd
+++ b/addons/dialogic/Modules/Wait/subsystem_wait.gd
@@ -10,7 +10,7 @@ var _timer: Timer = Timer.new()
 #region STATE
 ####################################################################################################
 
-func _clear_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
+func _clear_state(clear_flag:=DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	_timer.stop()
 
 

--- a/addons/dialogic/plugin.cfg
+++ b/addons/dialogic/plugin.cfg
@@ -3,6 +3,6 @@
 name="Dialogic"
 description="Create dialogs, characters and scenes to display conversations in your Godot games.
 https://github.com/dialogic-godot/dialogic"
-author="Jowan, Emi, Cake and more!"
-version="2.0-Alpha-20 WIP (Godot 4.4+)"
+author="Jowan, Emi, Cake, Zak and more!"
+version="2.0-Alpha-20 (Godot 4.5+)"
 script="plugin.gd"


### PR DESCRIPTION
Includes a bunch of fixes as well as the version bump (alpha 20, godot 4.5+).

Fixes include
- Adjust "Play from here" shortcuts
- make TestTimelineScene pause indicator visible on a higher canvas layer
- fix wrong Backgrounds.has_background() implementation (#2750)
- fix wrong easing on BOUNCE_OUT animation
- fix hidden choices being shown in history and disabled choices not being marked. This is a bit of a dangerous change for people with custom history layer implementations... we'll see
- Clear event will now avoid changing the style if it is the last event in the timeline
- small fix for custom richt text effects, especially fade in effects
- hopefully fix for #2762
- potential fix for #2786
- fix wait event not getting paused correctly via Dialogic.paused