### PR TITLE
Refactor Portrait Position Container Movement

### DIFF
--- a/addons/dialogic/Modules/Character/class_dialogic_animation.gd
+++ b/addons/dialogic/Modules/Character/class_dialogic_animation.gd
@@ -49,6 +49,7 @@ func finished_one_loop() -> void:
 
 	else:
 		finished.emit()
+		queue_free()
 
 
 func pause() -> void:
@@ -95,7 +96,7 @@ func get_node_origin() -> Vector2:
 	if not node:
 		return Vector2()
 	if node.get_parent() is DialogicNode_PortraitContainer:
-		return node.get_parent()._get_origin_position()
+		return node.get_parent().current_settings._get_origin_position()
 	return Vector2()
 
 

--- a/addons/dialogic/Modules/Character/default_portrait.tscn
+++ b/addons/dialogic/Modules/Character/default_portrait.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=2 format=3 uid="uid://b32paf0ll6um8"]
+[gd_scene format=3 uid="uid://b32paf0ll6um8"]
 
 [ext_resource type="Script" uid="uid://cork0heubbx7f" path="res://addons/dialogic/Modules/Character/default_portrait.gd" id="1_wn77n"]
 
-[node name="DefaultPortrait" type="Node2D"]
+[node name="DefaultPortrait" type="Node2D" unique_id=341737770]
 script = ExtResource("1_wn77n")
 
-[node name="Portrait" type="Sprite2D" parent="."]
+[node name="Portrait" type="Sprite2D" parent="." unique_id=1751347309]
 centered = false

--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -27,7 +27,7 @@ enum PositionModes {
 @export_subgroup("Portrait Placement")
 enum SizeModes {
 	KEEP, ## The height and width of the container have no effect, only the origin.
-	FIT_STRETCH, ## The portrait will be fitted into the container, ignoring it"s aspect ratio and the character/portrait scale.
+	FIT_STRETCH, ## The portrait will be fitted into the container, ignoring its aspect ratio and the character/portrait scale.
 	FIT_IGNORE_SCALE, ## The portrait will be fitted into the container, ignoring the character/portrait scale, but preserving the aspect ratio.
 	FIT_SCALE_HEIGHT ## Recommended. The portrait will be scaled to fit the container height. A character/portrait scale of 100% means 100% container height. Aspect ratio will be preserved.
 	}
@@ -95,7 +95,7 @@ enum SizeModes {
 ## Can be set at runtime. Will adjust the ordering of this container and all its siblings
 var container_z_index := 0:
 	set(z):
-		if z_index != z:
+		if container_z_index != z:
 			container_z_index = z
 			update_z_index()
 		else:
@@ -460,21 +460,6 @@ func _validate_property(property: Dictionary) -> void:
 		property.usage = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY
 
 
-## TODO check if we really need both
-func set_rotation(rot:float) -> void:
-	rotation = rot
-	if ignore_transform_change:
-		return
-	update_properties_from_transform()
-
-
-func set_rotation_degrees(rot:float) -> void:
-	rotation_degrees = rot
-	if ignore_transform_change:
-		return
-	update_properties_from_transform()
-
-
 func _update_character_transform(settings:ContainerSettings, character_node: Node, tween:Tween = null, time:float = 0.0) -> void:
 	var character: DialogicCharacter = character_node.get_meta("character")
 
@@ -519,7 +504,7 @@ func get_portrait_transform(settings:ContainerSettings, character: DialogicChara
 	return transform
 
 
-func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE) -> void:
+func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE, set_z_index:=true, set_mirror:=true) -> void:
 	if movement_tween and movement_tween.is_running():
 		movement_tween.kill()
 
@@ -546,7 +531,6 @@ func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.E
 	movement_tween.tween_property(self, "size_mode", to_settings.size_mode, time)
 
 	container_position.make_similar(to_settings.position)
-	## TODO make sure this converts incoming FlexVectors to the correct type!
 	movement_tween.tween_property(container_position, "x_value", to_settings.position.x_value, time)
 	movement_tween.tween_property(container_position, "y_value", to_settings.position.y_value, time)
 
@@ -556,12 +540,14 @@ func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.E
 	movement_tween.tween_property(container_size, "x_value", to_settings.size.x_value, time)
 	movement_tween.tween_property(container_size, "y_value", to_settings.size.y_value, time)
 
+	if set_mirror:
 	mirrored = to_settings.mirrored
 
 	container_origin.make_similar(to_settings.origin)
 	movement_tween.tween_property(container_origin, "x_value", to_settings.origin.x_value, time)
 	movement_tween.tween_property(container_origin, "y_value", to_settings.origin.y_value, time)
 
+	if set_z_index:
 	container_z_index = to_settings.z_index
 
 	movement_tween.finished.connect(current_settings.update_from_container.bind(self))

--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -1,4 +1,5 @@
 @tool
+@icon("node_portrait_container_icon.svg")
 class_name DialogicNode_PortraitContainer
 extends Control
 
@@ -7,24 +8,26 @@ extends Control
 enum PositionModes {
 	POSITION, ## This container can be joined/moved to with the Character Event
 	SPEAKER,  ## This container is joined/left automatically based on the speaker.
-	}
+	_CHARACTER, ## This container holds a specific character. These are created at runtime and shouldn't be assigned manually.
+}
 
 @export var mode := PositionModes.POSITION
 
-@export_subgroup('Mode: Position')
-## The position this node corresponds to.
+@export_subgroup("Mode: Position")
+## The position names this node corresponds to.
 @export var container_ids: PackedStringArray = ["1"]
 
 
-@export_subgroup('Mode: Speaker')
+@export_subgroup("Mode: Speaker")
 ## Can be used to use a different portrait.
 ## E.g. "Faces/" would mean instead of "happy" it will use portrait "Faces/happy"
-@export var portrait_prefix := ''
+@export var portrait_prefix := ""
 
-@export_subgroup('Portrait Placement')
+
+@export_subgroup("Portrait Placement")
 enum SizeModes {
 	KEEP, ## The height and width of the container have no effect, only the origin.
-	FIT_STRETCH, ## The portrait will be fitted into the container, ignoring it's aspect ratio and the character/portrait scale.
+	FIT_STRETCH, ## The portrait will be fitted into the container, ignoring it"s aspect ratio and the character/portrait scale.
 	FIT_IGNORE_SCALE, ## The portrait will be fitted into the container, ignoring the character/portrait scale, but preserving the aspect ratio.
 	FIT_SCALE_HEIGHT ## Recommended. The portrait will be scaled to fit the container height. A character/portrait scale of 100% means 100% container height. Aspect ratio will be preserved.
 	}
