### PR TITLE
Fix: translation id makes a shortcode event swallow the following lines

### DIFF
--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -430,8 +430,12 @@ func is_valid_event(string: String) -> bool:
 ## has to return true if this string seems to be a full event of this kind
 ## (only tested if is_valid_event() returned true)
 ## if a shortcode it used it will default to true if the string ends with ']'
+## a translation id is stored after the ']', so it is removed before that test
 func is_string_full_event(string: String) -> bool:
-	if get_shortcode() != 'default_shortcode': return string.strip_edges().ends_with(']')
+	if get_shortcode() != 'default_shortcode':
+		if '#id:' in string and can_be_translated():
+			return string.get_slice('#id:', 0).strip_edges().ends_with(']')
+		return string.strip_edges().ends_with(']')
 	return true
 
 


### PR DESCRIPTION
### The problem

With translation enabled, any bracketed event that carries a translation id
silently absorbs the lines after it. Those lines never become events — they
just disappear at runtime, with no error and nothing visibly wrong in the
timeline text.

### Reproduction

With `translation/enabled` on, a timeline saved as:

    [text_input text="What is your name?" var="name"] #id:1
    Some Character: First line.
    Some Character: Second line.

parses to a single `text_input` event. Both text lines are gone.

If a later line does end with `]`, the swallowing stops there — and that
event is consumed as well, so a bracketed event following the affected one
is lost along with the lines between them.

### Cause

`DialogicEvent.is_string_full_event()` treats a shortcode event as complete
only when the string ends with `']'`:

```gdscript
if get_shortcode() != 'default_shortcode': return string.strip_edges().ends_with(']')
```

but `_store_as_string()` appends the translation id *after* the closing
bracket:

```gdscript
return to_text() + ' #id:'+str(_translation_id)
```

So the event never reads as complete, and the collect loop in
`DialogicTimeline.process()` —
`while not event.is_string_full_event(event_content)` — keeps appending
following lines into it until one ends with `']'`.

Text events are unaffected, because they return `true` unconditionally. That
is why this only shows up once translation is enabled and ids begin to be
written onto bracketed events.

### The fix

`is_string_full_event()` now strips a trailing `#id:` before testing for the
bracket, the same way `_load_from_string()` and `_test_event_string()`
already do for the same suffix.

The strip is gated on `can_be_translated()`, matching `_store_as_string()` —
an id is only ever written under that condition, so no event that carries one
can be missed, and no event that lacks one changes behaviour.
