### PR TITLE
Fix infinite loop when an event block has a Vector field with conditional visibility

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/field_vector_base.gd
+++ b/addons/dialogic/Editor/Events/Fields/field_vector_base.gd
@@ -28,7 +28,6 @@ func _load_display_info(info: Dictionary) -> void:
 
 func _set_value(value: Variant) -> void:
 	_update_sub_component_text(value)
-	_on_value_changed(value)
 
 
 func _on_value_changed(value: Variant) -> void:


### PR DESCRIPTION
## Issue:
When creating a custom Dialogic event, if the event block has a parameter that is a Vector2, Vector3 or Vector4, and that parameter has a visibility condition, Godot will print 1049 errors to the console whenever that visibility condition becomes true.

It seems like the editor is getting caught in an infinite loop when calculating the parameter visibility for the timeline UI. The output prints this five times: 
```  ERROR: res://addons/dialogic/Editor/TimelineEditor/timeline_editor.gd:19 - Stack overflow. Check for infinite recursion in your script.
  ERROR: res://addons/dialogic/Editor/Events/EventBlock/event_block.gd:395 - Stack overflow. Check for infinite recursion in your script.
  ERROR: res://addons/dialogic/Editor/Events/EventBlock/event_block.gd:395 - Stack overflow. Check for infinite recursion in your script.
  ERROR: res://addons/dialogic/Editor/Events/EventBlock/event_block.gd:395 - Stack overflow. Check for infinite recursion in your script.
  ERROR: res://addons/dialogic/Editor/Events/EventBlock/event_block.gd:395 - Stack overflow. Check for infinite recursion in your script.
```
followed by this 1024 times: ```ERROR: modules/gdscript/gdscript.h:529 - Stack underflow! (Engine Bug)```

## Screenshots
<details>
<summary>Expand</summary>
<img width="2033" height="1726" alt="image" src="https://github.com/user-attachments/assets/3f857467-5cdf-4951-bc32-74db69488fcb" />
<img width="1744" height="475" alt="image" src="https://github.com/user-attachments/assets/9fdde629-6a3c-4128-b7b3-6e825ca3de58" />
<img width="2675" height="845" alt="image" src="https://github.com/user-attachments/assets/f74adaae-676b-4b99-97a2-e21fa20825db" />
</details>

## The Fix:
- Removed `_on_value_changed` signal from `_set_value` in `field_vector_base.gd`

Credit to @bazsupport for finding this fix.

I believe that when `event_block.gd` is looping in `recalculate_field_visibility`, it calls `_set_value` on the vector fields, which emits an `_on_value_changed` signal, which causes the UI to start updating again, bringing it back into the same loop.

The other `field_` scripts do not emit an `_on_value_changed` signal from `_set_value`, and in my testing, removing this line does not affect the Vector fields' ability to set and propagate their values.