@@ -38,31 +41,72 @@ enum SizeModes {
 @export var mirrored := false :
 	set(mirror):
 		mirrored = mirror
+		update_mirror()
 		_update_debug_portrait_scene()
 
+@export_group("Container Transform", "container")
+## The containers size either in pixels or as a percentage of the parent size.
+@export var container_size := DialogicFlexVector.new():
+	set(siz):
+		if siz == null:
+			container_size = DialogicFlexVector.new()
+			container_size.container_size = get_parent_control().size
+			container_size.overwrite_from_vector(size)
+		else:
+			container_size = siz
+			update_transform_from_properties.call_deferred()
+		if container_size != null and not container_size.changed.is_connected(update_transform_from_properties):
+			container_size.changed.connect(update_transform_from_properties)
 
-@export_group('Origin', 'origin')
-enum OriginAnchors {TOP_LEFT, TOP_CENTER, TOP_RIGHT, LEFT_MIDDLE, CENTER, RIGHT_MIDDLE, BOTTOM_LEFT, BOTTOM_CENTER, BOTTOM_RIGHT}
+## The containers origin position, either as an absolute position or as a percentage of the parent size.
+@export var container_position := DialogicFlexVector.new():
+	set(pos):
+		if pos == null:
+			container_position = DialogicFlexVector.new()
+			container_position.container_size = get_parent_control().size
+			container_position.overwrite_from_vector(position+current_settings._get_origin_position())
+		else:
+			container_position = pos
+			update_transform_from_properties.call_deferred()
+		if container_position != null and not container_position.changed.is_connected(update_transform_from_properties):
+			container_position.changed.connect(update_transform_from_properties)
+
+@export_range(-360, 360, 0.01, "degrees", "or_less", "or_greater") var container_rotation := 0.0:
+	set(rot):
+		container_rotation = rot
+		rotation_degrees = rot
+		update_transform_from_properties.call_deferred()
+
 ## The portrait will be placed relative to this point in the container.
-@export var origin_anchor: OriginAnchors = OriginAnchors.BOTTOM_CENTER :
-	set(anchor):
-		origin_anchor = anchor
-		_update_debug_origin()
+@export var container_origin := DialogicFlexVector.from_string("x0.5y1"):
+	set(ori):
+		if ori == null:
+			container_origin = DialogicFlexVector.new()
+			container_origin.container_size = container_size.in_pixels()
+			container_origin.x_value = 0.5
+			container_origin.y_value = 1.0
+		else:
+			container_origin = ori
+			update_transform_from_properties.call_deferred()
+		if container_origin != null and not container_origin.changed.is_connected(update_transform_from_properties):
+			container_origin.changed.connect(update_transform_from_properties)
 
-## An offset to apply to the origin. Rarely useful.
-@export var origin_offset := Vector2() :
-	set(offset):
-		origin_offset = offset
-		_update_debug_origin()
 
-enum PivotModes {AT_ORIGIN, PERCENTAGE, PIXELS}
-## Usually you want to rotate or scale around the portrait origin.
-## For the moments where that is not the case, set the mode to PERCENTAGE or PIXELS and use [member pivot_value].
-@export var pivot_mode: PivotModes = PivotModes.AT_ORIGIN
-## Only has an effect when [member pivot_mode] is not AT_ORIGIN. Meaning depends on whether [member pivot_mode] is PERCENTAGE or PIXELS.
-@export var pivot_value := Vector2()
+## Can be set at runtime. Will adjust the ordering of this container and all its siblings
+var container_z_index := 0:
+	set(z):
+		if z_index != z:
+			container_z_index = z
+			update_z_index()
+		else:
+			container_z_index = z
 
-@export_group('Debug', 'debug')
+var movement_tween : Tween = null
+var movement_time := 0.0
+
+
+#region debug_properties
+@export_group("Debug", "debug")
 ## A character that will be displayed in the editor, useful for getting the right size.
 @export var debug_character: DialogicCharacter = null:
 	set(character):
@@ -73,121 +117,131 @@ enum PivotModes {AT_ORIGIN, PERCENTAGE, PIXELS}
 		debug_character_portrait = portrait
 		_update_debug_portrait_scene()
 
+
 var debug_character_holder_node: Node2D = null
 var debug_character_scene_node: Node = null
-var debug_origin: Sprite2D = null
-var default_portrait_scene: String = DialogicUtil.get_module_path('Character').path_join("default_portrait.tscn")
-# Used if no debug character is specified
-var default_debug_character := load(DialogicUtil.get_module_path('Character').path_join("preview_character.tres"))
+var default_portrait_scene: String = DialogicUtil.get_module_path("Character").path_join("default_portrait.tscn")
+var default_debug_character := load("uid://dykf1j17ct5mo")
 
-var ignore_resize := false
 
 var debug_draw := false
+#endregion
 
+
+var ignore_resize := false
+var ignore_transform_change := false
+
+var current_settings : ContainerSettings
+var target_settings : ContainerSettings
 
 func _ready() -> void:
-	debug_draw = DialogicUtil.autoload().PortraitContainers.debug_draw
+	if not container_position.changed.is_connected(update_transform_from_properties):
+		container_position.changed.connect(update_transform_from_properties)
+	if not container_size.changed.is_connected(update_transform_from_properties):
+		container_size.changed.connect(update_transform_from_properties)
+	if not container_origin.changed.is_connected(update_transform_from_properties):
+		container_origin.changed.connect(update_transform_from_properties)
+
+	current_settings = ContainerSettings.from_container(self)
+
+	# For pre alpha 21 compatibility
+	if container_size.x_value == 0 and container_size.y_value == 0:
+		update_properties_from_transform()
+		set_anchor(SIDE_BOTTOM, 0, true)
+		set_anchor(SIDE_LEFT, 0, true)
+		set_anchor(SIDE_RIGHT, 0, true)
+		set_anchor(SIDE_TOP, 0, true)
+
+	update_transform_from_properties.call_deferred()
+
 	match mode:
-		PositionModes.POSITION:
-			add_to_group('dialogic_portrait_con_position')
+		PositionModes.POSITION, PositionModes._CHARACTER:
+			add_to_group("dialogic_portrait_con_position")
 		PositionModes.SPEAKER:
-			add_to_group('dialogic_portrait_con_speaker')
+			add_to_group("dialogic_portrait_con_speaker")
 
 	if Engine.is_editor_hint():
-		resized.connect(_update_debug_origin)
-
-		if !ProjectSettings.get_setting('dialogic/portraits/default_portrait', '').is_empty():
-			default_portrait_scene = ProjectSettings.get_setting('dialogic/portraits/default_portrait', '')
-
-		debug_origin = Sprite2D.new()
-		add_child(debug_origin)
-		debug_origin.texture = load("res://addons/dialogic/Editor/Images/Dropdown/default.svg")
-
-		_update_debug_origin()
 		_update_debug_portrait_scene()
+		if not ProjectSettings.get_setting("dialogic/portraits/default_portrait", "").is_empty():
+			default_portrait_scene = ProjectSettings.get_setting("dialogic/portraits/default_portrait", "")
+		item_rect_changed.connect(update_properties_from_transform)
+
 	else:
-		resized.connect(update_portrait_transforms)
+		debug_draw = DialogicUtil.autoload().PortraitContainers.debug_draw
+		item_rect_changed.connect(container_resized_during_game)
+		child_entered_tree.connect(_child_entered_tree)
+
+	connect_parent_resize()
+
+func connect_parent_resize() -> void:
+	if not get_parent().resized.is_connected(_on_parent_resized):
+		get_parent().resized.connect(_on_parent_resized)
 
 
+#region MAIN METHODS
 ################################################################################
-##						MAIN METHODS
-################################################################################
 
-func update_portrait_transforms() -> void:
-	if ignore_resize:
+func update_properties_from_transform() -> void:
+	if ignore_transform_change:
 		return
-
-	match pivot_mode:
-		PivotModes.AT_ORIGIN:
-			pivot_offset = _get_origin_position()
-		PivotModes.PERCENTAGE:
-			pivot_offset = size*pivot_value
-		PivotModes.PIXELS:
-			pivot_offset = pivot_value
-
-	for child in get_children():
-		DialogicUtil.autoload().Portraits._update_character_transform(child)
+	current_settings.update_from_container(self)
+	ignore_transform_change = true
+	set_parent_size(get_parent_control().size)
+	container_size.overwrite_from_vector(size)
+	container_origin.container_size = container_size.as_pixels()
+	container_rotation = rotation_degrees
+	container_position.overwrite_from_vector(position+current_settings._get_origin_position().rotated(rotation))
+	ignore_transform_change = false
 
 
-## Returns a Rect2 with the position as the position and the scale as the size.
-func get_local_portrait_transform(portrait_rect:Rect2, character_scale:=1.0) -> Rect2:
-	var transform := Rect2()
-	transform.position = _get_origin_position()
-
-	# Mode that ignores the containers size
-	if size_mode == SizeModes.KEEP:
-		transform.size = Vector2(1,1) * character_scale
-
-	# Mode that makes sure neither height nor width go out of container
-	elif size_mode == SizeModes.FIT_IGNORE_SCALE:
-		if size.x/size.y < portrait_rect.size.x/portrait_rect.size.y:
-			transform.size = Vector2(1,1) * size.x/portrait_rect.size.x
-		else:
-			transform.size = Vector2(1,1) * size.y/portrait_rect.size.y
-
-	# Mode that stretches the portrait to fill the whole container
-	elif size_mode == SizeModes.FIT_STRETCH:
-		transform.size = size/portrait_rect.size
-
-	# Mode that size the character so 100% size fills the height
-	elif size_mode == SizeModes.FIT_SCALE_HEIGHT:
-		transform.size = Vector2(1,1) * size.y / portrait_rect.size.y*character_scale
-
-	return transform
+func _on_parent_resized() -> void:
+	update_transform_from_properties()
 
 
-## Returns the current origin position
-func _get_origin_position(rect_size = null) -> Vector2:
-	if rect_size == null:
-		rect_size = size
-	return rect_size * Vector2(origin_anchor%3 / 2.0, floor(origin_anchor/3.0) / 2.0) + origin_offset
+func update_transform_from_properties() -> void:
+	if ignore_transform_change:
+		return
+	if not is_node_ready():
+		await ready
+	current_settings.update_from_container(self)
+	ignore_transform_change = true
+	set_parent_size(get_parent_control().size)
+	size = container_size.as_pixels()
+	position = current_settings._get_top_left_position()
+	ignore_transform_change = false
+	queue_redraw()
 
 
 func is_container(id:Variant) -> bool:
 	return str(id) in container_ids
 
+#endregion
+
+
 #region DEBUG METHODS
 ################################################################################
 ### USE THIS TO DEBUG THE POSITIONS
-
+var pivot_texture := load("res://addons/dialogic/Editor/Images/Resources/portrait.svg")
 func _draw():
-	if debug_draw:
+	if debug_draw or Engine.is_editor_hint():
 		draw_rect(Rect2(Vector2(), size), Color(1, 0.3098039329052, 1), false, 2)
-		draw_string(get_theme_default_font(),get_theme_default_font().get_string_size(container_ids[0], HORIZONTAL_ALIGNMENT_LEFT, 1, get_theme_default_font_size())+Vector2(8,0) , container_ids[0], HORIZONTAL_ALIGNMENT_CENTER)
-#
-#func _process(delta:float) -> void:
-	#queue_redraw()
+		if container_ids:
+			draw_string(get_theme_default_font(),get_theme_default_font().get_string_size(container_ids[0], HORIZONTAL_ALIGNMENT_LEFT, 1, get_theme_default_font_size())+Vector2(8,0) , container_ids[0], HORIZONTAL_ALIGNMENT_CENTER)
+
+
+		var pivot_draw_size := 32
+		draw_texture_rect(pivot_texture, Rect2(current_settings._get_origin_position()-Vector2.ONE*pivot_draw_size*0.5, Vector2.ONE*pivot_draw_size), false, Color(1.0, 0.966, 0.997, 1.0))
+		_update_debug_portrait_transform()
 
 
 ## Loads the debug_character with the debug_character_portrait
 ## Creates a holder node and applies mirror
 func _update_debug_portrait_scene() -> void:
-	if !Engine.is_editor_hint():
+	if not Engine.is_editor_hint():
 		return
 	if is_instance_valid(debug_character_holder_node):
 		for child in get_children():
-			if child != debug_origin:
-				child.free()
+			child.free()
 
 	# Get character
 	var character := _get_debug_character()
@@ -207,57 +261,397 @@ func _update_debug_portrait_scene() -> void:
 	var portrait_info: Dictionary = character.get_portrait_info(debug_portrait)
 
 	# Determine scene
-	var portrait_scene_path: String = portrait_info.get('scene', default_portrait_scene)
+	var portrait_scene_path: String = portrait_info.get("scene", default_portrait_scene)
 	if portrait_scene_path.is_empty():
 		portrait_scene_path = default_portrait_scene
 
 	debug_character_scene_node = load(portrait_scene_path).instantiate()
 
-	if !is_instance_valid(debug_character_scene_node):
+	if not is_instance_valid(debug_character_scene_node):
 		return
 
 	# Load portrait
-	DialogicUtil.apply_scene_export_overrides(debug_character_scene_node, character.portraits[debug_portrait].get('export_overrides', {}))
+	DialogicUtil.apply_scene_export_overrides(debug_character_scene_node, character.portraits[debug_portrait].get("export_overrides", {}))
 	debug_character_scene_node._update_portrait(character, debug_portrait)
 
 	# Add character node
-	if !is_instance_valid(debug_character_holder_node):
+	if not is_instance_valid(debug_character_holder_node):
 		debug_character_holder_node = Node2D.new()
 		add_child(debug_character_holder_node)
 
 	# Add portrait node
 	debug_character_holder_node.add_child(debug_character_scene_node)
 	move_child(debug_character_holder_node, 0)
-	debug_character_scene_node._set_mirror(character.mirror != mirrored != portrait_info.get('mirror', false))
+	debug_character_scene_node._set_mirror(character.mirror != mirrored != portrait_info.get("mirror", false))
 
 	_update_debug_portrait_transform()
 
 
-## Set's the size and position of the holder and scene node
+## Set"s the size and position of the holder and scene node
 ## according to the size_mode
 func _update_debug_portrait_transform() -> void:
-	if !Engine.is_editor_hint() or !is_instance_valid(debug_character_scene_node) or !is_instance_valid(debug_origin):
+	if not Engine.is_editor_hint() or not is_instance_valid(debug_character_scene_node):
 		return
+	if not is_node_ready():
+		await ready
 	var character := _get_debug_character()
+	current_settings.update_from_container(self)
 	var portrait_info := character.get_portrait_info(debug_character_portrait)
-	var transform := get_local_portrait_transform(debug_character_scene_node._get_covered_rect(), character.scale*portrait_info.get('scale', 1))
-	debug_character_holder_node.position = transform.position
-	debug_character_scene_node.position = portrait_info.get('offset', Vector2())+character.offset
+	debug_character_holder_node.position = current_settings._get_origin_position()
+	debug_character_scene_node.position = portrait_info.get("offset", Vector2())+character.offset
 
-	debug_character_holder_node.scale = transform.size
-
-
-## Updates the debug origins position. Also calls _update_debug_portrait_transform()
-func _update_debug_origin() -> void:
-	if !Engine.is_editor_hint() or !is_instance_valid(debug_origin):
-		return
-	debug_origin.position = _get_origin_position()
-	_update_debug_portrait_transform()
-
-
+	debug_character_scene_node.scale = current_settings.get_portrait_scale(debug_character_scene_node)
+	update_mirror()
 
 ## Returns the debug character or the default debug character
 func _get_debug_character() -> DialogicCharacter:
 	return debug_character if debug_character != null else default_debug_character
 
 #endregion
+
+
+
+class ContainerSettings extends Resource:
+	## A resource that allows transfering, storing and loading all settings relevant to a PortraitContainer.
+
+	@export var position := DialogicFlexVector.new()
+	@export var size := DialogicFlexVector.new()
+	@export var rotation := 0.0
+	@export var mirrored := false
+	## The portrait will be placed relative to this point in the container.
+	@export var origin := DialogicFlexVector.new()
+
+	## Defines how to affect the scale of the portrait
+	@export var size_mode: SizeModes = SizeModes.FIT_SCALE_HEIGHT
+
+	@export var z_index := 0
+
+	@export var reference_position_id := ""
+	var derived_from : DialogicNode_PortraitContainer = null
+
+	static var _transform_regex := r"(?<part>position|pos|size|siz|rotation|rot|ori|origin|mod|size_mode|mir|mirror|mirrored|sort|sor|z)\W*=(?<value>((?!(pos|siz|rot|mir|ori|mod|z|sor)).)*)"
+
+
+	## Creates a new ContainerSetting and set it's values from the given [param container].
+	static func from_container(container:DialogicNode_PortraitContainer) -> ContainerSettings:
+		var new := ContainerSettings.new()
+		new.update_from_container(container)
+		return new
+
+
+	## Copies the settings from the given PortraitContainer node [param container] to this ContainerSetting.
+	func update_from_container(container:DialogicNode_PortraitContainer) -> void:
+		position = container.container_position.copy()
+		size = container.container_size.copy()
+		mirrored = container.mirrored
+		rotation = container.container_rotation
+		origin = container.container_origin
+		size_mode = container.size_mode
+		z_index = container.container_z_index
+		if container.mode != DialogicNode_PortraitContainer.PositionModes._CHARACTER:
+			derived_from = container
+			reference_position_id = container.container_ids[0] if container.container_ids else ""
+
+
+	## Creates a new ContainerSetting and set it's values from the string. See [method update_from_string]
+	static func from_string(string:="") -> ContainerSettings:
+		var new := ContainerSettings.new()
+		new.update_from_string(string)
+		return new
+
+
+	## Applies settings from the given string to this ContainerSetting.
+	## The supported tags are pos/position, rot/rotation, siz/size, ori/origin, mir/mirrored, mod/size_mode.
+	func update_from_string(string:="") -> void:
+		var regex := RegEx.create_from_string(_transform_regex)
+		for found in regex.search_all(string):
+			match found.get_string("part"):
+				"pos", "position":
+					position.overwrite_from_string(found.get_string("value"))
+				"rot", "rotation":
+					rotation = float(found.get_string("value"))
+				"siz", "size":
+					size.overwrite_from_string(found.get_string("value"))
+				"ori", "origin":
+					origin.overwrite_from_string(found.get_string("value"))
+				"mir", "mirror", "mirrored":
+					mirrored = found.get_string("value").to_lower().strip_edges() == "true"
+				"mod", "mode", "size_mode":
+					size_mode = int(found.get_string("value"))
+				"sor", "sort", "z":
+					z_index = int(found.get_string("value"))
+				"ref", "reference":
+					reference_position_id = found.get_string("value").strip_edges()
+
+
+	## Returns the current origin position relative to this containers top left corner.
+	func _get_origin_position(rect_size = null) -> Vector2:
+		if rect_size == null:
+			rect_size = size
+		return origin.as_pixels()
+
+
+	## Returns the top left position of this container relative to it's parent.
+	func _get_top_left_position(rect_size = null) -> Vector2:
+		if rect_size == null:
+			rect_size = size
+		return position.as_pixels() - _get_origin_position(rect_size).rotated(deg_to_rad(rotation))
+
+
+	## Returns a scaling vector, that can be applied to the portrait node to fit it inside this container.
+	func get_portrait_scale(portrait_node:DialogicPortrait) -> Vector2:
+		var portrait_rect := portrait_node._get_covered_rect()
+		var character := portrait_node.character
+		var portrait_info := character.get_portrait_info(portrait_node.portrait)
+		var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
+
+		var character_scale : float =  character.scale * portrait_info.get("scale", 1) * int(apply_character_scale) + portrait_info.get("scale", 1) * int(!apply_character_scale)
+
+		var scale_vec := Vector2()
+
+		# Mode that ignores the containers size
+		if size_mode == SizeModes.KEEP:
+			scale_vec = Vector2(1,1) * character_scale
+
+		# Mode that makes sure neither height nor width go out of container
+		elif size_mode == SizeModes.FIT_IGNORE_SCALE:
+			if size.as_pixels().x/size.as_pixels().y < portrait_rect.size.x/portrait_rect.size.y:
+				scale_vec = Vector2(1,1) * size.as_pixels().x/portrait_rect.size.x
+			else:
+				scale_vec = Vector2(1,1) * size.as_pixels().y/portrait_rect.size.y
+
+		# Mode that stretches the portrait to fill the whole container
+		elif size_mode == SizeModes.FIT_STRETCH:
+			scale_vec = size.as_pixels()/portrait_rect.size
+
+		# Mode that size the character so 100% size fills the height
+		elif size_mode == SizeModes.FIT_SCALE_HEIGHT:
+			scale_vec = Vector2(1,1) * size.as_pixels().y / portrait_rect.size.y*character_scale
+
+		return scale_vec
+
+
+	func set_parent_size(parent_size:Vector2) -> void:
+		position.container_size = parent_size
+		size.container_size = parent_size
+		origin.container_size = size.as_pixels()
+
+
+	func _validate_property(property: Dictionary) -> void:
+		if property.name in ["position", "size", "origin"]:
+			property.usage = property.usage | PROPERTY_USAGE_ALWAYS_DUPLICATE
+
+
+	func as_string() -> String:
+		return "pos={pos} siz={siz} rot={rot} mir={mir} ori={ori} mod={mod} z={z} ref={ref}".format({
+			"pos":str(position), "siz":str(size), "rot":str(rotation), "mir":str(mirrored), "ori":str(origin), "mod":str(size_mode), "z":str(z_index), "ref":reference_position_id
+		})
+
+
+func set_parent_size(parent_size:Vector2) -> void:
+	container_position.container_size = parent_size
+	container_size.container_size = parent_size
+	container_origin.container_size = container_size.as_pixels()
+	current_settings.set_parent_size(parent_size)
+
+
+func _validate_property(property: Dictionary) -> void:
+	if property.name in ["position", "rotation", "size", "scale"]:
+		property.usage = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY
+
+
+## TODO check if we really need both
+func set_rotation(rot:float) -> void:
+	rotation = rot
+	if ignore_transform_change:
+		return
+	update_properties_from_transform()
+
+
+func set_rotation_degrees(rot:float) -> void:
+	rotation_degrees = rot
+	if ignore_transform_change:
+		return
+	update_properties_from_transform()
+
+
+func _update_character_transform(settings:ContainerSettings, character_node: Node, tween:Tween = null, time:float = 0.0) -> void:
+	var character: DialogicCharacter = character_node.get_meta("character")
+
+	if character_node.get_child_count() == 0:
+		return
+
+	var portrait_node: DialogicPortrait = character_node.get_child(-1)
+	var portrait_info: Dictionary = character.portraits.get(portrait_node.get_meta("portrait"), {})
+	var transform = get_portrait_transform(settings, character, portrait_node)
+
+	if time == 0:
+		character_node.position = transform.position
+	else:
+		tween.tween_method(DialogicUtil.multitween.bind(character_node, "position", "base"), character_node.position, transform.position, time)
+
+	for child in character_node.get_children():
+		if not child is DialogicPortrait:
+			continue
+
+		portrait_node = (child as DialogicPortrait)
+		portrait_info = character.portraits.get(portrait_node.get_meta("portrait"), {})
+		transform = get_portrait_transform(settings, character, portrait_node)
+
+		if time == 0:
+			portrait_node.position = character.offset + portrait_info.get("offset", Vector2())
+			portrait_node.scale = transform.size
+		else:
+			tween.tween_property(portrait_node, "position",character.offset + portrait_info.get("offset", Vector2()), time)
+			tween.tween_property(portrait_node, "scale", transform.size, time)
+
+
+func get_portrait_transform(settings:ContainerSettings, character: DialogicCharacter, portrait_node:DialogicPortrait) -> Rect2:
+	var portrait_info: Dictionary = character.portraits.get(portrait_node.get_meta("portrait"), {})
+
+	# ignore the character scale on custom portraits that have "ignore_char_scale" set to true
+	var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
+
+	var transform: Rect2 = settings.get_local_portrait_transform(
+		portrait_node._get_covered_rect(),
+		(character.scale * portrait_info.get("scale", 1))*int(apply_character_scale)+portrait_info.get("scale", 1)*int(!apply_character_scale))
+
+	return transform
+
+
+func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE) -> void:
+	if movement_tween and movement_tween.is_running():
+		movement_tween.kill()
+
+	## This handles moving the container to a different parent if necessary.
+	if to_settings.reference_position_id:
+		var ref_con := DialogicUtil.autoload().PortraitContainers.get_container(to_settings.reference_position_id)
+		if ref_con.get_parent() != get_parent():
+			var global_origin: Vector2 = global_position+current_settings._get_origin_position()
+			var global_size := container_size.as_pixels()
+			get_parent().remove_child(self)
+			ref_con.get_parent().add_child(self)
+			connect_parent_resize()
+			set_parent_size(get_parent_control().size)
+			container_position.overwrite_from_vector(global_origin-get_parent().global_position)
+			container_size.overwrite_from_vector(global_size)
+
+	movement_tween = create_tween()
+	movement_time = time
+	movement_tween.set_parallel(true).set_ease(easing).set_trans(trans)
+
+	target_settings = to_settings
+	to_settings.set_parent_size(get_parent_control().size)
+
+	movement_tween.tween_property(self, "size_mode", to_settings.size_mode, time)
+
+	container_position.make_similar(to_settings.position)
+	## TODO make sure this converts incoming FlexVectors to the correct type!
+	movement_tween.tween_property(container_position, "x_value", to_settings.position.x_value, time)
+	movement_tween.tween_property(container_position, "y_value", to_settings.position.y_value, time)
+
+	movement_tween.tween_property(self, 'container_rotation', to_settings.rotation, time)
+
+	container_size.make_similar(to_settings.size)
+	movement_tween.tween_property(container_size, "x_value", to_settings.size.x_value, time)
+	movement_tween.tween_property(container_size, "y_value", to_settings.size.y_value, time)
+
+	mirrored = to_settings.mirrored
+
+	container_origin.make_similar(to_settings.origin)
+	movement_tween.tween_property(container_origin, "x_value", to_settings.origin.x_value, time)
+	movement_tween.tween_property(container_origin, "y_value", to_settings.origin.y_value, time)
+
+	container_z_index = to_settings.z_index
+
+	movement_tween.finished.connect(current_settings.update_from_container.bind(self))
+	movement_tween.finished.connect(set.bind("target_settings", null))
+
+	for character_node in get_children():
+		if not character_node.has_meta("character"): continue
+		movement_tween.tween_property(character_node, "position", to_settings._get_origin_position(), time)
+		for portrait_node in character_node.get_children():
+			if not portrait_node is DialogicPortrait: continue
+			update_portrait_transform(portrait_node, to_settings, movement_tween, time)
+
+	if time == 0:
+		movement_tween.custom_step(99)
+
+
+func update_portrait_transform(portrait_node:DialogicPortrait, container_settings:ContainerSettings, tween:Tween=null, time:float=0.0) -> void:
+	var character: DialogicCharacter = portrait_node.get_parent().get_meta("character")
+	var portrait_info := character.get_portrait_info(portrait_node.portrait)
+	var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
+
+	var target_pos := get_portrait_offset(character, portrait_node.portrait)
+	var target_scale := container_settings.get_portrait_scale(portrait_node)
+	if tween == null or time == 0:
+		portrait_node.position = target_pos
+		portrait_node.scale = target_scale
+	else:
+		tween.tween_property(portrait_node, "position", target_pos, time)
+		tween.tween_property(portrait_node, "scale", target_scale, time)
+
+
+func get_portrait_offset(character:DialogicCharacter, portrait:String) -> Vector2:
+	return character.offset + character.get_portrait_info(portrait).get("offset", Vector2())
+
+
+func container_resized_during_game() -> void:
+	current_settings.update_from_container(self)
+	for child in get_children():
+		if child.has_meta("character"):
+			child.position = current_settings._get_origin_position()
+		for grand_child in child.get_children():
+			if grand_child is DialogicPortrait:
+				current_settings.update_from_container(self)
+				grand_child.position = get_portrait_offset(grand_child.character, grand_child.portrait)
+				grand_child.scale = current_settings.get_portrait_scale(grand_child)
+
+
+func _child_entered_tree(child:Node) -> void:
+	if child.has_meta("character"):
+		current_settings.update_from_container(self)
+		if not child.child_entered_tree.is_connected(_portrait_entered_tree):
+			child.child_entered_tree.connect(_portrait_entered_tree)
+		child.position = current_settings._get_origin_position()
+
+
+func _portrait_entered_tree(grand_child:Node) -> void:
+	if grand_child is DialogicPortrait:
+		current_settings.update_from_container(self)
+		grand_child.position = get_portrait_offset(grand_child.character, grand_child.portrait)
+		grand_child.scale = current_settings.get_portrait_scale(grand_child)
+		if movement_tween and target_settings:
+			update_portrait_transform(grand_child, target_settings, movement_tween, movement_time - movement_tween.get_total_elapsed_time())
+		update_mirror()
+
+
+func update_mirror() -> void:
+	if current_settings: current_settings.update_from_container(self)
+	for character_node in get_children():
+		if not character_node.has_meta("character"):
+			continue
+		var character: DialogicCharacter = character_node.get_meta("character", null)
+		for portrait_node in character_node.get_children():
+			if not portrait_node is DialogicPortrait:
+				continue
+			portrait_node = portrait_node as DialogicPortrait
+			var info: Dictionary = portrait_node.character.get_portrait_info(portrait_node.portrait)
+			var resulting_mirror: bool = mirrored != portrait_node.character.mirror != info.get('mirror', false)
+
+			portrait_node._set_mirror(resulting_mirror)
+
+
+func update_z_index() -> void:
+	if current_settings: current_settings.update_from_container(self)
+	var sorted_children := get_parent().get_children().filter(func(x): return x is DialogicNode_PortraitContainer)
+	sorted_children.sort_custom(z_sort_portrait_containers)
+	var idx := 0
+	for con in sorted_children:
+		con.get_parent().move_child(con, idx)
+		idx += 1
+
+
+func z_sort_portrait_containers(con1: DialogicNode_PortraitContainer, con2: DialogicNode_PortraitContainer) -> bool:
+	return con1.container_z_index < con2.container_z_index

