### PR TITLE
Fix: text input caret sits before the default value

### DIFF
--- a/addons/dialogic/Modules/TextInput/node_text_input.gd
+++ b/addons/dialogic/Modules/TextInput/node_text_input.gd
@@ -39,6 +39,9 @@ func set_placeholder(placeholder:String) -> void:
 func set_default(default:String) -> void:
 	if get_node(input_line_edit) is LineEdit:
 		get_node(input_line_edit).text = default
+		# Assigning `text` resets the caret to column 0. Put it after the default
+		# so a prefilled field can be typed into or backspaced straight away.
+		get_node(input_line_edit).caret_column = default.length()
 		_on_input_text_changed(default)
 
 


### PR DESCRIPTION
### Problem

When a `text_input` event supplies a `default`, the caret lands at column 0 — to the left of the prefilled text. Typing prepends, and holding backspace deletes nothing, until the player moves to the end of the field themselves. A prefilled field should be ready to append to or clear.

### Cause

`DialogicNode_TextInput.set_default()` assigns `LineEdit.text`, which resets `caret_column` to 0, and nothing sets it afterwards.

### Fix

Move the caret to the end of the default after assigning the text.

`Subsystem_TextInput.show_text_input()` calls `set_text` → `set_default` → `set_placeholder`, and `set_placeholder` is what calls `grab_focus()`. Since `select_all_on_focus` is off by default and focus does not otherwise move the caret, setting `caret_column` inside `set_default` survives the later focus. An empty default is unchanged — the caret stays at 0.

### Testing

Tested in a project using `[text_input ... default="..."]` with both an empty and a prefilled default. There are no existing tests around `DialogicNode_TextInput` (the unit suite covers resources and subsystems rather than layout nodes), so none were added — happy to add one if you'd like the node covered.