### PR TITLE
Fix crash on save load when a character has no portrait node

### DIFF
--- a/Tests/Unit/subsystem_portraits_test.gd
+++ b/Tests/Unit/subsystem_portraits_test.gd
@@ -1,0 +1,104 @@
+extends GdUnitTestSuite
+## Regression tests for dialogic-godot/dialogic#2801:
+## Dialogic.Save.load() crashes when a joined character has no portrait node
+## (e.g. after a scene change), because the portraits subsystem can hold a
+## joined-character entry whose portrait node is gone or was never created.
+
+
+var portraits
+
+
+func before_test() -> void:
+	DialogicResourceUtil.update()
+	portraits = Dialogic.Portraits
+	if portraits == null:
+		push_error("test setup failed: Dialogic.Portraits subsystem not available")
+		return
+	# Start from a clean subsystem state.
+	portraits.portraits.clear()
+	portraits.character_nodes.clear()
+
+
+func after_test() -> void:
+	# Free any nodes the tests created.
+	for node in portraits.character_nodes.values():
+		if is_instance_valid(node):
+			node.free()
+	portraits.portraits.clear()
+	portraits.character_nodes.clear()
+
+
+func _test_character() -> DialogicCharacter:
+	var character: DialogicCharacter = load("res://Tests/Resources/unit_test_character.dch")
+	character.display_name = "unit_test_character"
+	return character
+
+
+## A character whose portraits entry has no live node is not joined,
+## so consumers (get_character_node, highlighting, etc.) get null instead of
+## a "Invalid access to property or key" error.
+func test_is_character_joined_without_node() -> void:
+	var character := _test_character()
+
+	portraits.portraits[character.get_identifier()] = {'portrait': "", 'position_id': "center"}
+
+	assert_bool(portraits.is_character_joined(character)).is_false()
+	assert_object(portraits.get_character_node(character)).is_null()
+
+
+## Leaving a character that lost its node cleans the leftover entry instead
+## of crashing.
+func test_leave_character_without_node() -> void:
+	var character := _test_character()
+
+	portraits.portraits[character.get_identifier()] = {'portrait': "", 'position_id': "center"}
+
+	portraits.leave_character(character)
+
+	assert_that(portraits.portraits.has(character.get_identifier())).is_false()
+	assert_that(portraits.character_nodes.has(character.get_identifier())).is_false()
+
+
+## A freed portrait node must not count as joined either.
+func test_is_character_joined_freed_node() -> void:
+	var character := _test_character()
+
+	var node := Node.new()
+	portraits.portraits[character.get_identifier()] = {'portrait': "", 'position_id': "center"}
+	portraits.character_nodes[character.get_identifier()] = node
+	assert_bool(portraits.is_character_joined(character)).is_true()
+
+	node.free()
+	assert_bool(portraits.is_character_joined(character)).is_false()
+	assert_object(portraits.get_character_node(character)).is_null()
+
+
+## Loading state when the character cannot re-join (its position container is
+## not available) must not crash on the missing character_nodes entry.
+func test_load_state_missing_position_container() -> void:
+	var character := _test_character()
+
+	# Simulate a save with one joined character and no containers in the tree:
+	# unpack_state has restored the portraits entry, but add_character fails,
+	# because load_position_container returns null.
+	portraits.portraits = {character.get_identifier(): {'portrait': "", 'position_id': "center"}}
+
+	await portraits._load_state()
+
+	assert_bool(portraits.is_character_joined(character)).is_false()
+
+
+## Clearing the subsystem while a portrait node was already freed
+## (e.g. by a scene change) must not error on the freed node.
+func test_clear_state_freed_node() -> void:
+	var character := _test_character()
+
+	var node := Node.new()
+	portraits.portraits[character.get_identifier()] = {'portrait': "", 'position_id': "center"}
+	portraits.character_nodes[character.get_identifier()] = node
+	node.free()
+
+	portraits._clear_state()
+
+	assert_that(portraits.portraits.is_empty()).is_true()
+	assert_that(portraits.character_nodes.is_empty()).is_true()