--- a/addons/dialogic/Modules/Character/node_portrait_container.gd
+++ b/addons/dialogic/Modules/Character/node_portrait_container.gd
@@ -123,7 +123,8 @@ var debug_character_scene_node: Node = null
 var default_portrait_scene: String = DialogicUtil.get_module_path("Character").path_join("default_portrait.tscn")
 var default_debug_character := load("uid://dykf1j17ct5mo")
 
-
+## If true the outline, position-name and origin icon are drawn in-game like they are in the editor.
+## This value can be controlled for all containers by setting Dialogic.PortraitContainers.debug_draw
 var debug_draw := false
 #endregion
 
@@ -131,8 +132,10 @@ var debug_draw := false
 var ignore_resize := false
 var ignore_transform_change := false
 
-var current_settings : ContainerSettings
-var target_settings : ContainerSettings
+## Usually contains the containers current settings as a ContainerSettings
+var current_settings: ContainerSettings
+## While moving, this contains the containers target transform
+var target_settings: ContainerSettings
 
 func _ready() -> void:
 	if not container_position.changed.is_connected(update_transform_from_properties):
@@ -173,6 +176,7 @@ func _ready() -> void:
 
 	connect_parent_resize()
 
+
 func connect_parent_resize() -> void:
 	if not get_parent().resized.is_connected(_on_parent_resized):
 		get_parent().resized.connect(_on_parent_resized)
@@ -181,6 +185,155 @@ func connect_parent_resize() -> void:
 #region MAIN METHODS
 ################################################################################
 
+
+## Tweens the containers values to [param to_settings] values.
+func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE, set_z_index:=true, set_mirror:=true) -> void:
+	if movement_tween and movement_tween.is_running():
+		movement_tween.kill()
+
+	## This handles moving the container to a different parent if necessary.
+	if to_settings.reference_position_id:
+		var ref_con := DialogicUtil.autoload().PortraitContainers.get_container(to_settings.reference_position_id)
+		if ref_con.get_parent() != get_parent():
+			var global_origin: Vector2 = global_position+current_settings._get_origin_position()
+			var global_size := container_size.as_pixels()
+			get_parent().remove_child(self)
+			ref_con.get_parent().add_child(self)
+			connect_parent_resize()
+			set_parent_size(get_parent_control().size)
+			container_position.overwrite_from_vector(global_origin-get_parent().global_position)
+			container_size.overwrite_from_vector(global_size)
+
+	movement_tween = create_tween()
+	movement_time = time
+	movement_tween.set_parallel(true).set_ease(easing).set_trans(trans)
+
+	target_settings = to_settings
+	to_settings.set_parent_size(get_parent_control().size)
+
+	movement_tween.tween_property(self, "size_mode", to_settings.size_mode, time)
+
+	container_position.make_similar(to_settings.position)
+	movement_tween.tween_property(container_position, "x_value", to_settings.position.x_value, time)
+	movement_tween.tween_property(container_position, "y_value", to_settings.position.y_value, time)
+
+	movement_tween.tween_property(self, 'container_rotation', to_settings.rotation, time)
+
+	container_size.make_similar(to_settings.size)
+	movement_tween.tween_property(container_size, "x_value", to_settings.size.x_value, time)
+	movement_tween.tween_property(container_size, "y_value", to_settings.size.y_value, time)
+
+	if set_mirror:
+		mirrored = to_settings.mirrored
+
+	container_origin.make_similar(to_settings.origin)
+	movement_tween.tween_property(container_origin, "x_value", to_settings.origin.x_value, time)
+	movement_tween.tween_property(container_origin, "y_value", to_settings.origin.y_value, time)
+
+	if set_z_index:
+		container_z_index = to_settings.z_index
+
+	movement_tween.finished.connect(current_settings.update_from_container.bind(self))
+	movement_tween.finished.connect(set.bind("target_settings", null))
+
+	# tween the portraits transforms towards their final transforms in to_settings.
+	for character_node in get_children():
+		if not character_node.has_meta("character"): continue
+		movement_tween.tween_property(character_node, "position", to_settings._get_origin_position(), time)
+		for portrait_node in character_node.get_children():
+			if not portrait_node is DialogicPortrait: continue
+			update_portrait_transform(portrait_node, to_settings, movement_tween, time)
+
+	# if time is zero, make the movement_tween finish instantly
+	if time == 0:
+		movement_tween.custom_step(99)
+
+
+## Tween the scale and position ofthe given [param portrait_node] to fit into [param container_settings].
+func update_portrait_transform(portrait_node:DialogicPortrait, container_settings:ContainerSettings, tween:Tween=null, time:float=0.0) -> void:
+	var character: DialogicCharacter = portrait_node.get_parent().get_meta("character")
+
+	var target_pos: Vector2 = character.offset + character.get_portrait_info(portrait_node.portrait).get("offset", Vector2())
+	var target_scale := container_settings.get_portrait_scale(portrait_node)
+	if tween == null or time == 0:
+		portrait_node.position = target_pos
+		portrait_node.scale = target_scale
+	else:
+		tween.tween_property(portrait_node, "position", target_pos, time)
+		tween.tween_property(portrait_node, "scale", target_scale, time)
+
+
+## When the container is resized during the game
+## make sure to reposition the character nodes at the origin and update the portrait transform.
+func container_resized_during_game() -> void:
+	current_settings.update_from_container(self)
+	for child in get_children():
+		# reposition character nodes at the origin
+		if child.has_meta("character"):
+			child.position = current_settings._get_origin_position()
+
+		# update portrait transforms
+		for grand_child in child.get_children():
+			if grand_child is DialogicPortrait:
+				update_portrait_transform(grand_child, current_settings)
+
+
+## When a new character is added to this container,
+## position it correctly and start listening to children (portraits) being added to it.
+func _child_entered_tree(child:Node) -> void:
+	if child.has_meta("character"):
+		# positon character node at the origin
+		current_settings.update_from_container(self)
+		child.position = current_settings._get_origin_position()
+
+		# start listening to children (portraits) being added.
+		if not child.child_entered_tree.is_connected(_portrait_entered_tree):
+			child.child_entered_tree.connect(_portrait_entered_tree)
+
+
+## When portraits are added to a character, update their transforms and mirror.
+func _portrait_entered_tree(grand_child:Node) -> void:
+	if grand_child is DialogicPortrait:
+		current_settings.update_from_container(self)
+		update_portrait_transform(grand_child, current_settings, null, 0)
+		update_mirror()
+
+
+## Update the mirror of all the portraits in this container.
+func update_mirror() -> void:
+	if current_settings: current_settings.update_from_container(self)
+
+	for character_node in get_children():
+		if not character_node.has_meta("character"):
+			continue
+
+		for portrait_node in character_node.get_children():
+			if not portrait_node is DialogicPortrait:
+				continue
+
+			var info: Dictionary = portrait_node.character.get_portrait_info(portrait_node.portrait)
+			var resulting_mirror: bool = mirrored != portrait_node.character.mirror != info.get("mirror", false)
+
+			portrait_node._set_mirror(resulting_mirror)
+
+
+## Update the sorting of this node and its PortraitContainer siblings based on their z-index variable.
+func update_z_index() -> void:
+	if current_settings: current_settings.update_from_container(self)
+	var sorted_children := get_parent().get_children().filter(func(x): return x is DialogicNode_PortraitContainer)
+	sorted_children.sort_custom(func(con1, con2): return con1.container_z_index < con2.container_z_index)
+	var idx := 0
+	for con in sorted_children:
+		con.get_parent().move_child(con, idx)
+		idx += 1
+
+
+func _on_parent_resized() -> void:
+	update_transform_from_properties()
+
+
+## Updates [member container_size], [member container_position], [member container_container_origin]
+## and [member container_rotation] based on the transform (position, size, rotation) of this node.
 func update_properties_from_transform() -> void:
 	if ignore_transform_change:
 		return
