### PR TITLE
fix code folding when using apostrophes in dialogue

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
@@ -18,6 +18,7 @@ symbol_lookup_on_click = true
 line_folding = true
 gutters_draw_line_numbers = true
 gutters_draw_fold_gutter = true
+delimiter_strings = Array[String](["\" \""])
 code_completion_enabled = true
 code_completion_prefixes = Array[String](["[", "{"])
 indent_automatic = true

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
@@ -24,6 +24,12 @@ code_completion_prefixes = Array[String](["[", "{"])
 indent_automatic = true
 auto_brace_completion_enabled = true
 auto_brace_completion_highlight_matching = true
+auto_brace_completion_pairs = {
+"\"": "\"",
+"(": ")",
+"[": "]",
+"{": "}"
+}
 script = ExtResource("1_1kbx2")
 
 [node name="UpdateTimer" type="Timer" parent="." unique_id=2015408251]


### PR DESCRIPTION
the codeedit used in the text editor treats both double quotes and single quotes (apostrophes) as string delimiters by default. this means that when writing with apostrophes, you can often open a multiline string without realising, which stops code folding until it's closed.
