### PR TITLE
Bump Version & Update Unit Testing

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,115 +1,12 @@
-name: unit-test
-run-name: ${{ github.head_ref || github.ref_name }}-unit-test
-
-on:
-  push:
-
-    paths-ignore:
-        - '**.yml'
-        - '**.md'
-
-  pull_request:
-
-  workflow_dispatch:
-
-concurrency:
-  group: unit-test${{ github.event.number }}
-  cancel-in-progress: true
+name: GdUnit4 Tests
+on: [push, pull_request]
 
 jobs:
-  unit-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        # Insert here the Godot version you want to run your tests with.
-        godot-version: ['4.5']
-
-    name: "CI Unit Test v${{ matrix.godot-version }}"
-    runs-on: 'ubuntu-22.04'
-    # The overall timeout.
-    timeout-minutes: 10
-
-    steps:
-      - name: "Checkout your Repository"
-        uses: actions/checkout@v4
-        with:
-          lfs: true
-
-      - name: "Download and Install Godot ${{ matrix.godot-version }}"
-        continue-on-error: false
-        shell: bash
-        run: |
-          GODOT_HOME=$HOME/bin
-          GODOT_BIN=$GODOT_HOME/godot
-          mkdir -p $GODOT_HOME
-          chmod 770 $GODOT_HOME
-          GODOT_CONF_PATH=$HOME/.config/godot
-          if [ ! -d $GODOT_CONF_PATH ]; then
-            mkdir -p $GODOT_CONF_PATH
-            chmod 770 $GODOT_CONF_PATH
-          fi
-
-          GODOT_PACKAGE=Godot_v${{ matrix.godot-version }}-stable_linux.x86_64
-          wget https://github.com/godotengine/godot/releases/download/${{ matrix.godot-version }}-stable/$GODOT_PACKAGE.zip -P ${{ runner.temp }}
-          unzip ${{ runner.temp }}/$GODOT_PACKAGE.zip -d $GODOT_HOME
-          mv $GODOT_HOME/$GODOT_PACKAGE $GODOT_BIN
-          chmod u+x $GODOT_BIN
-          echo "GODOT_HOME=$GODOT_HOME" >> "$GITHUB_ENV"
-          echo "GODOT_BIN=$GODOT_BIN" >> "$GITHUB_ENV"
-
-      - name: "Copy `project.godot`"
-        run: cp .github/workflows/resources/project.godot .
-
-      - name: "Clone the gdUnit4 repository"
-        run: |
-            git clone --branch v6.1 --single-branch https://github.com/MikeSchulze/gdUnit4
-            rsync -av gdUnit4/addons/ ./addons/
-            rm -rf ./gdUnit4
-
-      - name: Print Directory Structure
-        run: |
-            ls -R
-
-      # We need to update the project before running tests, Godot has actually issues with loading the plugin.
-      - name: "Update Project"
-        if: ${{ !cancelled() }}
-        timeout-minutes: 1
-        # We still ignore the timeout, the script is not quit and we run into a timeout.
-        continue-on-error: true
-        shell: bash
-        run: |
-          xvfb-run --auto-servernum  ${{ env.GODOT_BIN }} -e --path . -s res://addons/gdUnit4/bin/ProjectScanner.gd --headless --audio-driver Dummy
-
-      - name: "Run Unit Tests"
-        if: ${{ !cancelled() }}
-        # Set your expected test timeout.
-        timeout-minutes: 8
-        env:
-          GODOT_BIN: ${{ env.GODOT_BIN }}
-        shell: bash
-        run: |
-          chmod +x ./addons/gdUnit4/runtest.sh
-          xvfb-run --auto-servernum ./addons/gdUnit4/runtest.sh --add "res://Tests/" --audio-driver Dummy --display-driver x11 --rendering-driver opengl3 --screen 0 --continue
-
-      - name: "Upload Unit Test Reports"
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: "godot-version"
-          path: |
-            reports/**
-            /var/lib/systemd/coredump/**
-            /var/log/syslog
-
-  finalize:
-    if: ${{ !cancelled() }}
+  test:
     runs-on: ubuntu-latest
-    name: Final Results
-    needs: [unit-test]
     steps:
-      - run: exit 1
-        if: >-
-          ${{
-              contains(needs.*.result, 'failure')
-            || contains(needs.*.result, 'cancelled')
-          }}
+      - uses: actions/checkout@v4
+      - uses: godot-gdunit-labs/gdUnit4-action@v1
+        with:
+          godot-version: '4.2.1'
+          paths: 'res://Tests'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
-          godot-version: '4.2.1'
+          godot-version: '4.5'
           paths: 'res://Tests'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # Insert here the Godot version you want to run your tests with.
-        godot-version: ['4.4']
+        godot-version: ['4.5']
 
     name: "CI Unit Test v${{ matrix.godot-version }}"
     runs-on: 'ubuntu-22.04'
@@ -62,7 +62,7 @@ jobs:
 
       - name: "Clone the gdUnit4 repository"
         run: |
-            git clone --branch v4.2.0 --single-branch https://github.com/MikeSchulze/gdUnit4
+            git clone --branch v6.1 --single-branch https://github.com/MikeSchulze/gdUnit4
             rsync -av gdUnit4/addons/ ./addons/
             rm -rf ./gdUnit4
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,12 +1,41 @@
-name: GdUnit4 Tests
-on: [push, pull_request]
+name: ci-pr-example
+run-name: ${{ github.head_ref || github.ref_name }}-ci-pr-example
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.yml'
+      - '**.md'
+  workflow_dispatch:
+
+
+concurrency:
+  group: ci-pr-example${{ github.event.number }}
+  cancel-in-progress: true
+
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  unit-test:
+    name: "CI Unit Test"
+    runs-on: 'ubuntu-22.04'
+    timeout-minutes: 10 # The overall timeout
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
+
     steps:
+      # checkout your repository
       - uses: actions/checkout@v4
+        with:
+          lfs: true
+      # run tests by using the gdUnit4-action with Godot version 4.5 and the latest GdUnit4 release 
       - uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5'
-          paths: 'res://Tests'
+          paths: |
+            res://Tests/
+          timeout: 5
+          report-name: test_report.xml      

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+      
+      - name: Copy CI project.godot
+        run: cp .github/workflows/resources/project.godot .
 
       - name: Show repository layout for debugging
         shell: bash

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       # Checkout the repository
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,12 +18,16 @@ jobs:
     name: "CI Unit Test"
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 10 # The overall timeout
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      pull-requests: write
+      statuses: write
 
     steps:
       # Checkout the repository
       - uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -38,6 +38,8 @@ jobs:
         uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5.1'
+          project_dir: .
           paths: |
             res://Tests/Unit
+          timeout: 10
           report-name: test_report.xml

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,12 +18,6 @@ jobs:
     name: "CI Unit Test"
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 10 # The overall timeout
-    permissions:
-      actions: write
-      checks: write
-      contents: write
-      pull-requests: write
-      statuses: write
 
     steps:
       # Checkout the repository

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -35,3 +35,13 @@ jobs:
             res://Tests/Unit
           timeout: 10
           report-name: test_report.xml
+        
+      - name: "Upload Unit Test Reports"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: "Test Reports"
+          path: |
+            reports/**
+            /var/lib/systemd/coredump/**
+            /var/log/syslog

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -18,38 +18,15 @@ jobs:
     name: "CI Unit Test"
     runs-on: 'ubuntu-22.04'
     timeout-minutes: 10 # The overall timeout
-    permissions:
-      actions: write
-      checks: write
-      contents: write
-      pull-requests: write
-      statuses: write
 
     steps:
-      # checkout your repository
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .
-
-      - name: Show repository layout for debugging
-        shell: bash
-        run: |
-          echo "Repository root: $PWD"
-          ls -la
-          echo "--- addons ---"
-          find addons -maxdepth 2 -type f | sort | head -200
-          echo "--- tests ---"
-          find Tests -maxdepth 3 -type f | sort
 
       - name: Run GdUnit4 tests
         uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5.1'
-          project_dir: .
           paths: |
             res://Tests/Unit
-          timeout: 10
           report-name: test_report.xml

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -31,16 +31,18 @@ jobs:
         with:
           lfs: true
 
-      # Ensure CI uses a fresh GdUnit4 addon installation instead of any local vendored copy.
-      - name: Prepare a clean GdUnit4 install
+      - name: Show repository layout for debugging
         shell: bash
         run: |
-          if [ -d addons/gdUnit4 ]; then
-            rm -rf addons/gdUnit4
-          fi
+          echo "Repository root: $PWD"
+          ls -la
+          echo "--- addons ---"
+          find addons -maxdepth 2 -type f | sort | head -200
+          echo "--- tests ---"
+          find Tests -maxdepth 3 -type f | sort
 
-      # run tests by using the gdUnit4-action against the project root and the unit test suite
-      - uses: godot-gdunit-labs/gdUnit4-action@v1
+      - name: Run GdUnit4 tests
+        uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5'
           version: 'v6.1.3'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       # Checkout the repository
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -44,8 +44,7 @@ jobs:
       - name: Run GdUnit4 tests
         uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
-          godot-version: '4.5'
-          version: 'v6.1.3'
+          godot-version: '4.5.1'
           project_dir: .
           paths: |
             res://Tests/Unit

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,16 +1,15 @@
-name: ci-pr-example
-run-name: ${{ github.head_ref || github.ref_name }}-ci-pr-example
+name: unit-test
+run-name: ${{ github.head_ref || github.ref_name }}-unit-test
 
 on:
   pull_request:
     paths-ignore:
-      - '**.yml'
       - '**.md'
   workflow_dispatch:
 
 
 concurrency:
-  group: ci-pr-example${{ github.event.number }}
+  group: unit-test-${{ github.event.number || github.run_id }}
   cancel-in-progress: true
 
 
@@ -31,11 +30,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      # run tests by using the gdUnit4-action with Godot version 4.5 and the latest GdUnit4 release 
+      # run tests by using the gdUnit4-action against the project root and the unit test suite
       - uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5'
+          project_dir: .
           paths: |
-            res://Tests/
-          timeout: 5
+            res://Tests/Unit
+          timeout: 10
           report-name: test_report.xml      

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -30,12 +30,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
+
+      # Ensure CI uses a fresh GdUnit4 addon installation instead of any local vendored copy.
+      - name: Prepare a clean GdUnit4 install
+        shell: bash
+        run: |
+          if [ -d addons/gdUnit4 ]; then
+            rm -rf addons/gdUnit4
+          fi
+
       # run tests by using the gdUnit4-action against the project root and the unit test suite
       - uses: godot-gdunit-labs/gdUnit4-action@v1
         with:
           godot-version: '4.5'
+          version: 'v6.1.3'
           project_dir: .
           paths: |
             res://Tests/Unit
           timeout: 10
-          report-name: test_report.xml      
+          report-name: test_report.xml

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -28,8 +28,6 @@ jobs:
     steps:
       # Checkout the repository
       - uses: actions/checkout@v4
-        with:
-          lfs: true
 
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 10 # The overall timeout
 
     steps:
+      # Checkout the repository
+      - uses: actions/checkout@v4
+
       - name: Copy CI project.godot
         run: cp .github/workflows/resources/project.godot .
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ export_presets.cfg
 
 # Godot 4 specific
 .godot
+
+/reports/*

--- a/addons/dialogic/plugin.cfg
+++ b/addons/dialogic/plugin.cfg
@@ -4,5 +4,5 @@ name="Dialogic"
 description="Create dialogs, characters and scenes to display conversations in your Godot games.
 https://github.com/dialogic-godot/dialogic"
 author="Jowan, Emi, Cake, Zak and more!"
-version="2.0-Alpha-20 (Godot 4.5+)"
+version="2.0-Alpha-21 WIP (Godot 4.5+)"
 script="plugin.gd"


### PR DESCRIPTION
Pushes main version to alpha 21.

Bumps godot version for unit tests to 4.5, and GDUnit4 to v6.1 (which is a big bump, let's hope it works).