@@ -194,10 +347,8 @@ func update_properties_from_transform() -> void:
 	ignore_transform_change = false
 
 
-func _on_parent_resized() -> void:
-	update_transform_from_properties()
-
-
+## Updates size, position and rotation based on [member container_size], [member container_position],
+## [member container_container_origin] and [member container_rotation].
 func update_transform_from_properties() -> void:
 	if ignore_transform_change:
 		return
@@ -212,6 +363,7 @@ func update_transform_from_properties() -> void:
 	queue_redraw()
 
 
+## Returns true if the given [param id] is one of the container_id's of this container.
 func is_container(id:Variant) -> bool:
 	return str(id) in container_ids
 
@@ -307,147 +459,6 @@ func _update_debug_portrait_transform() -> void:
 func _get_debug_character() -> DialogicCharacter:
 	return debug_character if debug_character != null else default_debug_character
 
-#endregion
-
-
-
-class ContainerSettings extends Resource:
-	## A resource that allows transfering, storing and loading all settings relevant to a PortraitContainer.
-
-	@export var position := DialogicFlexVector.new()
-	@export var size := DialogicFlexVector.new()
-	@export var rotation := 0.0
-	@export var mirrored := false
-	## The portrait will be placed relative to this point in the container.
-	@export var origin := DialogicFlexVector.new()
-
-	## Defines how to affect the scale of the portrait
-	@export var size_mode: SizeModes = SizeModes.FIT_SCALE_HEIGHT
-
-	@export var z_index := 0
-
-	@export var reference_position_id := ""
-	var derived_from : DialogicNode_PortraitContainer = null
-
-	static var _transform_regex := r"(?<part>position|pos|size|siz|rotation|rot|ori|origin|mod|size_mode|mir|mirror|mirrored|sort|sor|z)\W*=(?<value>((?!(pos|siz|rot|mir|ori|mod|z|sor)).)*)"
-
-
-	## Creates a new ContainerSetting and set it's values from the given [param container].
-	static func from_container(container:DialogicNode_PortraitContainer) -> ContainerSettings:
-		var new := ContainerSettings.new()
-		new.update_from_container(container)
-		return new
-
-
-	## Copies the settings from the given PortraitContainer node [param container] to this ContainerSetting.
-	func update_from_container(container:DialogicNode_PortraitContainer) -> void:
-		position = container.container_position.copy()
-		size = container.container_size.copy()
-		mirrored = container.mirrored
-		rotation = container.container_rotation
-		origin = container.container_origin
-		size_mode = container.size_mode
-		z_index = container.container_z_index
-		if container.mode != DialogicNode_PortraitContainer.PositionModes._CHARACTER:
-			derived_from = container
-			reference_position_id = container.container_ids[0] if container.container_ids else ""
-
-
-	## Creates a new ContainerSetting and set it's values from the string. See [method update_from_string]
-	static func from_string(string:="") -> ContainerSettings:
-		var new := ContainerSettings.new()
-		new.update_from_string(string)
-		return new
-
-
-	## Applies settings from the given string to this ContainerSetting.
-	## The supported tags are pos/position, rot/rotation, siz/size, ori/origin, mir/mirrored, mod/size_mode.
-	func update_from_string(string:="") -> void:
-		var regex := RegEx.create_from_string(_transform_regex)
-		for found in regex.search_all(string):
-			match found.get_string("part"):
-				"pos", "position":
-					position.overwrite_from_string(found.get_string("value"))
-				"rot", "rotation":
-					rotation = float(found.get_string("value"))
-				"siz", "size":
-					size.overwrite_from_string(found.get_string("value"))
-				"ori", "origin":
-					origin.overwrite_from_string(found.get_string("value"))
-				"mir", "mirror", "mirrored":
-					mirrored = found.get_string("value").to_lower().strip_edges() == "true"
-				"mod", "mode", "size_mode":
-					size_mode = int(found.get_string("value"))
-				"sor", "sort", "z":
-					z_index = int(found.get_string("value"))
-				"ref", "reference":
-					reference_position_id = found.get_string("value").strip_edges()
-
-
-	## Returns the current origin position relative to this containers top left corner.
-	func _get_origin_position(rect_size = null) -> Vector2:
-		if rect_size == null:
-			rect_size = size
-		return origin.as_pixels()
-
-
-	## Returns the top left position of this container relative to it's parent.
-	func _get_top_left_position(rect_size = null) -> Vector2:
-		if rect_size == null:
-			rect_size = size
-		return position.as_pixels() - _get_origin_position(rect_size).rotated(deg_to_rad(rotation))
-
-
-	## Returns a scaling vector, that can be applied to the portrait node to fit it inside this container.
-	func get_portrait_scale(portrait_node:DialogicPortrait) -> Vector2:
-		var portrait_rect := portrait_node._get_covered_rect()
-		var character := portrait_node.character
-		var portrait_info := character.get_portrait_info(portrait_node.portrait)
-		var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
-
-		var character_scale : float =  character.scale * portrait_info.get("scale", 1) * int(apply_character_scale) + portrait_info.get("scale", 1) * int(!apply_character_scale)
-
-		var scale_vec := Vector2()
-
-		# Mode that ignores the containers size
-		if size_mode == SizeModes.KEEP:
-			scale_vec = Vector2(1,1) * character_scale
-
-		# Mode that makes sure neither height nor width go out of container
-		elif size_mode == SizeModes.FIT_IGNORE_SCALE:
-			if size.as_pixels().x/size.as_pixels().y < portrait_rect.size.x/portrait_rect.size.y:
-				scale_vec = Vector2(1,1) * size.as_pixels().x/portrait_rect.size.x
-			else:
-				scale_vec = Vector2(1,1) * size.as_pixels().y/portrait_rect.size.y
-
-		# Mode that stretches the portrait to fill the whole container
-		elif size_mode == SizeModes.FIT_STRETCH:
-			scale_vec = size.as_pixels()/portrait_rect.size
-
-		# Mode that size the character so 100% size fills the height
-		elif size_mode == SizeModes.FIT_SCALE_HEIGHT:
-			scale_vec = Vector2(1,1) * size.as_pixels().y / portrait_rect.size.y*character_scale
-
-		return scale_vec
-
-
-	func set_parent_size(parent_size:Vector2) -> void:
-		position.container_size = parent_size
-		size.container_size = parent_size
-		origin.container_size = size.as_pixels()
-
-
-	func _validate_property(property: Dictionary) -> void:
-		if property.name in ["position", "size", "origin"]:
-			property.usage = property.usage | PROPERTY_USAGE_ALWAYS_DUPLICATE
-
-
-	func as_string() -> String:
-		return "pos={pos} siz={siz} rot={rot} mir={mir} ori={ori} mod={mod} z={z} ref={ref}".format({
-			"pos":str(position), "siz":str(size), "rot":str(rotation), "mir":str(mirrored), "ori":str(origin), "mod":str(size_mode), "z":str(z_index), "ref":reference_position_id
-		})
-
-
 func set_parent_size(parent_size:Vector2) -> void:
 	container_position.container_size = parent_size
 	container_size.container_size = parent_size
