### PR TITLE
Fix inherited style overrides and VN name label alignment

### DIFF
--- a/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.gd
+++ b/addons/dialogic/Modules/DefaultLayoutParts/Layer_VN_Textbox/vn_textbox_layer.gd
@@ -203,13 +203,21 @@ func _apply_name_label_settings() -> void:
 	else:
 		name_label_panel.self_modulate = name_label_box_modulate
 	var dialog_text_panel: PanelContainer = %DialogTextPanel
-	name_label_panel.position = name_label_box_offset+Vector2(0, -40)
-	name_label_panel.position -= Vector2(
+	var label_offset := name_label_box_offset+Vector2(0, -40)
+	label_offset -= Vector2(
 		dialog_text_panel.get_theme_stylebox(&'panel', &'PanelContainer').content_margin_left,
 		dialog_text_panel.get_theme_stylebox(&'panel', &'PanelContainer').content_margin_top)
-	name_label_panel.anchor_left = name_label_alignment/2.0
-	name_label_panel.anchor_right = name_label_alignment/2.0
-	name_label_panel.grow_horizontal = [1, 2, 0][name_label_alignment]
+
+	var alignment_preset: Control.LayoutPreset = [
+		Control.PRESET_TOP_LEFT,
+		Control.PRESET_CENTER_TOP,
+		Control.PRESET_TOP_RIGHT,
+	][name_label_alignment]
+	name_label_panel.set_anchors_and_offsets_preset(
+		alignment_preset,
+		Control.PRESET_MODE_MINSIZE
+	)
+	name_label_panel.position += label_offset
 
 
 ## Applies all text settings to the scene.

--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -68,11 +68,12 @@ func load_style(style_name := "", parent: Node = null, is_base_style := true, st
 		# If this has the same scene setup, just apply the new overrides
 		elif previous_layout.get_meta('style') == style_resource.get_inheritance_root() or previous_layout.get_meta('style').get_inheritance_root() == style_resource.get_inheritance_root():
 			DialogicUtil.apply_scene_export_overrides(previous_layout, style_resource.get_layer_inherited_info("").overrides)
+			var layer_ids := style_resource.get_layer_inherited_list()
 			var index := 0
 			for layer in previous_layout.get_layers():
 				DialogicUtil.apply_scene_export_overrides(
 					layer,
-					style_resource.get_layer_inherited_info(style_resource.get_layer_id_at_index(index)).overrides)
+					style_resource.get_layer_inherited_info(layer_ids[index]).overrides)
 				index += 1
 
 			previous_layout.set_meta('style', style_resource)

--- a/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
+++ b/addons/dialogic/Modules/StyleEditor/style_layer_editor.gd
@@ -104,6 +104,7 @@ func load_layer(layer_id:=""):
 	current_style.set_meta("_latest_layer", current_layer_id)
 
 	var layer_info := current_style.get_layer_inherited_info(layer_id)
+	var local_layer_info := current_style.get_layer_info(layer_id)
 
 	%SmallLayerPreview.hide()
 	if %StyleBrowser.is_premade_style_part(layer_info.get("path", "Unkown Layer")):
@@ -129,7 +130,7 @@ func load_layer(layer_id:=""):
 	var inherited_layer_info := current_style.get_layer_inherited_info(layer_id, true)
 	load_layout_scene_customization(
 			layer_info.path,
-			layer_info.overrides,
+			local_layer_info.overrides,
 			inherited_layer_info.overrides)
 
 

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -138,8 +138,28 @@ func set_layer_scene(layer_id:String, scene:String) -> void:
 	changed.emit()
 
 
+## Ensures that inherited layers have local placeholders for storing overrides.
+func _ensure_local_layer_info(layer_id: String) -> bool:
+	if has_layer(layer_id):
+		return true
+
+	if not inherits_anything():
+		return false
+
+	var inherited_layer_list := get_layer_inherited_list()
+	if layer_id not in inherited_layer_list:
+		return false
+
+	for inherited_layer_id in inherited_layer_list:
+		if inherited_layer_id not in layer_info:
+			layer_info[inherited_layer_id] = DialogicStyleLayer.new()
+
+	layer_list = inherited_layer_list.duplicate()
+	return true
+
+
 func set_layer_overrides(layer_id:String, overrides:Dictionary) -> void:
-	if not has_layer(layer_id):
+	if not _ensure_local_layer_info(layer_id):
 		return
 
 	layer_info[layer_id].overrides = overrides
@@ -148,7 +168,7 @@ func set_layer_overrides(layer_id:String, overrides:Dictionary) -> void:
 
 ## Changes an override of the DialogicStyleLayer resource at [param layer_id].
 func set_layer_setting(layer_id:String, setting:String, value:Variant) -> void:
-	if not has_layer(layer_id):
+	if not _ensure_local_layer_info(layer_id):
 		return
 
 	layer_info[layer_id].overrides[setting] = value


### PR DESCRIPTION
## Problem

Inherited styles did not always save or apply their settings correctly.

If a child style was missing local layer data, changing a setting could fail without showing an error. The Style Editor also treated inherited values as if they were saved directly in the child style.

When switching between inherited styles during a dialogue, Dialogic could use the wrong layer ID. This caused some settings, such as name label alignment, to return to their default values.

The VN textbox name label also kept anchors and offsets from the previous style. After several style changes, the label could appear in the wrong position.

## Changes

- Missing local layer data is created before saving a child override.
- The Style Editor now keeps local overrides separate from inherited values.
- Runtime style changes use the complete inherited layer list.
- VN textbox name labels use Godot's layout presets to reset their anchors and offsets before applying their configured position.

## Testing

I tested:

- normal styles without inheritance;
- Base → Child → Grandchild inheritance;
- adding and resetting child overrides;
- repeated changes between Left, Center, and Right name label alignment;
- short and long character names;
- style changes after resizing the game window.

Fixes #2698