--- a/Tests/Unit/subsystem_portraits_test.gd.uid
+++ b/Tests/Unit/subsystem_portraits_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b5qovr34swrn

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -24,7 +24,9 @@ var default_portrait_scene: PackedScene = load(get_script().resource_path.get_ba
 
 func _clear_state(_clear_flag := DialogicGameHandler.ClearFlags.FULL_CLEAR) -> void:
 	for character_node in character_nodes.values():
-		_remove_character(character_node)
+		# The node can already be freed (e.g. the scene was changed).
+		if is_instance_valid(character_node):
+			_remove_character(character_node)
 	portraits.clear()
 	character_nodes.clear()
 
@@ -39,8 +41,10 @@ func _load_state(_load_flag := LoadFlags.FULL_LOAD) -> void:
 		var character: DialogicCharacter = DialogicResourceUtil.get_character_resource(character_identifier)
 		if character:
 			var container := dialogic.PortraitContainers.load_position_container(character.get_character_name())
-			await add_character(character, container, character_info.portrait, character_info.position_id)
-			character_nodes[character.get_identifier()].get_child(-1)._load_state(portrait_states.get(character.get_identifier(), {}))
+			var character_node := await add_character(character, container, character_info.portrait, character_info.position_id)
+			# The character can fail to re-join (e.g. it's position container is not available).
+			if character_node and character_node.get_child_count() > 0:
+				character_node.get_child(-1)._load_state(portrait_states.get(character.get_identifier(), {}))
 		else:
 			push_error('[Dialogic] Failed to load character "' + str(character_identifier) + '".')
 
@@ -499,6 +503,10 @@ func move_character(character:DialogicCharacter, position_id:String, time:= 0.0,
 ## Removes a character with a given animation or the default animation.
 func leave_character(character: DialogicCharacter, animation_name:= "", animation_length:= 0.0, animation_wait := false) -> void:
 	if not is_character_joined(character):
+		if character:
+			# Clean up an entry that lost it's node (e.g. after a scene change).
+			character_nodes.erase(character.get_identifier())
+			portraits.erase(character.get_identifier())
 		return
 
 	var character_node := get_character_node(character)
@@ -539,17 +547,20 @@ func leave_all_characters(animation_name:="", animation_length:=0.0, animation_w
 ## Return `null` if the [param character] is not part of the scene.
 func get_character_node(character: DialogicCharacter) -> Node:
 	if is_character_joined(character):
-		if is_instance_valid(character_nodes[character.get_identifier()]):
-			return character_nodes[character.get_identifier()]
+		return character_nodes[character.get_identifier()]
 	return null
 
 
 ## Returns true if the given character is currently joined.
+## A character is only joined while it also has a valid portrait node:
+## entries left without one (e.g. after a scene change) are not joined.
 func is_character_joined(character: DialogicCharacter) -> bool:
-	if character == null or not character.get_identifier() in portraits:
+	if character == null:
 		return false
-
-	return true
+	var id := character.get_identifier()
+	if not id in portraits:
+		return false
+	return character_nodes.has(id) and is_instance_valid(character_nodes[id])
 
 
 ## Returns a list of the joined charcters (as resources)


### PR DESCRIPTION
Fixes #2801

Loading a save right after a scene change (or over a previously used slot) could crash with:

```
Invalid access to property or key 'test_cleo' on a base object of type 'Dictionary[String, Node]'
```

As the issue suspects, joined characters are tracked in two places: `portraits` (exported, so it is packed into saves and restored by `unpack_state`) and `character_nodes` (runtime only, rebuilt in `_load_state`). Those two can get out of sync:

- after a scene change the portrait nodes are gone, but the restored `portraits` entries say the character is joined, so `is_character_joined()` passes and every `character_nodes[...]` access afterwards hits a missing/freed key (this is the exact line from the issue report)
- in `_load_state`, `add_character()` can fail (e.g. the position container is not available after a scene change) and returns null, but the node was still accessed unconditionally
- `_clear_state` passed nodes that the scene change already freed into `_remove_character()`

What i changed, all in `subsystem_portraits.gd`:

- `is_character_joined()` now only reports a character as joined while it also has a valid entry in `character_nodes`. This is the single predicate most consumers already check (get_character_node, leave_character, highlighting, change/update methods), so stale entries now fail safely everywhere instead of just moving the crash one call further (a null node would previously reach `_animate_node` and crash there)
- `leave_character()` cleans up an entry that lost its node instead of leaving it behind
- `_load_state()` skips the portrait state restore when re-joining the character failed
- `_clear_state()` skips nodes that were already freed

Verification (headless Godot 4.5.1 + gdUnit4):

- on current main the new test suite fails with the exact reported error (`Invalid access to property or key ... Dictionary[String, Node]` in `get_character_node`) plus the follow-up null crash in `_animate_node`, and the runner aborts
- with this patch `Tests/Unit/subsystem_portraits_test.gd` passes (5 tests covering missing key, freed node, leave cleanup, failed re-join on load, clear with freed nodes), full existing `Tests/Unit` suite stays green (21 tests, 0 failures)