@@ -503,141 +514,141 @@ func get_portrait_transform(settings:ContainerSettings, character: DialogicChara
 
 	return transform
 
-
-func update_container(to_settings: ContainerSettings, time:=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE, set_z_index:=true, set_mirror:=true) -> void:
-	if movement_tween and movement_tween.is_running():
-		movement_tween.kill()
-
-	## This handles moving the container to a different parent if necessary.
-	if to_settings.reference_position_id:
-		var ref_con := DialogicUtil.autoload().PortraitContainers.get_container(to_settings.reference_position_id)
-		if ref_con.get_parent() != get_parent():
-			var global_origin: Vector2 = global_position+current_settings._get_origin_position()
-			var global_size := container_size.as_pixels()
-			get_parent().remove_child(self)
-			ref_con.get_parent().add_child(self)
-			connect_parent_resize()
-			set_parent_size(get_parent_control().size)
-			container_position.overwrite_from_vector(global_origin-get_parent().global_position)
-			container_size.overwrite_from_vector(global_size)
-
-	movement_tween = create_tween()
-	movement_time = time
-	movement_tween.set_parallel(true).set_ease(easing).set_trans(trans)
-
-	target_settings = to_settings
-	to_settings.set_parent_size(get_parent_control().size)
-
-	movement_tween.tween_property(self, "size_mode", to_settings.size_mode, time)
-
-	container_position.make_similar(to_settings.position)
-	movement_tween.tween_property(container_position, "x_value", to_settings.position.x_value, time)
-	movement_tween.tween_property(container_position, "y_value", to_settings.position.y_value, time)
-
-	movement_tween.tween_property(self, 'container_rotation', to_settings.rotation, time)
-
-	container_size.make_similar(to_settings.size)
-	movement_tween.tween_property(container_size, "x_value", to_settings.size.x_value, time)
-	movement_tween.tween_property(container_size, "y_value", to_settings.size.y_value, time)
-
-	if set_mirror:
-	mirrored = to_settings.mirrored
-
-	container_origin.make_similar(to_settings.origin)
-	movement_tween.tween_property(container_origin, "x_value", to_settings.origin.x_value, time)
-	movement_tween.tween_property(container_origin, "y_value", to_settings.origin.y_value, time)
-
-	if set_z_index:
-	container_z_index = to_settings.z_index
-
-	movement_tween.finished.connect(current_settings.update_from_container.bind(self))
-	movement_tween.finished.connect(set.bind("target_settings", null))
-
-	for character_node in get_children():
-		if not character_node.has_meta("character"): continue
-		movement_tween.tween_property(character_node, "position", to_settings._get_origin_position(), time)
-		for portrait_node in character_node.get_children():
-			if not portrait_node is DialogicPortrait: continue
-			update_portrait_transform(portrait_node, to_settings, movement_tween, time)
-
-	if time == 0:
-		movement_tween.custom_step(99)
+#endregion
 
 
-func update_portrait_transform(portrait_node:DialogicPortrait, container_settings:ContainerSettings, tween:Tween=null, time:float=0.0) -> void:
-	var character: DialogicCharacter = portrait_node.get_parent().get_meta("character")
-	var portrait_info := character.get_portrait_info(portrait_node.portrait)
-	var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
+#region CONTAINER SETTINGS
+################################################################################
 
-	var target_pos := get_portrait_offset(character, portrait_node.portrait)
-	var target_scale := container_settings.get_portrait_scale(portrait_node)
-	if tween == null or time == 0:
-		portrait_node.position = target_pos
-		portrait_node.scale = target_scale
-	else:
-		tween.tween_property(portrait_node, "position", target_pos, time)
-		tween.tween_property(portrait_node, "scale", target_scale, time)
+class ContainerSettings extends Resource:
+	## A resource that allows transfering, storing and loading all settings relevant to a PortraitContainer.
 
+	@export var position := DialogicFlexVector.new()
+	@export var size := DialogicFlexVector.new()
+	@export var rotation := 0.0
+	@export var mirrored := false
+	@export var origin := DialogicFlexVector.new()
+	@export var size_mode: SizeModes = SizeModes.FIT_SCALE_HEIGHT
+	@export var z_index := 0
+	@export var reference_position_id := ""
 
-func get_portrait_offset(character:DialogicCharacter, portrait:String) -> Vector2:
-	return character.offset + character.get_portrait_info(portrait).get("offset", Vector2())
+	var derived_from : DialogicNode_PortraitContainer = null
 
-
-func container_resized_during_game() -> void:
-	current_settings.update_from_container(self)
-	for child in get_children():
-		if child.has_meta("character"):
-			child.position = current_settings._get_origin_position()
-		for grand_child in child.get_children():
-			if grand_child is DialogicPortrait:
-				current_settings.update_from_container(self)
-				grand_child.position = get_portrait_offset(grand_child.character, grand_child.portrait)
-				grand_child.scale = current_settings.get_portrait_scale(grand_child)
+	static var _transform_regex := r"(?<part>position|pos|size|siz|rotation|rot|ori|origin|mod|size_mode|mir|mirror|mirrored|sort|sor|z)\W*=(?<value>((?!(pos|siz|rot|mir|ori|mod|z|sor)).)*)"
 
 
-func _child_entered_tree(child:Node) -> void:
-	if child.has_meta("character"):
-		current_settings.update_from_container(self)
-		if not child.child_entered_tree.is_connected(_portrait_entered_tree):
-			child.child_entered_tree.connect(_portrait_entered_tree)
-		child.position = current_settings._get_origin_position()
+	## Creates a new ContainerSetting and set its values from the given [param container].
+	static func from_container(container:DialogicNode_PortraitContainer) -> ContainerSettings:
+		var new := ContainerSettings.new()
+		new.update_from_container(container)
+		return new
 
 
-func _portrait_entered_tree(grand_child:Node) -> void:
-	if grand_child is DialogicPortrait:
-		current_settings.update_from_container(self)
-		grand_child.position = get_portrait_offset(grand_child.character, grand_child.portrait)
-		grand_child.scale = current_settings.get_portrait_scale(grand_child)
-		if movement_tween and target_settings:
-			update_portrait_transform(grand_child, target_settings, movement_tween, movement_time - movement_tween.get_total_elapsed_time())
-		update_mirror()
+	## Copies the settings from the given PortraitContainer node [param container] to this ContainerSetting.
+	func update_from_container(container:DialogicNode_PortraitContainer) -> void:
+		position = container.container_position.copy()
+		size = container.container_size.copy()
+		mirrored = container.mirrored
+		rotation = container.container_rotation
+		origin = container.container_origin
+		size_mode = container.size_mode
+		z_index = container.container_z_index
+		if container.mode != DialogicNode_PortraitContainer.PositionModes._CHARACTER:
+			derived_from = container
+			reference_position_id = container.container_ids[0] if container.container_ids else ""
 
 
-func update_mirror() -> void:
-	if current_settings: current_settings.update_from_container(self)
-	for character_node in get_children():
-		if not character_node.has_meta("character"):
-			continue
-		var character: DialogicCharacter = character_node.get_meta("character", null)
-		for portrait_node in character_node.get_children():
-			if not portrait_node is DialogicPortrait:
-				continue
-			portrait_node = portrait_node as DialogicPortrait
-			var info: Dictionary = portrait_node.character.get_portrait_info(portrait_node.portrait)
-			var resulting_mirror: bool = mirrored != portrait_node.character.mirror != info.get('mirror', false)
-
-			portrait_node._set_mirror(resulting_mirror)
+	## Creates a new ContainerSetting and set its values from the string. See [method update_from_string]
+	static func from_string(string:="") -> ContainerSettings:
+		var new := ContainerSettings.new()
+		new.update_from_string(string)
+		return new
 
 
-func update_z_index() -> void:
-	if current_settings: current_settings.update_from_container(self)
-	var sorted_children := get_parent().get_children().filter(func(x): return x is DialogicNode_PortraitContainer)
-	sorted_children.sort_custom(z_sort_portrait_containers)
-	var idx := 0
-	for con in sorted_children:
-		con.get_parent().move_child(con, idx)
-		idx += 1
+	## Applies settings from the given string to this ContainerSetting.
+	## The supported tags are pos/position, rot/rotation, siz/size, ori/origin, mir/mirrored, mod/size_mode.
+	func update_from_string(string:="") -> void:
+		var regex := RegEx.create_from_string(_transform_regex)
+		for found in regex.search_all(string):
+			match found.get_string("part"):
+				"pos", "position":
+					position.overwrite_from_string(found.get_string("value"))
+				"rot", "rotation":
+					rotation = float(found.get_string("value"))
+				"siz", "size":
+					size.overwrite_from_string(found.get_string("value"))
+				"ori", "origin":
+					origin.overwrite_from_string(found.get_string("value"))
+				"mir", "mirror", "mirrored":
+					mirrored = found.get_string("value").to_lower().strip_edges() == "true"
+				"mod", "mode", "size_mode":
+					size_mode = (int(found.get_string("value")) as SizeModes)
+				"sor", "sort", "z":
+					z_index = int(found.get_string("value"))
+				"ref", "reference":
+					reference_position_id = found.get_string("value").strip_edges()
 
 
-func z_sort_portrait_containers(con1: DialogicNode_PortraitContainer, con2: DialogicNode_PortraitContainer) -> bool:
-	return con1.container_z_index < con2.container_z_index
+	## Returns the current origin position relative to this containers top left corner.
+	func _get_origin_position(rect_size = null) -> Vector2:
+		if rect_size == null:
+			rect_size = size
+		return origin.as_pixels()
+
+
+	## Returns the top left position of this container relative to its parent.
+	func _get_top_left_position(rect_size = null) -> Vector2:
+		if rect_size == null:
+			rect_size = size
+		return position.as_pixels() - _get_origin_position(rect_size).rotated(deg_to_rad(rotation))
+
+
+	## Returns a scaling vector, that can be applied to the portrait node to fit it inside this container.
+	func get_portrait_scale(portrait_node:DialogicPortrait) -> Vector2:
+		var portrait_rect := portrait_node._get_covered_rect()
+		var character := portrait_node.character
+		var portrait_info := character.get_portrait_info(portrait_node.portrait)
+		var apply_character_scale: bool = not portrait_info.get("ignore_char_scale", false)
+
+		var character_scale : float =  character.scale * portrait_info.get("scale", 1) * int(apply_character_scale) + portrait_info.get("scale", 1) * int(!apply_character_scale)
+
+		var scale_vec := Vector2()
+
+		# Mode that ignores the containers size
+		if size_mode == SizeModes.KEEP:
+			scale_vec = Vector2(1,1) * character_scale
+
+		# Mode that makes sure neither height nor width go out of container
+		elif size_mode == SizeModes.FIT_IGNORE_SCALE:
+			if size.as_pixels().x/size.as_pixels().y < portrait_rect.size.x/portrait_rect.size.y:
+				scale_vec = Vector2(1,1) * size.as_pixels().x/portrait_rect.size.x
+			else:
+				scale_vec = Vector2(1,1) * size.as_pixels().y/portrait_rect.size.y
+
+		# Mode that stretches the portrait to fill the whole container
+		elif size_mode == SizeModes.FIT_STRETCH:
+			scale_vec = size.as_pixels()/portrait_rect.size
+
+		# Mode that size the character so 100% size fills the height
+		elif size_mode == SizeModes.FIT_SCALE_HEIGHT:
+			scale_vec = Vector2(1,1) * size.as_pixels().y / portrait_rect.size.y*character_scale
+
+		return scale_vec
+
+
+	func set_parent_size(parent_size:Vector2) -> void:
+		position.container_size = parent_size
+		size.container_size = parent_size
+		origin.container_size = size.as_pixels()
+
+
+	func _validate_property(property: Dictionary) -> void:
+		if property.name in ["position", "size", "origin"]:
+			property.usage = property.usage | PROPERTY_USAGE_ALWAYS_DUPLICATE
+
+
+	func as_string() -> String:
+		return "pos={pos} siz={siz} rot={rot} mir={mir} ori={ori} mod={mod} z={z} ref={ref}".format({
+			"pos":str(position), "siz":str(size), "rot":str(rotation), "mir":str(mirrored), "ori":str(origin), "mod":str(size_mode), "z":str(z_index), "ref":reference_position_id
+		})
+#endregion

--- a/addons/dialogic/Modules/Character/subsystem_containers.gd
+++ b/addons/dialogic/Modules/Character/subsystem_containers.gd
@@ -13,8 +13,12 @@ var transform_regex := r"(?<part>position|pos|size|siz|rotation|rot)\W*=(?<value
 var debug_draw := false :
 	set(x):
 		debug_draw = x
-		for n in get_tree().get_nodes_in_group(&'dialogic_portrait_con_position'):
+		for n:Node in get_tree().get_nodes_in_group(&'dialogic_portrait_con_position'):
 			n.debug_draw = x
+			n.queue_redraw()
+		for n:Node in get_tree().get_nodes_in_group(&'dialogic_portrait_con_speaker'):
+			n.debug_draw = x
+			n.queue_redraw()
 
 
 #region STATE
@@ -40,13 +44,6 @@ func get_containers(position_id: String) -> Array[DialogicNode_PortraitContainer
 			return node.is_visible_in_tree() and node.is_container(position_id))
 
 
-func get_container_container() -> CanvasItem:
-	var any_portrait_container := get_tree().get_first_node_in_group(&'dialogic_portrait_con_position')
-	if any_portrait_container:
-		return any_portrait_container.get_parent()
-	return null
-
-
 ## Creates a new portrait container node.
 ## It will copy it's size and most settings from the first p_container in the tree.
 ## It will be added as a sibling of the first p_container in the tree.
@@ -54,9 +51,9 @@ func add_container(position_id: String) -> DialogicNode_PortraitContainer:
 	var example_position := get_tree().get_first_node_in_group(&'dialogic_portrait_con_position')
 	if example_position:
 		var new_position := DialogicNode_PortraitContainer.new()
+		new_position.mode = DialogicNode_PortraitContainer.PositionModes._CHARACTER
 		example_position.get_parent().add_child(new_position)
 		new_position.name = "Portrait_"+position_id.validate_node_name()
-		copy_container_setup(example_position, new_position)
 		new_position.container_ids = [position_id]
 		position_changed.emit({&'change':'added', &'container_node':new_position, &'position_id':position_id})
 		return new_position
@@ -65,160 +62,26 @@ func add_container(position_id: String) -> DialogicNode_PortraitContainer:
 
 ## Moves the [container] to the [destionation] (using [tween] and [time]).
 ## The destination can be a position_id (e.g. "center") or translation, roataion and scale.
-## When moving to a preset container, then some more will be "copied" (e.g. anchors, etc.)
-func move_container(container:DialogicNode_PortraitContainer, destination:String, tween:Tween = null, time:float=1.0) -> void:
-	var target_position: Vector2 = container.position + container._get_origin_position()
-	var target_rotation: float = container.rotation
-	var target_size: Vector2 = container.size
+func update_container(container:DialogicNode_PortraitContainer, destination:String, time:float=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE) -> void:
+	var to_settings : DialogicNode_PortraitContainer.ContainerSettings
 
 	var destination_container := get_container(destination)
 	if destination_container:
-		container.set_meta("target_container", destination_container)
-		target_position = destination_container.position + destination_container._get_origin_position()
-		target_rotation = destination_container.rotation_degrees
-		target_size = destination_container.size
+		to_settings = destination_container.current_settings.duplicate(true)
 	else:
-		var regex := RegEx.create_from_string(transform_regex)
-		for found in regex.search_all(destination):
-			match found.get_string('part'):
-				'pos', 'position':
-					target_position = str_to_vector(found.get_string("value"), target_position)
-				'rot', 'rotation':
-					target_rotation = float(found.get_string("value"))
-				'siz', 'size':
-					target_size = str_to_vector(found.get_string("value"), target_size)
+		to_settings = container.current_settings.duplicate(true)
+		to_settings.update_from_string(destination)
 
-	translate_container(container, target_position, false, tween, time)
-	rotate_container(container, target_rotation, false, tween, time)
-	resize_container(container, target_size, false, tween, time)
+	container.update_container(to_settings, time, easing, trans)
 
-	if destination_container:
-		if time:
-			tween.finished.connect(func():
-				if container.has_meta("target_container"):
-					if container.get_meta("target_container") == destination_container:
-						copy_container_setup(destination_container, container)
-				)
-		else:
-			copy_container_setup(destination_container, container)
-
-
-func copy_container_setup(from:DialogicNode_PortraitContainer, to:DialogicNode_PortraitContainer) -> void:
-	to.ignore_resize = true
-	to.layout_mode = from.layout_mode
-	to.anchors_preset = from.anchors_preset
-	to.anchor_bottom = from.anchor_bottom
-	to.anchor_left = from.anchor_left
-	to.anchor_right = from.anchor_right
-	to.anchor_top = from.anchor_top
-	to.offset_bottom = from.offset_bottom
-	to.offset_top = from.offset_top
-	to.offset_right = from.offset_right
-	to.offset_left = from.offset_left
-	to.size_mode = from.size_mode
-	to.origin_anchor = from.origin_anchor
-	to.ignore_resize = false
-	to.update_portrait_transforms()
-
-
-## Translates the given container.
-## The given translation should be the target position of the ORIGIN point, not the container!
-func translate_container(container:DialogicNode_PortraitContainer, translation:Variant, relative := false, tween:Tween=null, time:float=1.0) -> void:
-	if !container.has_meta(&'default_translation'):
-		container.set_meta(&'default_translation', container.position + container._get_origin_position())
-
-	var final_translation: Vector2
-	if typeof(translation) == TYPE_STRING:
-		final_translation = str_to_vector(translation, container.position+container._get_origin_position())
-	elif typeof(translation) == TYPE_VECTOR2:
-		final_translation = translation
-
-	if relative:
-		final_translation += container.position
-	else:
-		final_translation -= container._get_origin_position()
-
-	if tween:
-		tween.tween_method(DialogicUtil.multitween.bind(container, "position", "base"), container.position, final_translation, time)
-		if not tween.finished.is_connected(save_position_container):
-			tween.finished.connect(save_position_container.bind(container))
-	else:
-		container.position = final_translation
-		save_position_container(container)
-	position_changed.emit({&'change':'moved', &'container_node':container})
-
-
-func rotate_container(container:DialogicNode_PortraitContainer, rotation:float, relative := false, tween:Tween=null, time:float=1.0) -> void:
-	if !container.has_meta(&'default_rotation'):
-		container.set_meta(&'default_rotation', container.rotation_degrees)
-
-	var final_rotation := rotation
-
-	if relative:
-		final_rotation += container.rotation_degrees
-
-	container.pivot_offset = container._get_origin_position()
-
-	if tween:
-		tween.tween_property(container, 'rotation_degrees', final_rotation, time)
-		if not tween.finished.is_connected(save_position_container):
-			tween.finished.connect(save_position_container.bind(container))
-	else:
-		container.rotation_degrees = final_rotation
-		save_position_container(container)
-
-	position_changed.emit({&'change':'rotated', &'container_node':container})
-
-
-func resize_container(container: DialogicNode_PortraitContainer, rect_size: Variant, relative := false, tween:Tween=null, time:float=1.0) -> void:
-	if !container.has_meta(&'default_size'):
-		container.set_meta(&'default_size', container.size)
-
-	var final_rect_resize: Vector2
-	if typeof(rect_size) == TYPE_STRING:
-		final_rect_resize = str_to_vector(rect_size, container.size)
-	elif typeof(rect_size) == TYPE_VECTOR2:
-		final_rect_resize = rect_size
-
-	if relative:
-		final_rect_resize += container.rect_size
-
-	var relative_position_change := container._get_origin_position()-container._get_origin_position(final_rect_resize)
-
-	if tween:
-		tween.tween_method(DialogicUtil.multitween.bind(container, "position", "resize_move"), Vector2(), relative_position_change, time)
-		tween.tween_property(container, 'size', final_rect_resize, time)
-		if not tween.finished.is_connected(save_position_container):
-			tween.finished.connect(save_position_container.bind(container))
-	else:
-		container.position = container.position + relative_position_change
-		#container.size = final_rect_resize
-		container.set_deferred("size", final_rect_resize)
-		save_position_container(container)
-
-	position_changed.emit({&'change':'resized', &'container_node':container})
+	save_position_container(container)
 
 
 func save_position_container(container: DialogicNode_PortraitContainer) -> void:
-	var info := {
-		"container_ids" : container.container_ids,
-		"position" : container.position,
-		"rotation" : container.rotation_degrees,
-		"size" : container.size,
-		"pivot_mode" : container.pivot_mode,
-		"pivot_value" : container.pivot_value,
-		"origin_anchor" : container.origin_anchor,
-		"anchor_left" : container.anchor_left,
-		"anchor_right" : container.anchor_right,
-		"anchor_top" : container.anchor_top,
-		"anchor_bottom" : container.anchor_bottom,
-		"offset_left" : container.offset_left,
-		"offset_right" : container.offset_right,
-		"offset_top" : container.offset_top,
-		"offset_bottom" : container.offset_bottom,
-	}
-
-	container_info[container.container_ids[0]] = info
+	if container.target_settings:
+		container_info[container.container_ids[0]] = container.target_settings.as_string()
+	else:
+		container_info[container.container_ids[0]] = container.current_settings.as_string()
 
 
 func load_position_container(position_id: String) -> DialogicNode_PortraitContainer:
@@ -230,63 +93,12 @@ func load_position_container(position_id: String) -> DialogicNode_PortraitContai
 	if not container_info.has(position_id):
 		return null
 
-	var info: Dictionary = container_info[position_id]
+	var info: String = container_info[position_id]
 	container = add_container(position_id)
 
 	if not container:
 		return null
 
-	container.container_ids = info.container_ids
-	container.position = info.position
-	container.rotation = info.rotation
-	container.size = info.size
-	container.pivot_mode = info.pivot_mode
-	container.pivot_value = info.pivot_value
-	container.origin_anchor = info.origin_anchor
-	container.anchor_left = info.anchor_left
-	container.anchor_right = info.anchor_right
-	container.anchor_top = info.anchor_top
-	container.anchor_bottom = info.anchor_bottom
-	container.offset_left = info.offset_left
-	container.offset_right = info.offset_right
-	container.offset_top = info.offset_top
-	container.offset_bottom = info.offset_bottom
-
+	var settings := DialogicNode_PortraitContainer.ContainerSettings.from_string(info)
+	container.update_container(settings)
 	return container
-
-
-func str_to_vector(input: String, base_vector:=Vector2()) -> Vector2:
-	var vector_regex := RegEx.create_from_string(r"(?<part>x|y)\s*(?<number>(-|\+)?(\d|\.|)*)(\s*(?<type>%|px))?")
-	var vec := base_vector
-	for i in vector_regex.search_all(input):
-		var value := float(i.get_string(&'number'))
-		match i.get_string(&'type'):
-			'px':
-				pass # Keep values as they are
-			'%', _:
-				match i.get_string(&'part'):
-					'x': value *= get_viewport().get_visible_rect().size.x
-					'y': value *= get_viewport().get_visible_rect().size.y
-
-		match i.get_string(&'part'):
-			'x': vec.x = value
-			'y': vec.y = value
-	return vec
-
-
-func vector_to_str(vec:Vector2) -> String:
-	return "x" + str(vec.x) + "px y" + str(vec.y) + "px"
-
-
-func reset_all_containers(time:= 0.0, tween:Tween = null) -> void:
-	for container in get_tree().get_nodes_in_group(&'dialogic_portrait_con_position'):
-		reset_container(container, time, tween)
-
-
-func reset_container(container:DialogicNode_PortraitContainer, time := 0.0, tween: Tween = null ) -> void:
-	if container.has_meta(&'default_translation'):
-		translate_container(container, vector_to_str(container.get_meta(&'default_translation')), false, tween, time)
-	if container.has_meta(&'default_rotation'):
-		rotate_container(container, container.get_meta(&'default_rotation'), false, tween, time)
-	if container.has_meta(&'default_size'):
-		resize_container(container, vector_to_str(container.get_meta(&'default_size')), false, tween, time)

--- a/addons/dialogic/Modules/Character/subsystem_containers.gd
+++ b/addons/dialogic/Modules/Character/subsystem_containers.gd
@@ -10,6 +10,8 @@ var transform_regex := r"(?<part>position|pos|size|siz|rotation|rot)\W*=(?<value
 @export_group("State")
 @export var container_info := {}
 
+
+## Use this to update the debug_draw setting on all PortraitContainers currently in the tree.
 var debug_draw := false :
 	set(x):
 		debug_draw = x

--- a/addons/dialogic/Modules/Character/subsystem_containers.gd
+++ b/addons/dialogic/Modules/Character/subsystem_containers.gd
@@ -61,13 +61,17 @@ func add_container(position_id: String) -> DialogicNode_PortraitContainer:
 
 
 ## Moves the [container] to the [destionation] (using [tween] and [time]).
-## The destination can be a position_id (e.g. "center") or translation, roataion and scale.
-func update_container(container:DialogicNode_PortraitContainer, destination:String, time:float=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE) -> void:
+## The destination can be a position_id (e.g. "center") or translation, rotation and scale.
+## If full_update is false, the mirror and z_index will be preserved.
+func update_container(container:DialogicNode_PortraitContainer, destination:String, time:float=0.0, easing:=Tween.EASE_IN_OUT, trans:=Tween.TRANS_SINE, full_update:=true) -> void:
 	var to_settings : DialogicNode_PortraitContainer.ContainerSettings
 
 	var destination_container := get_container(destination)
 	if destination_container:
 		to_settings = destination_container.current_settings.duplicate(true)
+		if not full_update:
+			to_settings.mirrored = container.current_settings.mirrored
+			to_settings.z_index = container.current_settings.z_index
 	else:
 		to_settings = container.current_settings.duplicate(true)
 		to_settings.update_from_string(destination)

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -23,8 +23,8 @@ var default_portrait_scene: PackedScene = load(get_script().resource_path.get_ba
 ####################################################################################################
 
 func _clear_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
-	for character_identifier in portraits.keys():
-		remove_character(DialogicResourceUtil.get_character_resource(character_identifier))
+	for character_node in character_nodes.values():
+		_remove_character(character_node)
 	portraits.clear()
 	character_nodes.clear()
 
@@ -40,8 +40,6 @@ func _load_state(_load_flag := LoadFlags.FULL_LOAD) -> void:
 		if character:
 			var container := dialogic.PortraitContainers.load_position_container(character.get_character_name())
 			await add_character(character, container, character_info.portrait, character_info.position_id)
-			change_character_mirror(character, character_info.get('custom_mirror', false))
-			change_character_z_index(character, character_info.get('z_index', 0))
 			character_nodes[character.get_identifier()].get_child(-1)._load_state(portrait_states.get(character.get_identifier(), {}))
 		else:
 			push_error('[Dialogic] Failed to load character "' + str(character_identifier) + '".')
@@ -98,8 +96,8 @@ func _create_character_node(character:DialogicCharacter, container:DialogicNode_
 	if container == null:
 		return null
 	var character_node := Node2D.new()
-	character_node.name = character.get_character_name()
-	character_node.set_meta('character', character)
+	character_node.name = character.get_character_name().validate_node_name()
+	character_node.set_meta("character", character)
 	container.add_child(character_node)
 	return character_node
 
@@ -140,6 +138,7 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 				info["same_scene"] = true
 
 	if portrait_node == null:
+		if previous_portrait: previous_portrait.name = "Previous_Portrait"
 		if ResourceLoader.exists(scene_path):
 			ResourceLoader.load_threaded_request(scene_path)
 
@@ -159,6 +158,7 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 
 		if not portrait_node:
 			portrait_node = default_portrait_scene.instantiate()
+			portrait_node.name = portrait.validate_node_name()
 
 		portrait_node.set_meta('scene', scene_path)
 
@@ -179,8 +179,6 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 		if not portrait_node.is_inside_tree():
 			character_node.add_child(portrait_node)
 
-		_update_portrait_transform(portrait_node)
-
 		## Handle Cross-Animating
 		if previous_portrait and previous_portrait != portrait_node:
 			if not fade_animation.is_empty() and fade_length > 0:
@@ -193,16 +191,9 @@ func _change_portrait(character_node: Node2D, portrait: String, fade_animation:=
 	return info
 
 
-## Changes the mirroring of the given portrait.
-## Unless @force is false, this will take into consideration the character mirror,
-## portrait mirror and portrait position mirror settings.
-func _change_portrait_mirror(character_node: Node2D, mirrored := false, force := false) -> void:
-	var latest_portrait := character_node.get_child(-1) if character_node.get_child_count() > 0 else null
-
-	if latest_portrait and latest_portrait.has_method("_set_mirror"):
-		var character: DialogicCharacter = character_node.get_meta('character')
-		var current_portrait_info := character.get_portrait_info(character_node.get_meta('portrait'))
-		latest_portrait._set_mirror(force or (mirrored != character.mirror != character_node.get_parent().mirrored != current_portrait_info.get('mirror', false)))
+## Changes the mirroring of the given character.
+func _change_portrait_mirror(character_node: Node2D, mirrored := false) -> void:
+	dialogic.PortraitContainers.update_container(character_node.get_parent(), "mir="+str(mirrored), 0)
 
 
 func _change_portrait_extradata(character_node: Node2D, extra_data := "") -> void:
@@ -218,44 +209,6 @@ func _change_portrait_extradata(character_node: Node2D, extra_data := "") -> voi
 	else:
 		push_warning("[Dialogic] No portrait found for character node: " + character_node.name)
 
-func _update_character_transform(character_node:Node, time := 0.0) -> void:
-	for child in character_node.get_children():
-		_update_portrait_transform(child, time)
-
-
-func _update_portrait_transform(portrait_node: Node, time:float = 0.0) -> void:
-	var character_node: Node = portrait_node.get_parent()
-
-	var character: DialogicCharacter = character_node.get_meta('character')
-	var portrait_info: Dictionary = character.portraits.get(portrait_node.get_meta('portrait'), {})
-
-	# ignore the character scale on custom portraits that have 'ignore_char_scale' set to true
-	var apply_character_scale: bool = not portrait_info.get('ignore_char_scale', false)
-
-	var transform: Rect2 = character_node.get_parent().get_local_portrait_transform(
-		portrait_node._get_covered_rect(),
-		(character.scale * portrait_info.get('scale', 1))*int(apply_character_scale)+portrait_info.get('scale', 1)*int(!apply_character_scale))
-
-	var tween: Tween
-
-	if character_node.has_meta('move_tween'):
-		if character_node.get_meta('move_tween').is_running():
-			time = character_node.get_meta('move_time')-character_node.get_meta('move_tween').get_total_elapsed_time()
-			tween = character_node.get_meta('move_tween')
-			tween.stop()
-	if time == 0:
-		character_node.position = transform.position
-		portrait_node.position = character.offset + portrait_info.get('offset', Vector2())
-		portrait_node.scale = transform.size
-	else:
-		if not tween:
-			tween = character_node.create_tween().set_parallel().set_ease(Tween.EASE_IN_OUT).set_trans(Tween.TRANS_SINE)
-			character_node.set_meta('move_tween', tween)
-			character_node.set_meta('move_time', time)
-		tween.tween_method(DialogicUtil.multitween.bind(character_node, "position", "base"), character_node.position, transform.position, time)
-		tween.tween_property(portrait_node, 'position',character.offset + portrait_info.get('offset', Vector2()), time)
-		tween.tween_property(portrait_node, 'scale', transform.size, time)
-
 
 ## Animates the node with the given animation.
 ## Is used both on the character node (most animations) and the portrait nodes (cross-fade animations)
@@ -267,6 +220,7 @@ func _animate_node(node: Node, animation_path: String, length: float, repeats :=
 	var anim_node := Node.new()
 	anim_node.set_script(anim_script)
 	anim_node = (anim_node as DialogicAnimation)
+	anim_node.name = node.name +"_"+animation_path.get_file().trim_suffix(".gd").validate_node_name()
 	anim_node.node = node
 	anim_node.base_position = node.position
 	anim_node.base_scale = node.scale
@@ -290,28 +244,14 @@ func _animate_node(node: Node, animation_path: String, length: float, repeats :=
 
 ## Moves the given portrait to the given container.
 func _move_character(character_node: Node2D, transform:="", time := 0.0, easing:= Tween.EASE_IN_OUT, trans:= Tween.TRANS_SINE) -> void:
-	var tween := character_node.create_tween().set_ease(easing).set_trans(trans).set_parallel()
-	if time == 0:
-		tween.kill()
-		tween = null
 	var container: DialogicNode_PortraitContainer = character_node.get_parent()
-	dialogic.PortraitContainers.move_container(container, transform, tween, time)
-
-	for portrait_node in character_node.get_children():
-		_update_portrait_transform(portrait_node, time)
+	dialogic.PortraitContainers.update_container(container, transform, time, easing, trans)
 
 
-## Changes the given portraits z_index.
+## Changes the given characters z_index.
 func _change_portrait_z_index(character_node: Node, z_index:int, update_zindex:= true) -> void:
 	if update_zindex:
-		character_node.get_parent().set_meta('z_index', z_index)
-
-		var sorted_children := character_node.get_parent().get_parent().get_children()
-		sorted_children.sort_custom(z_sort_portrait_containers)
-		var idx := 0
-		for con in sorted_children:
-			con.get_parent().move_child(con, idx)
-			idx += 1
+		dialogic.PortraitContainers.update_container(character_node.get_parent(), "z="+str(z_index), 0)
 
 
 ## Checks if [para, character] has joined the scene, if so, returns its
@@ -330,17 +270,23 @@ func get_character_portrait(character: DialogicCharacter) -> DialogicPortrait:
 	return null
 
 
-func z_sort_portrait_containers(con1: DialogicNode_PortraitContainer, con2: DialogicNode_PortraitContainer) -> bool:
-	if con1.get_meta('z_index', 0) < con2.get_meta('z_index', 0):
-		return true
-
-	return false
-
-
 ## Private method to remove a [param portrait_node].
 func _remove_portrait(portrait_node: Node) -> void:
 	portrait_node.get_parent().remove_child(portrait_node)
 	portrait_node.queue_free()
+
+
+
+## Removes the given characters portrait.
+## Only works with joined characters.
+func _remove_character(character_node:Node) -> void:
+	if is_instance_valid(character_node) and character_node is Node:
+		character_left.emit({'character': character_node.get_meta("character")})
+		var container := character_node.get_parent()
+		container.get_parent().remove_child(container)
+		container.queue_free()
+		character_node.queue_free()
+
 
 
 ## Gets the default animation length for joining characters
@@ -420,7 +366,7 @@ func join_character(character:DialogicCharacter, portrait:String,  position_id:S
 	if character_node == null:
 		return null
 
-	portraits[character.get_identifier()] = {'portrait':portrait, 'position_id':position_id, 'custom_mirror':mirrored}
+	portraits[character.get_identifier()] = {'portrait':portrait, 'position_id':position_id}
 	character_nodes[character.get_identifier()] = character_node
 
 	_change_portrait_mirror(character_node, mirrored)
@@ -448,7 +394,7 @@ func join_character(character:DialogicCharacter, portrait:String,  position_id:S
 	return character_node
 
 
-func add_character(character: DialogicCharacter, container: DialogicNode_PortraitContainer, portrait: String, position_id: String) -> Node:
+func add_character(character: DialogicCharacter, container: DialogicNode_PortraitContainer, portrait: String, transform: String) -> Node:
 	if is_character_joined(character):
 		printerr('[DialogicError] Cannot add an already joined character. If this is intended, call _create_character_node manually.')
 		return null
@@ -459,19 +405,19 @@ func add_character(character: DialogicCharacter, container: DialogicNode_Portrai
 		return null
 
 	if not character:
-		printerr('[DialogicError] Cannot call add_portrait() with null character.')
+		printerr('[DialogicError] Cannot call add_character() with null character.')
 		return null
 
 	var character_node := _create_character_node(character, container)
 
 	if character_node == null:
-		printerr('[Dialogic] Failed to join character to position ', position_id, ". Could not find position container.")
+		printerr('[Dialogic] Failed to join character to position ', transform, ". Could not find position container.")
 		return null
 
-	portraits[character.get_identifier()] = {'portrait': portrait, 'position_id': position_id}
+	portraits[character.get_identifier()] = {'portrait': portrait, 'position_id': transform}
 	character_nodes[character.get_identifier()] = character_node
 
-	_move_character(character_node, position_id)
+	_move_character(character_node, transform)
 	await _change_portrait(character_node, portrait)
 
 	return character_node
@@ -495,25 +441,20 @@ func change_character_portrait(character: DialogicCharacter, portrait: String, f
 
 	var info := await _change_portrait(character_nodes[character.get_identifier()], portrait, fade_animation, fade_length)
 	portraits[character.get_identifier()].portrait = info.portrait
-	_change_portrait_mirror(
-			character_nodes[character.get_identifier()],
-			portraits[character.get_identifier()].get('custom_mirror', false)
-			)
 	character_portrait_changed.emit(info)
 
 
 ## Changes the mirror of the given character. Only works with joined characters
-func change_character_mirror(character:DialogicCharacter, mirrored:= false, force:= false) -> void:
-	if !is_character_joined(character):
+func change_character_mirror(character:DialogicCharacter, mirrored:= false) -> void:
+	if not is_character_joined(character):
 		return
 
-	_change_portrait_mirror(character_nodes[character.get_identifier()], mirrored, force)
-	portraits[character.get_identifier()]['custom_mirror'] = mirrored
+	_change_portrait_mirror(character_nodes[character.get_identifier()], mirrored)
 
 
 ## Changes the z_index of a character. Only works with joined characters
 func change_character_z_index(character:DialogicCharacter, z_index:int, update_zindex:= true) -> void:
-	if !is_character_joined(character):
+	if not is_character_joined(character):
 		return
 
 	_change_portrait_z_index(character_nodes[character.get_identifier()], z_index, update_zindex)
@@ -560,6 +501,13 @@ func leave_character(character: DialogicCharacter, animation_name:= "", animatio
 	if not is_character_joined(character):
 		return
 
+	var character_node := get_character_node(character)
+
+	# We do this BEFORE the animation actually finishes
+	# because it's possible the character joines again while leaving.
+	portraits.erase(character.get_identifier())
+	character_nodes.erase(character.get_identifier())
+
 	if animation_name.is_empty():
 		animation_name = ProjectSettings.get_setting('dialogic/animations/leave_default', "Fade Out Down")
 		animation_length = _get_leave_default_length()
@@ -568,19 +516,17 @@ func leave_character(character: DialogicCharacter, animation_name:= "", animatio
 	animation_name = DialogicPortraitAnimationUtil.guess_animation(animation_name, DialogicPortraitAnimationUtil.AnimationType.OUT)
 
 	if not animation_name.is_empty():
-		var character_node := get_character_node(character)
-
 		var animation := _animate_node(character_node, animation_name, animation_length, 1, true)
 		if animation_length > 0:
 			if animation_wait:
 				dialogic.current_state = DialogicGameHandler.States.ANIMATING
 				await animation.finished
 				dialogic.current_state = DialogicGameHandler.States.IDLE
-				remove_character(character)
+				_remove_character(character_node)
 			else:
-				animation.finished.connect(func(): remove_character(character))
+				animation.finished.connect(_remove_character.bind(character_node))
 		else:
-			remove_character(character)
+			_remove_character(character_node)
 
 
 ## Removes all joined characters with a given animation or the default animation.
@@ -596,22 +542,6 @@ func get_character_node(character: DialogicCharacter) -> Node:
 		if is_instance_valid(character_nodes[character.get_identifier()]):
 			return character_nodes[character.get_identifier()]
 	return null
-
-
-## Removes the given characters portrait.
-## Only works with joined characters.
-func remove_character(character: DialogicCharacter) -> void:
-	var character_node := get_character_node(character)
-
-	if is_instance_valid(character_node) and character_node is Node:
-		var container := character_node.get_parent()
-		container.get_parent().remove_child(container)
-		container.queue_free()
-		character_node.queue_free()
-		character_left.emit({'character': character})
-
-	portraits.erase(character.get_identifier())
-	character_nodes.erase(character.get_identifier())
 
 
 ## Returns true if the given character is currently joined.
@@ -718,8 +648,6 @@ func change_speaker(speaker: DialogicCharacter = null, portrait := "") -> void:
 
 			if join_animation and join_animation_length:
 				await _animate_node(character_node, join_animation, join_animation_length).finished
-
-		_change_portrait_mirror(character_node)
 
 	var prev_speaker: DialogicCharacter = dialogic.Text.get_current_speaker()
 	if speaker != prev_speaker:

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -245,7 +245,7 @@ func _animate_node(node: Node, animation_path: String, length: float, repeats :=
 ## Moves the given portrait to the given container.
 func _move_character(character_node: Node2D, transform:="", time := 0.0, easing:= Tween.EASE_IN_OUT, trans:= Tween.TRANS_SINE) -> void:
 	var container: DialogicNode_PortraitContainer = character_node.get_parent()
-	dialogic.PortraitContainers.update_container(container, transform, time, easing, trans)
+	dialogic.PortraitContainers.update_container(container, transform, time, easing, trans)#, false)
 
 
 ## Changes the given characters z_index.

--- a/addons/dialogic/Modules/Clear/event_clear.gd
+++ b/addons/dialogic/Modules/Clear/event_clear.gd
@@ -60,8 +60,8 @@ func _execute() -> void:
 		else:
 			dialogic.Styles.change_style()
 
-	if clear_portrait_positions and dialogic.has_subsystem("Portraits"):
-		dialogic.PortraitContainers.reset_all_containers()
+	#if clear_portrait_positions and dialogic.has_subsystem("Portraits"):
+		#dialogic.PortraitContainers.reset_all_containers()
 
 	if not step_by_step:
 		await dialogic.get_tree().create_timer(final_time).timeout

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/textbox_with_speaker_portrait.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/textbox_with_speaker_portrait.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=3 uid="uid://by6waso0mjpjp"]
+[gd_scene format=3 uid="uid://by6waso0mjpjp"]
 
 [ext_resource type="Script" uid="uid://d0ptqnbudhkyj" path="res://addons/dialogic/Modules/Character/node_portrait_container.gd" id="1_4jxq7"]
 [ext_resource type="Script" uid="uid://bk84r61kckpxa" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/speaker_portrait_textbox_layer.gd" id="1_7jt4d"]
 [ext_resource type="Script" uid="uid://bak74s0kcr0ao" path="res://addons/dialogic/Modules/Text/node_name_label.gd" id="2_y0h34"]
 [ext_resource type="Script" uid="uid://drhfq6rmdeuri" path="res://addons/dialogic/Modules/Text/node_dialog_text.gd" id="3_11puy"]
+[ext_resource type="Script" uid="uid://diexbgvrksk2k" path="res://addons/dialogic/Resources/flex_vector.gd" id="3_hywg0"]
 [ext_resource type="Script" uid="uid://dpv2dfiv5dhmr" path="res://addons/dialogic/Modules/Text/node_type_sound.gd" id="5_sr2qw"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dmg1w"]
@@ -14,7 +15,22 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[node name="TextboxWithSpeakerPortrait" type="Control"]
+[sub_resource type="Resource" id="Resource_liigb"]
+script = ExtResource("3_hywg0")
+x_value = 1.0
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_5guxu"]
+script = ExtResource("3_hywg0")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_nwps4"]
+script = ExtResource("3_hywg0")
+x_value = 0.5
+y_value = 1.0
+
+[node name="TextboxWithSpeakerPortrait" type="Control" unique_id=1114094937]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -25,7 +41,7 @@ mouse_filter = 2
 script = ExtResource("1_7jt4d")
 box_panel = "res://addons/dialogic/Modules/DefaultLayoutParts/Layer_SpeakerPortraitTextbox/default_stylebox.tres"
 
-[node name="Anchor" type="Control" parent="."]
+[node name="Anchor" type="Control" parent="." unique_id=734727101]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
@@ -36,7 +52,7 @@ grow_horizontal = 2
 grow_vertical = 0
 mouse_filter = 2
 
-[node name="Panel" type="PanelContainer" parent="Anchor"]
+[node name="Panel" type="PanelContainer" parent="Anchor" unique_id=1800887369]
 unique_name_in_owner = true
 self_modulate = Color(0.533333, 0.376471, 0.176471, 1)
 layout_mode = 1
@@ -53,21 +69,20 @@ grow_horizontal = 2
 grow_vertical = 0
 mouse_filter = 2
 
-[node name="HBox" type="HBoxContainer" parent="Anchor/Panel"]
+[node name="HBox" type="HBoxContainer" parent="Anchor/Panel" unique_id=2044797712]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 15
 
-[node name="PortraitPanel" type="Panel" parent="Anchor/Panel/HBox"]
+[node name="PortraitPanel" type="Panel" parent="Anchor/Panel/HBox" unique_id=1942071493]
 unique_name_in_owner = true
-clip_children = 1
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.3
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_dmg1w")
 
-[node name="PortraitBackgroundColor" type="ColorRect" parent="Anchor/Panel/HBox/PortraitPanel"]
+[node name="PortraitBackgroundColor" type="ColorRect" parent="Anchor/Panel/HBox/PortraitPanel" unique_id=1525845813]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -82,33 +97,32 @@ grow_vertical = 2
 mouse_filter = 2
 color = Color(0, 0, 0, 0.231373)
 
-[node name="DialogicNode_PortraitContainer" type="Control" parent="Anchor/Panel/HBox/PortraitPanel/PortraitBackgroundColor"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = 4.0
-grow_horizontal = 2
-grow_vertical = 2
+[node name="DialogicNode_PortraitContainer" type="Control" parent="Anchor/Panel/HBox/PortraitPanel/PortraitBackgroundColor" unique_id=26229883]
+anchors_preset = 0
+offset_right = 125.0
+offset_bottom = 156.0
 mouse_filter = 2
 script = ExtResource("1_4jxq7")
 mode = 1
 container_ids = PackedStringArray("1")
+container_size = SubResource("Resource_liigb")
+container_position = SubResource("Resource_5guxu")
+container_origin = SubResource("Resource_nwps4")
 debug_character_portrait = "speaker"
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Anchor/Panel/HBox"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Anchor/Panel/HBox" unique_id=282274382]
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="DialogicNode_NameLabel" type="Label" parent="Anchor/Panel/HBox/VBoxContainer"]
+[node name="DialogicNode_NameLabel" type="Label" parent="Anchor/Panel/HBox/VBoxContainer" unique_id=476676289]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_font_sizes/font_size = 8
 text = "Name"
 script = ExtResource("2_y0h34")
 
-[node name="DialogicNode_DialogText" type="RichTextLabel" parent="Anchor/Panel/HBox/VBoxContainer" node_paths=PackedStringArray("textbox_root")]
+[node name="DialogicNode_DialogText" type="RichTextLabel" parent="Anchor/Panel/HBox/VBoxContainer" unique_id=1350930746 node_paths=PackedStringArray("textbox_root")]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
@@ -120,5 +134,5 @@ visible_characters_behavior = 1
 script = ExtResource("3_11puy")
 textbox_root = NodePath("../../..")
 
-[node name="DialogicNode_TypeSounds" type="AudioStreamPlayer" parent="Anchor/Panel/HBox/VBoxContainer/DialogicNode_DialogText"]
+[node name="DialogicNode_TypeSounds" type="AudioStreamPlayer" parent="Anchor/Panel/HBox/VBoxContainer/DialogicNode_DialogText" unique_id=1944491081]
 script = ExtResource("5_sr2qw")

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/vn_portrait_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/vn_portrait_layer.gd
@@ -11,4 +11,3 @@ func _apply_export_overrides() -> void:
 	# apply portrait size
 	for child: DialogicNode_PortraitContainer in %Portraits.get_children():
 		child.size_mode = portrait_size_mode
-		child.update_portrait_transforms()

--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/vn_portrait_layer.tscn
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/vn_portrait_layer.tscn
@@ -1,9 +1,85 @@
-[gd_scene load_steps=3 format=3 uid="uid://cy1y14inwkplb"]
+[gd_scene format=3 uid="uid://cy1y14inwkplb"]
 
 [ext_resource type="Script" uid="uid://cx1i44s2olq2d" path="res://addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Portraits/vn_portrait_layer.gd" id="1_1i7em"]
 [ext_resource type="Script" uid="uid://d0ptqnbudhkyj" path="res://addons/dialogic/Modules/Character/node_portrait_container.gd" id="1_rxdcc"]
+[ext_resource type="Script" uid="uid://diexbgvrksk2k" path="res://addons/dialogic/Resources/flex_vector.gd" id="3_j0v32"]
 
-[node name="VN_PortraitLayer" type="Control"]
+[sub_resource type="Resource" id="Resource_nf3k4"]
+script = ExtResource("3_j0v32")
+x_value = 0.2
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_j0v32"]
+script = ExtResource("3_j0v32")
+x_value = 0.1
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_kwhsf"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_np73d"]
+script = ExtResource("3_j0v32")
+x_value = 0.19999999
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_pw8le"]
+script = ExtResource("3_j0v32")
+x_value = 0.3
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_u26y7"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_46qkt"]
+script = ExtResource("3_j0v32")
+x_value = 0.19999999
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_vcdlt"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_vnd0q"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_w5lxs"]
+script = ExtResource("3_j0v32")
+x_value = 0.19999999
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_2ixhv"]
+script = ExtResource("3_j0v32")
+x_value = 0.7
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_ssa17"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_y7160"]
+script = ExtResource("3_j0v32")
+x_value = 0.19999999
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_owffp"]
+script = ExtResource("3_j0v32")
+x_value = 0.9
+y_value = 1.0
+
+[sub_resource type="Resource" id="Resource_wacbv"]
+script = ExtResource("3_j0v32")
+x_value = 0.5
+y_value = 1.0
+
+[node name="VN_PortraitLayer" type="Control" unique_id=770308938]
 layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
@@ -13,7 +89,7 @@ grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_1i7em")
 
-[node name="Portraits" type="Control" parent="."]
+[node name="Portraits" type="Control" parent="." unique_id=1118283014]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -23,62 +99,80 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="DialogicNode_PortraitContainer1" type="Control" parent="Portraits"]
+[node name="leftmost" type="Control" parent="Portraits" unique_id=1680326072]
 layout_mode = 1
-anchor_right = 0.2
-anchor_bottom = 1.0
-offset_right = -1.52588e-05
-grow_vertical = 2
+anchors_preset = 0
+offset_right = 230.4
+offset_bottom = 648.0
+size = Vector2(230.4, 648)
 pivot_offset = Vector2(115.2, 648)
 mouse_filter = 2
 script = ExtResource("1_rxdcc")
 container_ids = PackedStringArray("leftmost", "0")
-metadata/_edit_use_anchors_ = true
+container_size = SubResource("Resource_nf3k4")
+container_position = SubResource("Resource_j0v32")
+container_origin = SubResource("Resource_kwhsf")
 
-[node name="DialogicNode_PortraitContainer2" type="Control" parent="Portraits"]
+[node name="left" type="Control" parent="Portraits" unique_id=2147382048]
 layout_mode = 1
-anchor_left = 0.2
-anchor_right = 0.4
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_left = 230.40001
+offset_right = 460.8
+offset_bottom = 648.0
+size = Vector2(230.39998, 648)
+position = Vector2(230.40001, 0)
 mouse_filter = 2
 script = ExtResource("1_rxdcc")
 container_ids = PackedStringArray("left", "1")
+container_size = SubResource("Resource_np73d")
+container_position = SubResource("Resource_pw8le")
+container_origin = SubResource("Resource_u26y7")
 metadata/_edit_use_anchors_ = true
 
-[node name="DialogicNode_PortraitContainer3" type="Control" parent="Portraits"]
+[node name="center" type="Control" parent="Portraits" unique_id=452412182]
 layout_mode = 1
-anchor_left = 0.4
-anchor_right = 0.6
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_left = 460.8
+offset_right = 691.19995
+offset_bottom = 648.0
+size = Vector2(230.39996, 648)
+position = Vector2(460.8, 0)
 mouse_filter = 2
 script = ExtResource("1_rxdcc")
 container_ids = PackedStringArray("center", "middle", "2")
+container_size = SubResource("Resource_46qkt")
+container_position = SubResource("Resource_vcdlt")
+container_origin = SubResource("Resource_vnd0q")
 metadata/_edit_use_anchors_ = true
 
-[node name="DialogicNode_PortraitContainer4" type="Control" parent="Portraits"]
+[node name="right" type="Control" parent="Portraits" unique_id=1797107823]
 layout_mode = 1
-anchor_left = 0.6
-anchor_right = 0.8
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_left = 691.2
+offset_right = 921.6
+offset_bottom = 648.0
+size = Vector2(230.39996, 648)
+position = Vector2(691.2, 0)
 mouse_filter = 2
 script = ExtResource("1_rxdcc")
 container_ids = PackedStringArray("right", "3")
+container_size = SubResource("Resource_w5lxs")
+container_position = SubResource("Resource_2ixhv")
+container_origin = SubResource("Resource_ssa17")
 metadata/_edit_use_anchors_ = true
 
-[node name="DialogicNode_PortraitContainer5" type="Control" parent="Portraits"]
+[node name="rightmost" type="Control" parent="Portraits" unique_id=1200320127]
 layout_mode = 1
-anchor_left = 0.8
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_left = 921.60004
+offset_right = 1152.0
+offset_bottom = 648.0
+size = Vector2(230.39996, 648)
+position = Vector2(921.60004, 0)
 mouse_filter = 2
 script = ExtResource("1_rxdcc")
 container_ids = PackedStringArray("rightmost", "4")
+container_size = SubResource("Resource_y7160")
+container_position = SubResource("Resource_owffp")
+container_origin = SubResource("Resource_wacbv")
 metadata/_edit_use_anchors_ = true

--- a/addons/dialogic/Resources/flex_vector.gd
+++ b/addons/dialogic/Resources/flex_vector.gd
@@ -1,0 +1,154 @@
+@tool
+class_name DialogicFlexVector
+extends Resource
+## Represents a position or size in either absolute pixels or relative to a given parent size.[br][br]
+## Allows mixing sizes, e.g. x could be absolute and y be relative.
+## Make sure that whenever you are editing this value or retrieving it via [method as_pixels]
+## or [method as_percent] the [member container_size] is up to date.
+## Percentage is a float between 0.0 and 1.0, with 1.0 being 100% of the container_size dimension.
+## Mainly used by PortraitContainer.
+
+## The FlexVectors x_value.
+@export var x_value := 0.0:
+	set(x):
+		x_value = x
+		emit_changed()
+
+## The FlexVectors y_value.
+@export var y_value := 0.0:
+	set(y):
+		y_value = y
+		emit_changed()
+
+## If true, the [param x_value] is in percent (ranging from 0 to 1 as a multiplier of the parents x dimension).
+@export var x_percent := true
+## If true, the [param y_value] is in percent (ranging from 0 to 1 as a multiplier of the parents y dimension).
+@export var y_percent := true
+
+var container_size := Vector2()
+
+
+## Returns the value in pixels. Make sure container_size is up to date.
+func as_pixels() -> Vector2:
+	return Vector2(
+		x_value if not x_percent else x_value * container_size.x,
+		y_value if not y_percent else y_value * container_size.y
+		)
+
+
+## Returns the value in percent. Make sure container_size is up to date.
+func as_percent() -> Vector2:
+	return Vector2(
+		0 if container_size.x == 0 else x_value / container_size.x if not x_percent else x_value,
+		0 if container_size.y == 0 else y_value / container_size.y if not y_percent else y_value
+		)
+
+
+## Adds the given vector, while keeping the current x_percent and y_percent states and converting the incoming values if necessary.
+func add(flex_vector:DialogicFlexVector) -> void:
+	if x_percent == flex_vector.x_percent:
+		x_value += flex_vector.x_value
+	else:
+		if x_percent:
+			x_value += flex_vector.as_percent().x
+		else:
+			x_value += flex_vector.as_pixels().x
+
+	if y_percent == flex_vector.y_percent:
+		y_value += flex_vector.y_value
+	else:
+		if y_percent:
+			y_value += flex_vector.as_percent().y
+		else:
+			y_value += flex_vector.as_pixels().y
+
+
+## Creates a new FlexVector from the given string. See [method overwrite_from_string]
+static func from_string(input: String) -> DialogicFlexVector:
+	var vec := DialogicFlexVector.new()
+	vec.overwrite_from_string(input)
+	return vec
+
+
+## Extracts information from an input string and applies it to this FlexVector.
+## The string can be of format "x10 y20" or "x10px y0.2%".
+## Just a single dimension can be supplied, leaving the other where it's at.
+## If type isn't specified, percentag is assumed.
+func overwrite_from_string(input:String) -> void:
+	var vector_regex := RegEx.create_from_string(r"(?<part>x|y)\s*(?<number>(-|\+)?(\d|\.|)*)(\s*(?<type>%|px))?")
+	for i in vector_regex.search_all(input):
+		var value := float(i.get_string(&'number'))
+		match i.get_string(&'part').to_lower().strip_edges():
+			"x":
+				x_value = value
+				match i.get_string(&'type'):
+					"px":
+						x_percent = false
+					"%", _:
+						x_percent = true
+			"y":
+				y_value = value
+				match i.get_string(&'type'):
+					"px":
+						y_percent = false
+					"%", _:
+						y_percent = true
+
+
+
+## Creates a new FlexVector with the given parent_size and values from the [param vector] assumed to be in pixels.
+static func from_vector(vector:Vector2, parent_size:=Vector2()) -> DialogicFlexVector:
+	var vec := DialogicFlexVector.new()
+	vec.container_size = parent_size
+	vec.x_value = vector.x
+	vec.x_percent = false
+	vec.y_value = vector.y
+	vec.y_percent = false
+	return vec
+
+
+## Replaces the given values with the values from the [param vector] assumed to be in pixels, but keeping x_percent and y_percent state and converting if necessary.
+func overwrite_from_vector(vector:Vector2) -> void:
+	zero()
+	add(from_vector(vector, container_size))
+
+
+
+func copy() -> DialogicFlexVector:
+	var vec := DialogicFlexVector.new()
+	vec.x_value = x_value
+	vec.y_value = y_value
+	vec.x_percent = x_percent
+	vec.y_percent = y_percent
+	vec.container_size = container_size
+	return vec
+
+
+## Sets both values to 0.
+func zero() -> void:
+	x_value = 0
+	y_value = 0
+
+
+## Converts a string representation of the FlexVector.
+func _to_string() -> String:
+	return "x" + str(self.x_value) + ["px", "%"][int(self.x_percent)] + " y" + str(self.y_value) + ["px", "%"][int(self.y_percent)] + " "+str(get_instance_id())
+
+
+## Applies x_percent and y_percent from the given [param flex_vec] to this one and converts the values.
+## Make sure container_size is up to date before.
+func make_similar(flex_vec: DialogicFlexVector) -> void:
+	if flex_vec.x_percent != x_percent:
+		if flex_vec.x_percent:
+			x_value = as_percent().x
+			x_percent = true
+		else:
+			x_value = as_pixels().x
+			x_percent = false
+	if flex_vec.y_percent != y_percent:
+		if flex_vec.y_percent:
+			y_value = as_percent().y
+			y_percent = true
+		else:
+			y_value = as_pixels().y
+			y_percent = false

--- a/addons/dialogic/Resources/flex_vector.gd.uid
+++ b/addons/dialogic/Resources/flex_vector.gd.uid
@@ -1,0 +1,1 @@
+uid://diexbgvrksk2k


### PR DESCRIPTION
This is a relatively big refactor of how portrait containers behave.

The main goal was to have a more robust system of moving characters between containers (inspired by #2760 which this supersedes by fixing the same and similar issues).

This new system has moved a lot of the logic to the PortraitContainer node that was previously on the Portrait or PortraitContainer subsystem. Because at runtime positions can be represented as pixels or percentages, the PortraitContainers now can do so already in the editor. They use a new DialogicFlexVector to do so, which allows setting these values. The default 5 Position layer already does this now. Custom layouts might suffer from this and might have to reposition/scale their PortraitContainers, if we get reports about this maybe the conversion can be improved (it works mostly, and layouts will suffer much more later from the style PR anyways, so idk). Importantly PortraitContainers should no longer use Godots very confusing Anchor system, as they do very similar calculations themselves now if necessary.

The PortraitContainers have a new ContainerSettings resource which is useful to store temporary or target states. This in combination with its new update_container() method allows to smoothly transition between wildly different containers unlike what would happen before. This is not a common use-case, but means this system is both more powerful, predictable and reliable. The new ContainerSettings resource can be converted to/from string (an extended syntax of the previous "pos=x0.2y1 siz=x0.2y0.4 ...". This is now used to store containers state via save/loads. It also has the side-effect that you *could* now change things like z_index, mirror, size_mode or origin from the Character event like this: `update Lilly z=2 mode=3 mirror=true` For now I will keep these unsuggested and the old ways for mirror and z-index intact (though I still consider renaming z-index). 

A bit of a deep-dive into containers:
Portrait Containers are used in 3 Modes, these are now also differentiated more properly by the PortraitContainer.mode variable (now either POSITION, SPEAKER or _CHARACTER). 
- POSITION defines a preset transform and associates it with one or multiple names. This is how leftmost, left, center, right and rightmost are defined. These containers never actually contain a character (besides the debug preview character in the editor).
- SPEAKER defines a container that will always show the current speaker (if they have portraits). Those WILL be directly inside that container.
- _CHARACTER containers will be added and populated at runtime when a character is joined. They contain the actual portraits and one Character each and will be moved around until that character leaves.

Mirror and Z-Index are now handled directly by the container instead of the portrait subsystem. This means you can now specify an initial z-index and mirror on the container directly (however to work more intuitive, mirror and z-index are NOT overwritten when moving to a position, only on join, not on update).

The new system now also allows specifying portrait containers under multiple parents, it will correctly re-parent a portrait if it moves to a container under a different parent and this will also be correctly loaded and saved. This is GREAT because it will allow setups with portraits both BELOW and ABOVE the textbox and you can freely move your characters between those. The movement might look a bit strange (they are re-parented at the beginning of the move) but this can be designed around if it looks wrong.

This PR breaks compatibility in multiple ways. It removes a few features:
- origin_anchor (now just container_origin), origin_offset, pivot_mode and pivot_value. I could not see much use for these and so I removed them. We could introduce pivot again (mainly to specifiy where to rotate around - currently always the origin), but we should use containers own pivot value for that if possible, which can now also be specified in percent.
- old containers might not correctly update their position/size (in my tests they did, but who knows)
- old saves are once again invalidated if they contain portraits

I have tested this pretty extensively, but problems might still occur. I have also added an extensive timeline to the TestProject's "Fake Unit Test" section that tests all kinds of portrait things and should help catch issues. I would like to keep adding problem-cases whenever new bugs appear.